### PR TITLE
YALB-393: Body copy type component spacing

### DIFF
--- a/components/00-tokens/layout/_layout.scss
+++ b/components/00-tokens/layout/_layout.scss
@@ -18,3 +18,9 @@ $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
     }
   }
 }
+
+@mixin spacing-page-inner {
+  &:not(.no-page-spacing) {
+    margin-bottom: var(--spacing-page-inner);
+  }
+}

--- a/components/00-tokens/layout/layout.js
+++ b/components/00-tokens/layout/layout.js
@@ -1,0 +1,29 @@
+Drupal.behaviors.layout = {
+  attach(context) {
+    // Classes.
+    // This array of classes should not have the preceding `.` so that we can
+    // check for them in `classList.contains` below.
+    const classesToCheck = ['text-field', 'pop-out-image'];
+    // Generate a string of the above classes with preceding `.` for the
+    // querySelectorAll below.
+    const bodyCopyClasses = classesToCheck.map((i) => `.${i}`);
+    // Selectors.
+    const bodyCopyComponents = context.querySelectorAll(bodyCopyClasses);
+
+    bodyCopyComponents.forEach((component) => {
+      const nextElement = component.nextElementSibling;
+
+      if (
+        // If there is a next element.
+        nextElement &&
+        // And the next element contains one of the classesToCheck
+        classesToCheck.some((className) =>
+          nextElement.classList.contains(className),
+        )
+      ) {
+        // Add the `no-page-spacing` class to the component.
+        component.classList.add('no-page-spacing');
+      }
+    });
+  },
+};

--- a/components/01-atoms/divider/_divider.scss
+++ b/components/01-atoms/divider/_divider.scss
@@ -1,4 +1,4 @@
-@use '~@yalesites-org/tokens/build/scss/tokens';
+@use '../../00-tokens/tokens';
 @use '../../00-tokens/functions/map';
 
 $widths: map.deep-get(tokens.$tokens, layout, width);
@@ -6,7 +6,7 @@ $thicknesses: map.deep-get(tokens.$tokens, size, thickness);
 $positions: map.deep-get(tokens.$tokens, layout, flex-position);
 
 .divider__wrapper {
-  margin-bottom: var(--spacing-page-inner);
+  @include tokens.spacing-page-inner;
 }
 
 .divider__inner {

--- a/components/02-molecules/image/_content-image.scss
+++ b/components/02-molecules/image/_content-image.scss
@@ -1,3 +1,5 @@
+@use '../../00-tokens/tokens';
+
 .content-image {
-  margin-bottom: var(--spacing-page-inner);
+  @include tokens.spacing-page-inner;
 }

--- a/components/02-molecules/page-title/_page-title.scss
+++ b/components/02-molecules/page-title/_page-title.scss
@@ -1,7 +1,7 @@
 @use '../../00-tokens/tokens';
 
 .page-title {
-  margin-bottom: var(--spacing-page-inner);
+  @include tokens.spacing-page-inner;
 }
 
 .page-title__heading {

--- a/components/02-molecules/pop-out-image/_pop-out-image.scss
+++ b/components/02-molecules/pop-out-image/_pop-out-image.scss
@@ -1,5 +1,16 @@
 @use '../../00-tokens/tokens';
 
+.pop-out-image {
+  @include tokens.spacing-page-inner;
+
+  // Clear the float in case the next component is an image or something.
+  &::after {
+    content: '';
+    display: block;
+    clear: both;
+  }
+}
+
 .pop-out-image__inner {
   position: relative;
 }
@@ -15,8 +26,4 @@
     margin-right: -5%;
     margin-bottom: var(--size-spacing-7);
   }
-}
-
-.pop-out-image__clearfix {
-  clear: both;
 }

--- a/components/02-molecules/pop-out-image/pop-out-image.twig
+++ b/components/02-molecules/pop-out-image/pop-out-image.twig
@@ -41,4 +41,3 @@
     } %}
   </div>
 </div>
-<div {{ bem('clearfix', [], pop_out_image__base_class) }}></div>

--- a/components/02-molecules/pull-quote/_pull-quote.scss
+++ b/components/02-molecules/pull-quote/_pull-quote.scss
@@ -1,3 +1,5 @@
+@use '../../00-tokens/tokens';
+
 blockquote {
   margin: 0;
 }
@@ -6,7 +8,7 @@ blockquote {
   --color-pull-quote-quote: var(--color-gray-800);
   --color-pull-quote-attribution: var(--color-basics-brown-gray);
 
-  margin-bottom: var(--spacing-page-inner);
+  @include tokens.spacing-page-inner;
 }
 
 .pull-quote__figure {

--- a/components/02-molecules/text-with-image/_text-with-image.scss
+++ b/components/02-molecules/text-with-image/_text-with-image.scss
@@ -1,7 +1,7 @@
 @use '../../00-tokens/tokens';
 
 .text-with-image {
-  margin-bottom: var(--spacing-page-inner);
+  @include tokens.spacing-page-inner;
 }
 
 .text-with-image__inner {

--- a/components/02-molecules/text/_text-field.scss
+++ b/components/02-molecules/text/_text-field.scss
@@ -1,3 +1,5 @@
+@use '../../00-tokens/tokens';
+
 .text-field {
-  margin-bottom: var(--spacing-page-inner);
+  @include tokens.spacing-page-inner;
 }

--- a/components/05-page-examples/page-examples.stories.js
+++ b/components/05-page-examples/page-examples.stories.js
@@ -1,12 +1,18 @@
+// Shared Storybook args.
 import argTypes from '../04-page-layouts/page-args';
 
+// Twig files.
 import standardPageTwig from './standard-page.twig';
 import newsArticleTwig from './news-article.twig';
 
+// Data files.
 import utilityNavData from '../03-organisms/menu/utility-nav/utility-nav.yml';
 import breadcrumbData from '../03-organisms/menu/breadcrumbs/breadcrumbs.yml';
 import imageData from '../01-atoms/images/image/image.yml';
 import textWithImageData from '../02-molecules/text-with-image/text-with-image.yml';
+
+// JavaScript.
+import '../00-tokens/layout/layout';
 
 /**
  * Storybook Definition.


### PR DESCRIPTION
## [YALB-393: Body copy type component spacing](https://yaleits.atlassian.net/browse/YALB-393)

### Description of work
- Fixes the pop-out-image clearfix that got missed in a previous PR
- Creates mixin for page-level spacing with a conditional based on a class
- JavaScript to add the class mentioned above to adjacent "body copy type" components to prevent unwanted spacing

### Testing Link(s)
- [ ] Navigate to the [News Page Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/page-examples-page-examples--news-article)

### Functional Review Steps
- [ ] Verify there is no "extra" spacing between any adjacent "text-field" and "pop-out-image" components.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
