### PR TITLE
feat: add storybook-addon-html

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,6 +7,7 @@ module.exports = {
     '@storybook/addon-a11y',
     '@storybook/addon-links',
     '@storybook/addon-essentials',
+    '@whitespace/storybook-addon-html',
   ],
   framework: "@storybook/html",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@storybook/addon-essentials": "^6.4.9",
         "@storybook/addon-links": "^6.4.9",
         "@storybook/html": "^6.4.9",
+        "@whitespace/storybook-addon-html": "^5.0.0",
         "@yalesites-org/eslint-config-and-other-formatting": "^1.0.0",
         "babel-loader": "^8.2.3",
         "husky": "^7.0.4",
@@ -5913,6 +5914,41 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@whitespace/storybook-addon-html": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-5.0.0.tgz",
+      "integrity": "sha512-1OkgqEGNcXFzeOCGtJsEcPPswVy+mDRgDOFClXWX/f2SG/JBfkltXoFnCj2EfGwhIQaVGxjT7k1gqANKy5VeJQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.13.9",
+        "@babel/parser": "^7.13.12",
+        "@storybook/api": "^6.1.21",
+        "@storybook/components": "^6.1.21",
+        "prettier": "^2.2.1",
+        "react-syntax-highlighter": "^15.4.3"
+      },
+      "peerDependencies": {
+        "@storybook/addons": "^6.1.21",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@whitespace/storybook-addon-html/node_modules/react-syntax-highlighter": {
+      "version": "15.4.5",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.5.tgz",
+      "integrity": "sha512-RC90KQTxZ/b7+9iE6s9nmiFLFjWswUcfULi4GwVzdFVKVMQySkJWBuOmJFfjwjMVCo0IUUuJrWebNKyviKpwLQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "^10.4.1",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.25.0",
+        "refractor": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -19247,7 +19283,6 @@
       "version": "2.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -29178,6 +29213,35 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@whitespace/storybook-addon-html": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-5.0.0.tgz",
+      "integrity": "sha512-1OkgqEGNcXFzeOCGtJsEcPPswVy+mDRgDOFClXWX/f2SG/JBfkltXoFnCj2EfGwhIQaVGxjT7k1gqANKy5VeJQ==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.13.9",
+        "@babel/parser": "^7.13.12",
+        "@storybook/api": "^6.1.21",
+        "@storybook/components": "^6.1.21",
+        "prettier": "^2.2.1",
+        "react-syntax-highlighter": "^15.4.3"
+      },
+      "dependencies": {
+        "react-syntax-highlighter": {
+          "version": "15.4.5",
+          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.5.tgz",
+          "integrity": "sha512-RC90KQTxZ/b7+9iE6s9nmiFLFjWswUcfULi4GwVzdFVKVMQySkJWBuOmJFfjwjMVCo0IUUuJrWebNKyviKpwLQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "highlight.js": "^10.4.1",
+            "lowlight": "^1.17.0",
+            "prismjs": "^1.25.0",
+            "refractor": "^3.2.0"
+          }
+        }
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "dev": true
@@ -38243,8 +38307,7 @@
     },
     "prettier": {
       "version": "2.5.1",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@storybook/addon-essentials": "^6.4.9",
     "@storybook/addon-links": "^6.4.9",
     "@storybook/html": "^6.4.9",
+    "@whitespace/storybook-addon-html": "^5.0.0",
     "@yalesites-org/eslint-config-and-other-formatting": "^1.0.0",
     "babel-loader": "^8.2.3",
     "husky": "^7.0.4",


### PR DESCRIPTION
## feat: add storybook-addon-html

### Description of work
- Adds [storybook-addon-html](https://storybook.js.org/addons/@whitespace/storybook-addon-html/) to show rendered HTML markup in Storybook

### Testing Link(s)
- [x] Navigate to the [Storybook](https://deploy-preview-43--dev-component-library-twig.netlify.app)

### Functional Review Steps
- [x] Verify that the 'HTML' tab appears on component pages
