### PR TITLE
YALB-108: Standard Page

### DIFF
--- a/.storybook/setupTwig.js
+++ b/.storybook/setupTwig.js
@@ -8,6 +8,7 @@ module.exports.namespaces = {
   molecules: resolve(__dirname, '../', 'components/02-molecules'),
   organisms: resolve(__dirname, '../', 'components/03-organisms'),
   'page-layouts': resolve(__dirname, '../', 'components/04-page-layouts'),
+  'page-examples': resolve(__dirname, '../', 'components/05-page-examples'),
 };
 
 /**

--- a/components/02-molecules/menu/menu.twig
+++ b/components/02-molecules/menu/menu.twig
@@ -33,7 +33,6 @@
 {% endif %}
 
 {% set menu__attributes = menu__attributes|merge({
-  'id': menu__base_class,
   'class': bem(menu__base_class, menu__modifiers, menu__blockname, menu__additional_classes),
   'aria-label': menu__name,
 }) %}

--- a/components/02-molecules/page-title/page-title.twig
+++ b/components/02-molecules/page-title/page-title.twig
@@ -7,7 +7,7 @@
 {% set page_title__base_class = 'page-title' %}
 
 {% set page_title__attributes = {
-  'data-component-width': 'max',
+  'data-component-width': 'content',
   class: bem(page_title__base_class),
 } %}
 

--- a/components/02-molecules/pop-out-image/_pop-out-image.scss
+++ b/components/02-molecules/pop-out-image/_pop-out-image.scss
@@ -16,3 +16,7 @@
     margin-bottom: var(--size-spacing-7);
   }
 }
+
+.pop-out-image__clearfix {
+  clear: both;
+}

--- a/components/02-molecules/pop-out-image/pop-out-image.twig
+++ b/components/02-molecules/pop-out-image/pop-out-image.twig
@@ -41,3 +41,4 @@
     } %}
   </div>
 </div>
+<div {{ bem('clearfix', [], pop_out_image__base_class) }}></div>

--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs.js
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs.js
@@ -8,7 +8,6 @@ Drupal.behaviors.breadcrumbs = {
     // Used to show all breadcrumbs on mobile
     breadcrumbsButton.addEventListener('click', () => {
       breadcrumbsWrapper.setAttribute('data-breadcrumbs-overflow', 'visible');
-      breadcrumbsButton.setAttribute('aria-pressed', 'true');
       breadcrumbsButton.setAttribute('aria-expanded', 'true');
     });
   },

--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs.twig
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs.twig
@@ -15,7 +15,6 @@
 <div {{ add_attributes(breadcrumbs__attributes) }}>
   {% embed "@atoms/buttons/button.twig" with {
     button__blockname: breadcrumbs__base_class,
-    aria_pressed: 'false',
     aria_expanded: 'false',
     aria_controls: 'breadcrumbs-inner',
   } %}

--- a/components/03-organisms/site-header/_site-header.scss
+++ b/components/03-organisms/site-header/_site-header.scss
@@ -5,6 +5,7 @@
 $site-header-themes: map.deep-get(tokens.$tokens, site-header-themes);
 $site-header-border-thickness: map.deep-get(tokens.$tokens, border, thickness);
 $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
+$site-header-animation-speed: 800ms;
 
 // Mixin for the small branding typography.
 @mixin branding-small {
@@ -65,7 +66,7 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
   flex-direction: column;
 
   @media (max-width: tokens.$break-mobile-max) {
-    @include tokens.animate(max-height, 800ms);
+    @include tokens.animate(max-height, $site-header-animation-speed);
 
     z-index: 1;
     position: absolute;
@@ -78,6 +79,22 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
     [data-main-menu-state='closed'] & {
       max-height: 0;
+
+      // This animation is to remove hidden items from screen readers and
+      // keyboard navigation, while maintaining the slow "close" effect.
+      visibility: hidden;
+      animation: $site-header-animation-speed fade-out;
+      animation-fill-mode: forwards;
+
+      @keyframes fade-out {
+        99% {
+          visibility: visible;
+        }
+
+        100% {
+          visibility: hidden;
+        }
+      }
     }
   }
 }
@@ -192,12 +209,13 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
   // The animate mixin doesn't support multiple transitions.
   @media (prefers-reduced-motion: no-preference) {
-    transition: opacity 800ms, height 0ms ease-out 800ms;
+    transition: opacity $site-header-animation-speed,
+      height 0ms ease-out $site-header-animation-speed;
   }
 
   @media (max-width: tokens.$break-mobile-max) {
     [data-main-menu-state='open'] ~ & {
-      @include tokens.animate(opacity, 800ms);
+      @include tokens.animate(opacity, $site-header-animation-speed);
 
       height: 100vh;
       opacity: 1;

--- a/components/05-page-examples/_intro-content-examples.twig
+++ b/components/05-page-examples/_intro-content-examples.twig
@@ -1,0 +1,13 @@
+{% if intro_content == 'image' %}
+  {% include "@molecules/image/content-image.twig" %}
+{% elseif intro_content =='image--feature' %}
+  {% include "@molecules/image/content-image.twig" with {
+    content_image__width: 'feature',
+  } %}
+{% elseif intro_content =='image--max' %}
+  {% include "@molecules/image/content-image.twig" with {
+    content_image__width: 'max',
+  } %}
+{% elseif intro_content =='pop-out-image' %}
+  {% include "@molecules/pop-out-image/pop-out-image.twig" %}
+{% endif %}

--- a/components/05-page-examples/_intro-content-examples.twig
+++ b/components/05-page-examples/_intro-content-examples.twig
@@ -9,5 +9,7 @@
     content_image__width: 'max',
   } %}
 {% elseif intro_content =='pop-out-image' %}
-  {% include "@molecules/pop-out-image/pop-out-image.twig" %}
+  {% include "@molecules/pop-out-image/pop-out-image.twig" with {
+    pop_out_image__content: '<p>Dr. Davis’s research group at the Kline Chemistry Laboratory uses experiments at multiple scales – in vitro, single cell, and whole organism – to study fundamental and applied problems at the intersection of chemistry, physics, and biology. They develop new quantitative spectroscopic imaging techniques to elucidate the relationship between function and dynamics of proteins and RNA inside living cells. </p><p>Caitlin Davis obtained her Ph.D. from Emory University in 2015, where she studied protein folding in the laboratory of Dr. Brian Dyer in the Chemistry Department. She completed her postdoctoral training with Dr. Martin Gruebele at the Center for the Physics of Living Cells at the University of Illinois at Urbana-Champaign, where she developed a method for studying protein thermodynamics and kinetics in differentiated tissues of living zebrafish and she developed a mimic of cytoplasm that can be used to reproduce protein behaviors in vitro. She came to Yale as a faculty member in 2020.</p>',
+  } %}
 {% endif %}

--- a/components/05-page-examples/page-examples.stories.js
+++ b/components/05-page-examples/page-examples.stories.js
@@ -28,6 +28,7 @@ export const StandardPage = ({
   utilityNavSearch,
   siteFooterTheme,
   footerBorderThickness,
+  introContent,
 }) =>
   standardPageTwig({
     site_name: siteName,
@@ -44,7 +45,15 @@ export const StandardPage = ({
     utility_nav__search: utilityNavSearch,
     breadcrumbs__items: breadcrumbData.items,
     ...imageData.responsive_images['16x9'],
+    intro_content: introContent,
   });
+StandardPage.argTypes = {
+  introContent: {
+    options: ['none', 'image', 'image--feature', 'image--max', 'pop-out-image'],
+    type: 'select',
+    defaultValue: 'none',
+  },
+};
 
 export const NewsArticle = ({
   siteName,

--- a/components/05-page-examples/page-examples.stories.js
+++ b/components/05-page-examples/page-examples.stories.js
@@ -49,6 +49,7 @@ export const StandardPage = ({
   });
 StandardPage.argTypes = {
   introContent: {
+    name: 'Intro Content',
     options: ['none', 'image', 'image--feature', 'image--max', 'pop-out-image'],
     type: 'select',
     defaultValue: 'none',

--- a/components/05-page-examples/standard-page.twig
+++ b/components/05-page-examples/standard-page.twig
@@ -2,6 +2,7 @@
   {% block page__content %}
     {% include "@organisms/menu/breadcrumbs/breadcrumbs.twig" %}
     {% include "@molecules/page-title/page-title.twig" %}
+    {% include "@page-examples/_intro-content-examples.twig" %}
     {% include "@molecules/text/text-field.twig" with {
       text_field__content: '<p>Chemistry has been responsible for some of the most significant improvements in our quality of life over the last century.</p><p>The discovery of antibiotics and other pharmaceuticals, the advent of computers, and the development of industrial methods to produce fertilizer, all have required fundamental advances in chemistry. Chemistry is increasingly playing a central role in the development of alternative-energy vectors to replace fossil fuels, the realization of practical quantum computers, the discovery of new methods to treat and prevent diseases, and the adoption of more sustainable industrial processes.</p>',
     } %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5950,9 +5950,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.15.1",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.15.1/05115356875f13860d48a8de60690ae11fb44e7bad338e8bd7cc9f07117bb006",
-      "integrity": "sha512-k08z7ove6IK3al1Vdx9kElK1/RjdopiwJpoDqjoxezzgwcu85veY6NC8lYSOgwBBjfwq+X7rZKA2dF/4aldADw=="
+      "version": "1.15.3",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.15.3/4d1628cd750de4df30ac78c555ace485ccda8d9225d17ede99fb5dedbcd25299",
+      "integrity": "sha512-RQSPd1fFRj8Z0xnxnNdfx9nIl7SagecJRQflIvCOY3l01JV57FeCKKV9YZI4JpODf6vV+l/IC8j6vdFcte4GnQ=="
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -29194,9 +29194,9 @@
       "requires": {}
     },
     "@yalesites-org/tokens": {
-      "version": "1.15.1",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.15.1/05115356875f13860d48a8de60690ae11fb44e7bad338e8bd7cc9f07117bb006",
-      "integrity": "sha512-k08z7ove6IK3al1Vdx9kElK1/RjdopiwJpoDqjoxezzgwcu85veY6NC8lYSOgwBBjfwq+X7rZKA2dF/4aldADw=="
+      "version": "1.15.3",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.15.3/4d1628cd750de4df30ac78c555ace485ccda8d9225d17ede99fb5dedbcd25299",
+      "integrity": "sha512-RQSPd1fFRj8Z0xnxnNdfx9nIl7SagecJRQflIvCOY3l01JV57FeCKKV9YZI4JpODf6vV+l/IC8j6vdFcte4GnQ=="
     },
     "accepts": {
       "version": "1.3.7",


### PR DESCRIPTION
## [YALB-108: Standard Page](https://yaleits.atlassian.net/browse/YALB-108)

### Description of work
- Adds into content examples to standard page
- Sets the page-title width to "content" width
- Updates tokens to remove "beige" from site-footer color schemes

### Testing Link(s)
- [ ] Navigate to the [Standard Page Story](https://deploy-preview-42--dev-component-library-twig.netlify.app/?path=/story/page-examples-page-examples--standard-page)

### Functional Review Steps
- [ ] Verify the Standard Page story has a new "Intro Content" control, and you can choose "image", "image-feature", "image-max", and "pop-out-image" to see each of them at the top of the page.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
