### PR TITLE
YALB-76: List

### DIFF
--- a/components/01-atoms/lists/_list-item.twig
+++ b/components/01-atoms/lists/_list-item.twig
@@ -1,0 +1,15 @@
+{#
+ # Available variables:
+ # - list__item__content - the content of the list_item (typically text)
+ #
+ # Available blocks:
+ # - list__item__content - used to replace the content of the list_item with something other than text
+ #   for example: to insert the image and/or link components
+ #}
+{% set list__item__base_class = list__item__base_class|default('item') %}
+
+<li {{ bem(list__item__base_class, list__item__modifiers, list__item__blockname) }}>
+  {% block list__item__content %}
+    {{ list__item__content }}
+  {% endblock %}
+</li>

--- a/components/01-atoms/lists/_list-item.twig
+++ b/components/01-atoms/lists/_list-item.twig
@@ -7,8 +7,11 @@
  #   for example: to insert the image and/or link components
  #}
 {% set list__item__base_class = list__item__base_class|default('item') %}
+{% set list__item__attributes = {
+  class: bem(list__item__base_class, list__item__modifiers, list__item__blockname),
+} %}
 
-<li {{ bem(list__item__base_class, list__item__modifiers, list__item__blockname) }}>
+<li {{ add_attributes(list__item__attributes) }}>
   {% block list__item__content %}
     {{ list__item__content }}
   {% endblock %}

--- a/components/01-atoms/lists/_list.scss
+++ b/components/01-atoms/lists/_list.scss
@@ -1,0 +1,5 @@
+@mixin reset {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/components/01-atoms/lists/list.stories.js
+++ b/components/01-atoms/lists/list.stories.js
@@ -1,0 +1,11 @@
+import listTwig from './list.twig';
+
+import listData from './list.yml';
+
+/**
+ * Storybook Definition.
+ */
+export default { title: 'Atoms/Lists' };
+
+export const UnorderedList = () => listTwig(listData);
+export const OrderedList = () => listTwig({ ...listData, list__type: 'ol' });

--- a/components/01-atoms/lists/list.twig
+++ b/components/01-atoms/lists/list.twig
@@ -1,0 +1,20 @@
+{#
+ # Available variables:
+ # - list__items - the array of list items
+ #
+ # Available blocks:
+ # - list__content
+ #}
+{% set list__base_class = list__base_class|default('list') %}
+{% set list__type = list__type|default('ul') %}
+
+<{{ list__type }} {{ bem(list__base_class, list__modifiers, list__blockname) }}>
+  {% block list__content %}
+    {% for list__item in list__items %}
+      {% include "@atoms/lists/_list-item.twig" with {
+        list__item__content: list__item.list__item__content,
+        list__item__blockname: list__base_class,
+      } %}
+    {% endfor %}
+  {% endblock %}
+</{{ list__type }}>

--- a/components/01-atoms/lists/list.twig
+++ b/components/01-atoms/lists/list.twig
@@ -7,8 +7,11 @@
  #}
 {% set list__base_class = list__base_class|default('list') %}
 {% set list__type = list__type|default('ul') %}
+{% set list__attributes = {
+  class: bem(list__base_class, list__modifiers, list__blockname),
+} %}
 
-<{{ list__type }} {{ bem(list__base_class, list__modifiers, list__blockname) }}>
+<{{ list__type }} {{ add_attributes(list__attributes) }}>
   {% block list__content %}
     {% for list__item in list__items %}
       {% include "@atoms/lists/_list-item.twig" with {

--- a/components/01-atoms/lists/list.yml
+++ b/components/01-atoms/lists/list.yml
@@ -1,0 +1,4 @@
+list__items:
+  - list__item__content: 'Entesque pellentesque sit purus justo feugiat.'
+  - list__item__content: 'Amet consectetur purus justo feugiat mattis sit ultricies odio. Pellentesque pellentesque sit sed porttitor duis interdum.'
+  - list__item__content: 'Elementum elit est, vitae feugiat enim odio cursus. Enim cum dictum gravida amet id eget.'


### PR DESCRIPTION
## [YALB-76: List](https://yaleits.atlassian.net/browse/YALB-76)

### Description of work
- Initial List component. (to support menus)

### Testing Link(s)
- [ ] Navigate to the [Unordered List Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/atoms-lists--unordered-list) preview
- [ ] Navigate to the [Ordered List Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/atoms-lists--ordered-list) preview

### Functional Review Steps
- [ ] Verify the lists show up

### Design Review
- [x] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)

### Accessibility Review
- [x] Verify the component meets Accessibility requirements

## Notes:
- This doesn't currently support nested items. That'll come later if/when needed. The majority of lists are in a wysiwyg, and therefor don't even use this component. Menus do use this, but have their own mechanism for doing nested list items. So this is just to get the basic pieces in place.