### PR TITLE
Mobile Header Base

### DIFF
--- a/components/00-tokens/breakpoints/_breakpoints.scss
+++ b/components/00-tokens/breakpoints/_breakpoints.scss
@@ -1,0 +1,9 @@
+@use '~@yalesites-org/tokens/build/scss/tokens.scss' as *;
+
+// The basic breakpoints below are defined as tokens:
+// $break-s, $break-m, $break-l, $break-xl, $break-2xl, $break-max-width
+// The breakpoints defined in this file are utility breakpoints derived from
+// those basic ones, and used to support web development, specifically.
+
+$break-mobile: $break-m;
+$break-mobile-max: $break-m - 0.05;

--- a/components/00-tokens/colors/cl-colors.scss
+++ b/components/00-tokens/colors/cl-colors.scss
@@ -8,7 +8,6 @@
 .cl-colors__item {
   list-style: none;
   padding: var(--size-spacing-5) var(--size-spacing-7);
-  transition: all 0.4s;
   flex: 1 1 20%;
   min-width: 150px;
   min-height: 150px;

--- a/components/00-tokens/effects/_effects.scss
+++ b/components/00-tokens/effects/_effects.scss
@@ -1,0 +1,10 @@
+@mixin animate(
+  $property: all,
+  $duration: 200ms,
+  $function: ease-in-out,
+  $delay: 0ms
+) {
+  @media (prefers-reduced-motion: no-preference) {
+    transition: #{$property} #{$duration} #{$function} #{$delay};
+  }
+}

--- a/components/00-tokens/index.scss
+++ b/components/00-tokens/index.scss
@@ -1,4 +1,7 @@
+@forward 'breakpoints/breakpoints';
 @use 'functions/map';
 @use 'colors/color-pairings';
 @use 'typography/typography';
 @use 'layout/layout';
+@forward 'utility/utility';
+@forward 'effects/effects';

--- a/components/00-tokens/utility/_utility.scss
+++ b/components/00-tokens/utility/_utility.scss
@@ -1,0 +1,12 @@
+@mixin visually-hidden {
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+  word-wrap: normal;
+}
+
+.visually-hidden {
+  @include visually-hidden;
+}

--- a/components/01-atoms/buttons/_buttons.scss
+++ b/components/01-atoms/buttons/_buttons.scss
@@ -10,6 +10,15 @@ $button-outline-weights: (
   '4': var(--border-thickness-4),
 );
 
+// The button-reset mixin is used to remove browser default styles for button
+// elements that shouldn't look like a traditional "button".
+@mixin button-reset {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+
 @mixin button {
   --color-button-outline: var(--color-link);
 
@@ -42,7 +51,7 @@ $button-outline-weights: (
 
   // Outline weights options
   @each $weight, $value in $button-outline-weights {
-    &[data-outline-weight='#{$weight}'] {
+    &[data-button-outline-weight='#{$weight}'] {
       --border-thickness-button: #{$value};
     }
   }

--- a/components/01-atoms/buttons/_buttons.scss
+++ b/components/01-atoms/buttons/_buttons.scss
@@ -1,3 +1,5 @@
+@use '../../00-tokens/index' as base;
+
 $button-radii: (
   'soft': var(--button-radius-soft),
   'pill': 100vmax,
@@ -19,10 +21,7 @@ $button-outline-weights: (
   font-weight: var(--font-weights-mallory-500);
   padding: var(--size-spacing-4) var(--size-spacing-7);
   text-decoration: none;
-
-  @media (prefers-reduced-motion: no-preference) {
-    transition: 200ms ease-out;
-  }
+  text-align: center;
 
   &:hover {
     background-color: var(--color-button-bg-hover);
@@ -77,7 +76,13 @@ $button-outline-weights: (
   }
 
   // Hover styles
+  &[data-button-hover-style='fade'] {
+    @include base.animate('color, background-color');
+  }
+
   &[data-button-hover-style='rise'] {
+    @include base.animate('transform, box-shadow');
+
     &:hover {
       transform: translateY(-0.25em);
       color: var(--color-button-text);
@@ -87,7 +92,7 @@ $button-outline-weights: (
   }
 
   &[data-button-hover-style='wipe'] {
-    transition-duration: 400ms;
+    @include base.animate($duration: 400ms);
 
     &:hover {
       &[data-button-style='outline'] {

--- a/components/01-atoms/buttons/button.twig
+++ b/components/01-atoms/buttons/button.twig
@@ -1,9 +1,7 @@
 {#
  # Available props
  # Reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#associated_aria_roles_states_and_properties
- # - aria_pressed: whether the button is pressed or not
  # - aria_expanded: whether the controlled grouping is expanded or not
- # - aria_controls (required if aria_expanded is used): id of the grouping element that is controlled
  # - button__hover_style: fade (default), rise, or swipe
  # - button__radius: none (default), soft, or pill
  # - button__style: filled (defualt) or outline
@@ -28,16 +26,9 @@
   'data-button-outline-weight': button__outline_weight|default('2'),
 } %}
 
-{% if aria_pressed %}
-  {% set button__attributes = button__attributes|merge({
-    'aria-pressed': aria_pressed,
-  }) %}
-{% endif %}
-
 {% if aria_expanded %}
   {% set button__attributes = button__attributes|merge({
     'aria-expanded': aria_expanded,
-    'aira-controls': aria_controls,
   }) %}
 {% endif %}
 

--- a/components/01-atoms/buttons/button.twig
+++ b/components/01-atoms/buttons/button.twig
@@ -18,13 +18,14 @@
  #}
 
 {% set button__base_class = button__base_class|default('button') %}
+{% set button__element = button__element|default('button') %}
 
 {% set button__attributes = {
   class: bem(button__base_class, button__modifiers, button__blockname),
   'data-button-hover-style': button__hover_style|default('fade'),
   'data-button-radius': button__radius|default('none'),
   'data-button-style': button__style|default('filled'),
-  'data-outline-weight': button__outline_weight|default('2'),
+  'data-button-outline-weight': button__outline_weight|default('2'),
 } %}
 
 {% if aria_pressed %}
@@ -40,8 +41,15 @@
   }) %}
 {% endif %}
 
-<button {{ add_attributes(button__attributes) }}>
+{% if button__href %}
+  {% set button__attributes = button__attributes|merge({
+    href: button__href,
+  }) %}
+  {% set button__element = 'a' %}
+{% endif %}
+
+<{{ button__element }} {{ add_attributes(button__attributes) }}>
   {% block button__content %}
     {{ button__content }}
   {% endblock %}
-</button>
+</{{ button__element }}>

--- a/components/01-atoms/links/_link.scss
+++ b/components/01-atoms/links/_link.scss
@@ -1,10 +1,15 @@
-// @LINK: https://yaleits.atlassian.net/browse/YALB-350
-// @TODO: These custom property settings seem like they shouldn't need to live
-// here. At some point it'd be nice to get rid of them.
+@use '../../00-tokens/index' as base;
+
 :root {
+  // The --color-link and --color-link-hover properties need to be defined here
+  // so that other elements can make use of them. Specifically the outline for
+  // button focus state.
   --color-link: var(--color-blue-medium);
   --color-link-hover: var(--color-text);
 
+  // @LINK: https://yaleits.atlassian.net/browse/YALB-350
+  // @TODO: These color scheme custom property settings seem like they shouldn't
+  // need to live here. At some point it'd be nice to get rid of them.
   [data-component-theme] {
     --link-styles-underline-bg-color: var(--link-color-base);
     --link-styles-no-underline-bg-color: var(--link-color-hover);
@@ -28,20 +33,11 @@
   }
 }
 
-// Mixin to capture the transition styles used by various link elements.
-@mixin animation-link($property) {
-  @media (prefers-reduced-motion: no-preference) {
-    transition-property: #{$property};
-    transition-duration: 0.2s;
-    transition-timing-function: ease-in-out;
-  }
-}
-
 // Mixin for generic links.
 // Style options are "underline" or "no-underline".
 // The style name indicates the initial appearance.
 @mixin link($style: underline) {
-  @include animation-link('color');
+  @include base.animate('color');
 
   position: relative;
   color: var(--link-color-base);
@@ -54,7 +50,7 @@
 
   // Add the decorative bar under links
   &::after {
-    @include animation-link('transform');
+    @include base.animate('transform');
 
     content: '';
     position: absolute;

--- a/components/02-molecules/menu/_menu-item.twig
+++ b/components/02-molecules/menu/_menu-item.twig
@@ -1,0 +1,52 @@
+{% set item__modifiers = item__modifiers|default([]) %}
+
+{% set item__attributes = item__attributes|default({
+  'title': item.title,
+  }) %}
+
+{% if item.in_active_trail == TRUE %}
+  {% set item__modifiers = item__modifiers|merge(['active']) %}
+{% endif %}
+{% if menu__level > 0 %}
+  {% set item__modifiers = item__modifiers|merge(['sub', 'sub-' ~ menu__level]) %}
+{% endif %}
+{% if item.below %}
+  {% set item__modifiers = item__modifiers|merge(['with-sub']) %}
+{% endif %}
+
+{% import "@molecules/menu/menu.twig" as menus %}
+
+{# Set link component as default #}
+{% set list__item %}
+  {% block list__item__content_block %}
+    {% include "@atoms/links/link.twig" with {
+      link__content: item.title,
+      link__url: item.url,
+      link__base_class: 'link',
+      link__blockname: menu__base_class,
+      link__modifiers: item__modifiers,
+      link__attributes: item__attributes
+    } %}
+  {% endblock %}
+{% endset %}
+
+{% embed "@atoms/lists/_list-item.twig" with {
+  list__item__base_class: item__base_class|default('item'),
+  list__item__modifiers: item__modifiers,
+  list__item__blockname: item__blockname,
+}%}
+{% block list__item__content %}
+  {{ list__item }}
+  {% if item.below %}
+    {% if menu__level__toggle %}
+      {% include "@atoms/buttons/button.twig" with {
+        button__content: 'Expand Menu',
+        button__base_class: 'toggle',
+        button__blockname: menu__base_class,
+        aria_expanded: 'false',
+      } %}
+    {% endif %}
+    {{ menus.menu_links(item.below, attributes, menu__level + 1, menu__base_class, menu__modifiers, menu__blockname, menu__toggle, item__base_class, item__blockname) }}
+  {% endif %}
+{% endblock %}
+{% endembed %}

--- a/components/02-molecules/menu/_menu-list.twig
+++ b/components/02-molecules/menu/_menu-list.twig
@@ -1,0 +1,34 @@
+{% set item__blockname = menu__base_class %}
+
+{% set menu__item %}
+  {% block menu__item__content %}
+    {% for item in items %}
+      {% include "@molecules/menu/_menu-item.twig" %}
+    {% endfor %}
+    {# Menu level navigation #}
+    {% if menu__level > 0 and menu__level__toggle %}
+      {% embed "@molecules/menu/_menu-item.twig" with {
+        item__modifiers: 'sub-' ~ menu__level,
+      }%}
+        {% block list__item__content_block %}
+          {% include "@atoms/buttons/button.twig" with {
+            button__content: 'Back',
+            button__base_class: 'toggle',
+            button__blockname: menu__base_class,
+          } %}
+        {% endblock %}
+      {% endembed %}
+    {% endif %}
+  {% endblock %}
+{% endset %}
+
+{# List #}
+{% embed "@atoms/lists/list.twig" with {
+  list__base_class: 'menu',
+  list__blockname: menu__base_class,
+  list__modifiers: menu__modifiers,
+}%}
+  {% block list__content %}
+    {{ menu__item }}
+  {% endblock %}
+{% endembed %}

--- a/components/02-molecules/menu/menu-toggle/_menu-toggle.scss
+++ b/components/02-molecules/menu/menu-toggle/_menu-toggle.scss
@@ -1,0 +1,74 @@
+@use '../../../00-tokens/index.scss' as *;
+
+@mixin main-menu-is-open {
+  [data-main-menu-state='open'] & {
+    @content;
+  }
+}
+
+@mixin toggle-close-bar($rotation) {
+  top: 50%;
+  left: 0;
+  transform: rotate($rotation);
+}
+
+.menu-toggle {
+  @include button-reset;
+
+  display: flex;
+  place-content: center;
+  align-items: center;
+  position: relative;
+  min-height: 45px;
+  min-width: 45px;
+
+  &__bars {
+    position: relative;
+    display: block;
+    height: 22px;
+    width: 31px;
+  }
+
+  &__bar {
+    @include animate;
+
+    position: absolute;
+    display: block;
+    height: 2px;
+    width: 100%;
+    background: var(--color-text);
+    border-radius: var(--radius-4);
+
+    &:nth-child(1) {
+      top: 0;
+
+      @include main-menu-is-open {
+        @include toggle-close-bar(45deg);
+      }
+    }
+
+    &:nth-child(2) {
+      @include animate(opacity);
+
+      top: 50%;
+      transform: translateY(-50%);
+      opacity: 1;
+
+      @include main-menu-is-open {
+        opacity: 0;
+      }
+    }
+
+    &:nth-child(3) {
+      bottom: 0;
+
+      @include main-menu-is-open {
+        @include toggle-close-bar(-45deg);
+      }
+    }
+  }
+
+  &__text {
+    @include visually-hidden;
+  }
+}

--- a/components/02-molecules/menu/menu-toggle/menu-toggle.js
+++ b/components/02-molecules/menu/menu-toggle/menu-toggle.js
@@ -1,0 +1,38 @@
+Drupal.behaviors.menuToggle = {
+  attach(context) {
+    // Selectors
+    const menuToggle = context.querySelectorAll('.menu-toggle');
+    const header = context.querySelector('.site-header');
+    const headerOverlay = context.querySelector('.site-header__overlay');
+
+    // Function to toggle the open/closed state of an element.
+    function toggleMenuState(target, attribute) {
+      const menuState =
+        target.getAttribute(attribute) === 'closed' ? 'open' : 'closed';
+
+      target.setAttribute(attribute, menuState);
+    }
+
+    // Show/Hide menu on toggle click.
+    menuToggle.forEach((toggle) => {
+      toggle.addEventListener('click', () => {
+        toggleMenuState(header, 'data-main-menu-state');
+      });
+    });
+
+    // Hide menu on escape key press.
+    document.addEventListener('keyup', (e) => {
+      if (e.key === 'Escape') {
+        if (header.getAttribute('data-main-menu-state') === 'open') {
+          // Close the main menu if open.
+          toggleMenuState(header, 'data-main-menu-state');
+        }
+      }
+    });
+
+    // Hide menu on overlay click.
+    headerOverlay.addEventListener('click', () => {
+      toggleMenuState(header, 'data-main-menu-state');
+    });
+  },
+};

--- a/components/02-molecules/menu/menu-toggle/menu-toggle.js
+++ b/components/02-molecules/menu/menu-toggle/menu-toggle.js
@@ -16,7 +16,6 @@ Drupal.behaviors.menuToggle = {
       target.setAttribute(attribute, menuState);
 
       // Set the button aria properties.
-      menuToggle.setAttribute('aria-pressed', ariaButtonState);
       menuToggle.setAttribute('aria-expanded', ariaButtonState);
     }
 

--- a/components/02-molecules/menu/menu-toggle/menu-toggle.js
+++ b/components/02-molecules/menu/menu-toggle/menu-toggle.js
@@ -1,23 +1,28 @@
 Drupal.behaviors.menuToggle = {
   attach(context) {
     // Selectors
-    const menuToggle = context.querySelectorAll('.menu-toggle');
+    const menuToggle = context.querySelector('.menu-toggle');
     const header = context.querySelector('.site-header');
     const headerOverlay = context.querySelector('.site-header__overlay');
 
-    // Function to toggle the open/closed state of an element.
+    // Function to toggle the open/closed state of the main menu.
     function toggleMenuState(target, attribute) {
       const menuState =
         target.getAttribute(attribute) === 'closed' ? 'open' : 'closed';
+      const ariaButtonState =
+        target.getAttribute(attribute) === 'closed' ? 'true' : 'false';
 
+      // Set the menu state.
       target.setAttribute(attribute, menuState);
+
+      // Set the button aria properties.
+      menuToggle.setAttribute('aria-pressed', ariaButtonState);
+      menuToggle.setAttribute('aria-expanded', ariaButtonState);
     }
 
     // Show/Hide menu on toggle click.
-    menuToggle.forEach((toggle) => {
-      toggle.addEventListener('click', () => {
-        toggleMenuState(header, 'data-main-menu-state');
-      });
+    menuToggle.addEventListener('click', () => {
+      toggleMenuState(header, 'data-main-menu-state');
     });
 
     // Hide menu on escape key press.

--- a/components/02-molecules/menu/menu-toggle/menu-toggle.twig
+++ b/components/02-molecules/menu/menu-toggle/menu-toggle.twig
@@ -3,9 +3,7 @@
 {% embed "@atoms/buttons/button.twig" with {
   button__base_class: main_menu_toggle__base_class,
   button__blockname: main_menu_toggle__blockname,
-  aria_pressed: 'false',
   aria_expanded: 'false',
-  aria_controls: 'menu-wrapper',
 } %}
   {% block button__content %}
     <span {{ bem('text', [], main_menu_toggle__base_class) }}>Menu</span>

--- a/components/02-molecules/menu/menu-toggle/menu-toggle.twig
+++ b/components/02-molecules/menu/menu-toggle/menu-toggle.twig
@@ -1,0 +1,18 @@
+{% set main_menu_toggle__base_class = 'menu-toggle' %}
+
+{% embed "@atoms/buttons/button.twig" with {
+  button__base_class: main_menu_toggle__base_class,
+  button__blockname: main_menu_toggle__blockname,
+  aria_pressed: 'false',
+  aria_expanded: 'false',
+  aria_controls: 'menu-wrapper',
+} %}
+  {% block button__content %}
+    <span {{ bem('text', [], main_menu_toggle__base_class) }}>Menu</span>
+    <span {{ bem('bars', [], main_menu_toggle__base_class) }}>
+      <span {{ bem('bar', [], main_menu_toggle__base_class) }}></span>
+      <span {{ bem('bar', [], main_menu_toggle__base_class) }}></span>
+      <span {{ bem('bar', [], main_menu_toggle__base_class) }}></span>
+    </span>
+  {% endblock %}
+{% endembed %}

--- a/components/02-molecules/menu/menu.twig
+++ b/components/02-molecules/menu/menu.twig
@@ -1,0 +1,73 @@
+{#
+ # Available variables:
+ # - menu__base_class - base classname of the wrapper.
+ # - menu__blockname - blockname prepended to the base classname of the wrapper(s) and each component.
+ # - menu__modifiers - array of modifiers to add to the base classname of the wrapper.
+ # - menu__name - name of the menu.
+ # - menu__attributes - array of attributes for the nav.
+ # - menu__additional_classes - array of classes in addition to bem structure.
+ # - menu__level - current menu level number in the hierarchy.
+ # - menu__toggle - Boolean value for overall menu toggle.
+ # - menu__level__toggle - Boolean value for toggles within each level in the hierarchy.
+ # - items: A nested list of menu items. Each menu item contains:
+ #   - attributes: HTML attributes for the menu item.
+ #   - below: The menu item child items.
+ #   - title: The menu link title.
+ #   - url: The menu link url, instance of \Drupal\Core\Url
+ #   - localized_options: Menu link localized options.
+ #   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ #   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ #   - in_active_trail: TRUE if the link is in the active trail.
+ #}
+{% set menu__base_class = menu__base_class|default('menu') %}
+{% set menu__blockname = menu__blockname|default('menu') %}
+{% set menu__modifiers = menu__modifiers|default([]) %}
+{% set menu__attributes = menu__attributes|default([]) %}
+{% set menu__name = menu__name|default([]) %}
+{% set menu__additional_classes = menu__additional_classes|default([]) %}
+
+{% if menu__toggle or menu__level__toggle %}
+  {% set menu__additional_classes = menu__additional_classes|merge(['menu-with-toggle']) %}
+{% endif %}
+
+{% set menu__attributes = menu__attributes|merge({
+  'id': menu__base_class,
+  'class': bem(menu__base_class, menu__blockname, menu__modifiers, menu__additional_classes),
+  'aria-label': menu__name,
+}) %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{% macro menu_links(items, attributes, menu__level, menu__base_class, menu__modifiers, menu__blockname, menu__toggle, menu__level__toggle, item__base_class, item__modifiers, item__blockname) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu__level > 0 %}
+      {% set menu__modifiers = ['sub', 'sub-' ~ menu__level] %}
+    {% endif %}
+    {% block menu_list__content %}
+      {% include "@molecules/menu/_menu-list.twig" %}
+    {% endblock %}
+  {% endif %}
+{% endmacro %}
+
+{% import _self as menus %}
+
+<nav {{ add_attributes(menu__attributes) }}>
+  {% block menu_prefix %}{% endblock %}
+  {{ menus.menu_links(items, attributes, 0, menu__base_class, menu__modifiers, menu__blockname, menu__toggle, menu__level__toggle, item__base_class, item__modifiers, item__blockname) }}
+  {# Mobile nav toggle #}
+  {% if menu__toggle %}
+    {% include "@atoms/buttons/button.twig" with {
+      button__content: 'Menu Open',
+      button__base_class: 'toggle',
+      button__blockname: menu__base_class,
+      aria_expanded: 'false',
+      aria_controls: menu__base_class,
+    } %}
+  {% endif %}
+  {% block menu_suffix %}{% endblock %}
+</nav>

--- a/components/02-molecules/menu/menu.twig
+++ b/components/02-molecules/menu/menu.twig
@@ -66,7 +66,6 @@
       button__base_class: 'toggle',
       button__blockname: menu__base_class,
       aria_expanded: 'false',
-      aria_controls: menu__base_class,
     } %}
   {% endif %}
   {% block menu_suffix %}{% endblock %}

--- a/components/03-organisms/site-header/_site-header.scss
+++ b/components/03-organisms/site-header/_site-header.scss
@@ -1,16 +1,28 @@
 @use '~@yalesites-org/tokens/build/scss/tokens';
 @use '../../00-tokens/functions/map';
 @use 'sass:map' as sass-map;
+@use '../../00-tokens/index.scss' as base;
 
 $site-header-themes: map.deep-get(tokens.$tokens, site-header-themes);
 $site-header-border-thickness: map.deep-get(tokens.$tokens, border, thickness);
 $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
+// Mixin for the small branding typography.
+@mixin branding-small {
+  font: var(--font-style-branding-yale);
+  color: var(--color-site-header-yale-branding);
+}
+
 .site-header {
-  padding: var(--size-spacing-0) var(--size-spacing-8);
+  --site-header-padding: var(--size-spacing-0) var(--size-spacing-8);
 
   // prettier-ignore
-  border-bottom: var(--site-header-border-thickness) solid var(--color-site-header-border-color);
+  --site-header-border-bottom: var(--site-header-border-thickness) solid var(--color-site-header-border-color);
+
+  position: relative;
+  z-index: 2;
+  padding: var(--site-header-padding);
+  border-bottom: var(--site-header-border-bottom);
 
   // Component themes
   @each $theme, $value in $site-header-themes {
@@ -37,6 +49,41 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
   }
 }
 
+.site-header__mobile-header {
+  display: flex;
+  gap: var(--size-spacing-6);
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--size-spacing-4) 0;
+
+  @media (min-width: base.$break-mobile) {
+    display: none;
+  }
+}
+
+.site-header__menu-wrapper {
+  display: flex;
+  flex-direction: column-reverse;
+
+  @media (max-width: base.$break-mobile-max) {
+    @include base.animate(max-height, 800ms);
+
+    z-index: 1;
+    position: absolute;
+    left: 0;
+    background: var(--color-background);
+    flex-direction: column;
+    max-height: 100vh;
+    width: 100vw;
+    overflow: auto;
+    border-bottom: var(--site-header-border-bottom);
+
+    [data-main-menu-state='closed'] & {
+      max-height: 0;
+    }
+  }
+}
+
 .site-header__secondary {
   display: flex;
   flex-wrap: wrap;
@@ -45,8 +92,15 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
   align-items: center;
   padding: var(--size-spacing-4) 0;
 
-  // prettier-ignore
-  border-bottom: var(--border-thickness-hairline) solid var(--color-site-header-divider-color);
+  @media (max-width: base.$break-mobile-max) {
+    padding: var(--size-spacing-6) var(--size-spacing-8);
+    border-top: var(--site-header-border-bottom);
+  }
+
+  @media (min-width: base.$break-mobile) {
+    // prettier-ignore
+    border-bottom: var(--border-thickness-hairline) solid var(--color-site-header-divider-color);
+  }
 }
 
 .site-header__primary {
@@ -68,26 +122,73 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
       --site-header-layout-align: var(--site-header-layout-#{$layout}-align);
     }
   }
+
+  @media (max-width: base.$break-mobile-max) {
+    padding: var(--size-spacing-3) var(--size-spacing-5);
+  }
 }
 
 .site-header__yale-branding {
-  font: var(--font-style-branding-yale);
-  color: var(--color-site-header-yale-branding);
+  @include branding-small;
+
   text-decoration: none;
+
+  @media (max-width: base.$break-mobile-max) {
+    display: none;
+  }
 }
 
 .site-header__utility-nav {
   margin-left: auto;
+
+  @media (max-width: base.$break-mobile-max) {
+    width: 100%;
+  }
 }
 
 .site-header__site-branding {
   font: var(--font-style-branding-site);
   color: var(--color-site-header-site-branding);
   text-decoration: none;
+
+  &--primary {
+    @media (max-width: base.$break-mobile-max) {
+      display: none;
+    }
+  }
+
+  &--mobile {
+    @include branding-small;
+  }
 }
 
 .site-header__primary-nav {
   [data-site-header-nav-position='right'] & {
     margin-left: auto;
+  }
+}
+
+.site-header__overlay {
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  height: 0;
+  width: 100vw;
+  background-color: rgb(0 0 0 / 70%);
+  opacity: 0;
+
+  // The animate mixin doesn't support multiple transitions.
+  @media (prefers-reduced-motion: no-preference) {
+    transition: opacity 800ms, height 0ms ease-out 800ms;
+  }
+
+  @media (max-width: base.$break-mobile-max) {
+    [data-main-menu-state='open'] ~ & {
+      @include base.animate(opacity, 800ms);
+
+      height: 100vh;
+      opacity: 1;
+    }
   }
 }

--- a/components/03-organisms/site-header/site-header.stories.js
+++ b/components/03-organisms/site-header/site-header.stories.js
@@ -3,6 +3,8 @@ import tokens from '@yalesites-org/tokens/build/json/tokens.json';
 import siteHeaderTwig from './site-header.twig';
 import siteHeaderExamples from './_site-header--examples.twig';
 
+import '../../02-molecules/menu/menu-toggle/menu-toggle';
+
 const siteHeaderThemes = { themes: tokens['site-header-themes'] };
 const borderThicknessOptions = Object.keys(tokens.border.thickness);
 const primaryNavPositions = Object.keys(tokens.layout['flex-position']);

--- a/components/03-organisms/site-header/site-header.twig
+++ b/components/03-organisms/site-header/site-header.twig
@@ -15,6 +15,7 @@
 {% set site_header__base_class = 'site-header' %}
 
 {% set site_header__attributes = {
+  'data-main-menu-state': 'closed',
   'data-component-width': 'max',
   'data-site-header-nav-position': site_header__nav_position|default('right'),
   'data-site-header-border-thickness': site_header__border_thickness|default('0'),
@@ -24,37 +25,48 @@
 
 <header {{ add_attributes(site_header__attributes) }}>
   <div {{ bem('inner', [], site_header__base_class) }}>
-    {# Secondary #}
-    <div {{ bem('secondary', [], site_header__base_class) }}>
+    <div {{ bem('mobile-header', [], site_header__base_class) }}>
       {# Yale Branding #}
-      <a href="https://www.yale.edu/" {{ bem('yale-branding', [], site_header__base_class) }}>
-        Yale University
-      </a>
-      {# Utility Nav #}
-      <div {{ bem('utility-nav', [], site_header__base_class) }}>
-        {% block site_header__utility_nav %}
-          {% include "@page-layouts/placeholder/placeholder.twig" with {
-            placeholder: 'Utility Nav',
-            placeholder__type: 'element',
-          } %}
-        {% endblock %}
-      </div>
-    </div>
-    {# Primary #}
-    <div {{ bem('primary', [], site_header__base_class) }}>
-      {# Site Branding #}
-      <a href="/" {{ bem('site-branding', [], site_header__base_class) }}>
+      <a href="https://www.yale.edu/" {{ bem('site-branding', ['mobile'], site_header__base_class) }}>
         {{ site_name }}
       </a>
-      {# Primary Nav #}
-      <div {{ bem('primary-nav', [], site_header__base_class) }}>
-        {% block site_header__primary_nav %}
-          {% include "@page-layouts/placeholder/placeholder.twig" with {
-            placeholder: 'Primary Nav Item 1 / Primary Nav Item 2 / Primary Nav Item 3 / Primary Nav Item 4',
-            placeholder__type: 'element',
-          } %}
-        {% endblock %}
+      {# Mobile Menu Toggle #}
+      {% include "@molecules/menu/menu-toggle/menu-toggle.twig" %}
+    </div>
+    <div id="menu-wrapper" {{ bem('menu-wrapper', [], site_header__base_class) }}>
+      {# Primary #}
+      <div {{ bem('primary', [], site_header__base_class) }}>
+        {# Site Branding #}
+        <a href="/" {{ bem('site-branding', ['primary'], site_header__base_class) }}>
+          {{ site_name }}
+        </a>
+        {# Primary Nav #}
+        <div {{ bem('primary-nav', [], site_header__base_class) }}>
+          {% block site_header__primary_nav %}
+            {% include "@page-layouts/placeholder/placeholder.twig" with {
+              placeholder: 'Primary Nav Item 1 / Primary Nav Item 2 / Primary Nav Item 3 / Primary Nav Item 4',
+              placeholder__type: 'element',
+            } %}
+          {% endblock %}
+        </div>
+      </div>
+      {# Secondary #}
+      <div {{ bem('secondary', [], site_header__base_class) }}>
+        {# Yale Branding #}
+        <a href="https://www.yale.edu/" {{ bem('yale-branding', [], site_header__base_class) }}>
+          Yale University
+        </a>
+        {# Utility Nav #}
+        <div {{ bem('utility-nav', [], site_header__base_class) }}>
+          {% block site_header__utility_nav %}
+            {% include "@page-layouts/placeholder/placeholder.twig" with {
+              placeholder: 'Utility Nav',
+              placeholder__type: 'element',
+            } %}
+          {% endblock %}
+        </div>
       </div>
     </div>
   </div>
 </header>
+<div {{ bem('overlay', [], site_header__base_class) }}></div>

--- a/components/03-organisms/site-header/site-header.twig
+++ b/components/03-organisms/site-header/site-header.twig
@@ -33,7 +33,7 @@
       {# Mobile Menu Toggle #}
       {% include "@molecules/menu/menu-toggle/menu-toggle.twig" %}
     </div>
-    <div id="menu-wrapper" {{ bem('menu-wrapper', [], site_header__base_class) }}>
+    <div {{ bem('menu-wrapper', [], site_header__base_class) }}>
       {# Primary #}
       <div {{ bem('primary', [], site_header__base_class) }}>
         {# Site Branding #}

--- a/components/style.scss
+++ b/components/style.scss
@@ -1,14 +1,11 @@
 // Libraries
 @use '~normalize.css/normalize';
 
-// @import '~breakpoint-sass/stylesheets/breakpoint';
-
 // stylelint-disable
 @use '_settings/config';
 // Tokens
 @import '~@yalesites-org/tokens/build/css/tokens.css';
 // Components
-@import '00-tokens/index';
 @import '01-atoms/**/*.scss';
 @import '02-molecules/**/*.scss';
 @import '03-organisms/**/*.scss';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,14 @@
     "": {
       "name": "@yalesites-org/component-library-twig",
       "version": "0.0.0-development",
+      "hasInstallScript": true,
       "dependencies": {
         "@storybook/storybook-deployer": "^2.8.10",
         "@yalesites-org/tokens": "^1.11.3",
         "add-attributes-twig-extension": "^0.1.0",
         "bem-twig-extension": "^0.1.1",
-        "normalize.css": "^8.0.1"
+        "normalize.css": "^8.0.1",
+        "twig-drupal-filters": "^3.1.2"
       },
       "devDependencies": {
         "@babel/core": "^7.16.7",
@@ -5670,9 +5672,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@yalesites-org/eslint-config-and-other-formatting": {
-      "version": "1.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/eslint-config-and-other-formatting/1.4.0/6e30b01b33666fa6765058ad75841b0f91911c6385c0d94ccea67ce990ada3b1",
-      "integrity": "sha512-BQw/GckMULrmd92qkIqDI4jOrkcr9rA651VQ44rD/Wh0y97CI+GpLC8MprNw5tKGAj48r+v8aBPVPiouRGkE/g==",
+      "version": "1.4.2",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/eslint-config-and-other-formatting/1.4.2/9a696aa26612d548d5450156355ad2c918105ce237f28d169e59471dd299b9e1",
+      "integrity": "sha512-JOvwI2QtwFiId+p7zreoQHxFyz7+1y2gJ4/6U40t5EG8aGGlqIoIC1L7CV4wzEweW2nNBsOxmTQu8iIrPfPFNw==",
       "dev": true,
       "peerDependencies": {
         "@commitlint/cli": "^16.0.1",
@@ -17897,7 +17899,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -23087,6 +23088,15 @@
       },
       "engines": {
         "node": ">=8.16"
+      }
+    },
+    "node_modules/twig-drupal-filters": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/twig-drupal-filters/-/twig-drupal-filters-3.1.2.tgz",
+      "integrity": "sha512-95KoXIYvN+aPl9wUCweWgFE7f4JJNVVxDMpxfHWn+3sOO4gxXXmTU4jGnr/MxPNU7avH+BdhkzcAo+L0SyAPrg==",
+      "dependencies": {
+        "object-keys": "^1.1.1",
+        "twig": "^1.15.1"
       }
     },
     "node_modules/twig-loader": {
@@ -28541,9 +28551,9 @@
       "dev": true
     },
     "@yalesites-org/eslint-config-and-other-formatting": {
-      "version": "1.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/eslint-config-and-other-formatting/1.4.0/6e30b01b33666fa6765058ad75841b0f91911c6385c0d94ccea67ce990ada3b1",
-      "integrity": "sha512-BQw/GckMULrmd92qkIqDI4jOrkcr9rA651VQ44rD/Wh0y97CI+GpLC8MprNw5tKGAj48r+v8aBPVPiouRGkE/g==",
+      "version": "1.4.2",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/eslint-config-and-other-formatting/1.4.2/9a696aa26612d548d5450156355ad2c918105ce237f28d169e59471dd299b9e1",
+      "integrity": "sha512-JOvwI2QtwFiId+p7zreoQHxFyz7+1y2gJ4/6U40t5EG8aGGlqIoIC1L7CV4wzEweW2nNBsOxmTQu8iIrPfPFNw==",
       "dev": true,
       "requires": {}
     },
@@ -36859,8 +36869,7 @@
       "version": "1.12.0"
     },
     "object-keys": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "object-visit": {
       "version": "1.0.1",
@@ -40332,6 +40341,15 @@
         "locutus": "^2.0.11",
         "minimatch": "3.0.x",
         "walk": "2.3.x"
+      }
+    },
+    "twig-drupal-filters": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/twig-drupal-filters/-/twig-drupal-filters-3.1.2.tgz",
+      "integrity": "sha512-95KoXIYvN+aPl9wUCweWgFE7f4JJNVVxDMpxfHWn+3sOO4gxXXmTU4jGnr/MxPNU7avH+BdhkzcAo+L0SyAPrg==",
+      "requires": {
+        "object-keys": "^1.1.1",
+        "twig": "^1.15.1"
       }
     },
     "twig-loader": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "husky:pre-commit": "lint-staged",
     "lint:js": "eslint components",
     "lint:styles": "stylelint 'components/**/*.scss'",
+    "postinstall": "npx patch-package",
     "prepare": "husky install",
     "prettier": "prettier components --ignore-unknown --list-different",
     "semantic-release": "semantic-release",
@@ -44,7 +45,8 @@
     "@yalesites-org/tokens": "^1.11.3",
     "add-attributes-twig-extension": "^0.1.0",
     "bem-twig-extension": "^0.1.1",
-    "normalize.css": "^8.0.1"
+    "normalize.css": "^8.0.1",
+    "twig-drupal-filters": "^3.1.2"
   },
   "lint-staged": {
     "components/**/*.scss": [

--- a/patches/twig+1.15.4.patch
+++ b/patches/twig+1.15.4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/twig/twig.js b/node_modules/twig/twig.js
+index 9d50c4b..16fe0d7 100644
+--- a/node_modules/twig/twig.js
++++ b/node_modules/twig/twig.js
+@@ -8266,7 +8272,7 @@ module.exports = function (Twig) {
+       }).then(function (fileName) {
+         var embedOverrideTemplate = new Twig.Template({
+           data: token.output,
+-          id: state.template.id,
++          id: `${state.template.id}-override`,
+           base: state.template.base,
+           path: state.template.path,
+           url: state.template.url,


### PR DESCRIPTION
### Description of work
- [YALB-86: Utility Nav](https://yaleits.atlassian.net/browse/YALB-86) is temporarily blocked by some design discussions, so this PR abstracts some of the "shared" mobile header and menu stuff so that I can work on breadcrumbs and the main menu without being blocked by the utility nav. So, this includes:
- Menu base templates (not demoed anywhere, since they'll be used by each menu, but don't do anything by themselves)
- Mobile Menu toggle
- Updates to the site-header to support mobile designs

### Testing Link(s)
- [ ] Navigate to the [Full Page Layout](https://deploy-preview-30--dev-component-library-twig.netlify.app/?path=/story/page-layouts-page-layouts--full-width) preview

### Functional Review Steps
- [ ] Verify everything works as expected on small screens

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
