### PR TITLE
refactor: updated thickness names to match tokens

### DIFF
--- a/components/01-atoms/divider/_divider.scss
+++ b/components/01-atoms/divider/_divider.scss
@@ -16,9 +16,9 @@ $positions: map.deep-get(tokens.$tokens, layout, flex-position);
 }
 
 .divider {
-  background: var(--color-divider);
-  width: 100%;
-  height: calc(0.5rem / 16);
+  background: var(--color-divider, var(--color-gray-500));
+  width: var(--layout-width-100);
+  height: var(--size-thickness-1);
 
   @each $width, $value in $widths {
     &[data-divider-width='#{$width}'] {

--- a/components/01-atoms/divider/divider.stories.js
+++ b/components/01-atoms/divider/divider.stories.js
@@ -9,9 +9,9 @@ export default {
       defaultValue: 'center',
     },
     thickness: {
-      options: [1, 2, 3, 4, 5, 6],
+      options: ['hairline', 1, 2, 4, 6, 8],
       type: 'select',
-      defaultValue: 1,
+      defaultValue: 'hairline',
     },
     dividerColor: {
       options: ['gray-500', 'blue-yale', 'accent'],
@@ -22,12 +22,12 @@ export default {
 };
 
 export const Dividers = ({ position, thickness, dividerColor }) => `
+  ${dividerTwig({ divider__thickness: 'hairline' })}<br />
   ${dividerTwig({ divider__thickness: '1' })}<br />
   ${dividerTwig({ divider__thickness: '2' })}<br />
-  ${dividerTwig({ divider__thickness: '3' })}<br />
   ${dividerTwig({ divider__thickness: '4' })}<br />
-  ${dividerTwig({ divider__thickness: '5' })}<br />
-  ${dividerTwig({ divider__thickness: '6' })}<br /><br />
+  ${dividerTwig({ divider__thickness: '6' })}<br />
+  ${dividerTwig({ divider__thickness: '8' })}<br /><br />
   <h2>Playground</h2>
   <p>Use the StoryBook controls to see the dividers below implement the available positions, thicknesses, and colors.</p>
   <style>body {--color-divider: var(--color-${dividerColor})}</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5691,9 +5691,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.10.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.10.0/362b4f48c6a62945bcaf8b7fe54ebddec991096bba7c4d826db3b2774921e85d",
-      "integrity": "sha512-pw6nNNeeqBIy4YWhntbcVIuTIi60qpyrztpM+BJEU9lx4tfR0cK9VaAMWpjq6j7hifYdv7jAo7eAHcI6OLJqoQ=="
+      "version": "1.10.1",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.10.1/a1aa1f0a478e3221676fcb9aaf46921030dda786fb2d3fba7ffa8aeb85b92acf",
+      "integrity": "sha512-LRnVcNNov1jTibNvxBSloRPfhtUlE8qjW1ZVoWgQRD1vKPGpUXAcfhGTYB8oiqESvPHokyhpmRY1SHLGNPioXA=="
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -28538,9 +28538,9 @@
       "requires": {}
     },
     "@yalesites-org/tokens": {
-      "version": "1.10.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.10.0/362b4f48c6a62945bcaf8b7fe54ebddec991096bba7c4d826db3b2774921e85d",
-      "integrity": "sha512-pw6nNNeeqBIy4YWhntbcVIuTIi60qpyrztpM+BJEU9lx4tfR0cK9VaAMWpjq6j7hifYdv7jAo7eAHcI6OLJqoQ=="
+      "version": "1.10.1",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.10.1/a1aa1f0a478e3221676fcb9aaf46921030dda786fb2d3fba7ffa8aeb85b92acf",
+      "integrity": "sha512-LRnVcNNov1jTibNvxBSloRPfhtUlE8qjW1ZVoWgQRD1vKPGpUXAcfhGTYB8oiqESvPHokyhpmRY1SHLGNPioXA=="
     },
     "accepts": {
       "version": "1.3.7",


### PR DESCRIPTION
### Description of work
- This is just a cleanup ticket to align the thickness names in the component library with the token names
- 
### Testing Setup
- [ ] Checkout this branch
- [ ] Run `npm ci`
- [ ] Run `npm run develop`
- [ ] Verify the [Border Thickness](http://localhost:6006/?path=/story/tokens-effects--borders) and [Divider](http://localhost:6006/?path=/story/atoms-divider--dividers&args=position:!undefined;dividerColor:!undefined) stories both use the scale "hairline, 1, 2, 4, 6, 8"