### PR TITLE
YALB-250 and YALB-238: Wiring 2

### DIFF
--- a/components/01-atoms/images/icons/_icon.twig
+++ b/components/01-atoms/images/icons/_icon.twig
@@ -10,7 +10,7 @@
 {% set icon__base_class = icon__base_class|default('icon') %}
 {# If `directory` is defined, set the path relative for Drupal.
  # Otherwise, set the path relative to the Component Library. #}
-{% set icon__url = directory ? '/' ~ directory ~ '/dist/' %}
+{% set icon__url = directory ? '/' ~ directory ~ '/node_modules/@yalesites-org/component-library-twig/dist/' %}
 
 {% set unique_name = icon__name ~ '-' ~ random() %}
 

--- a/components/02-molecules/accordion/accordion.twig
+++ b/components/02-molecules/accordion/accordion.twig
@@ -1,3 +1,11 @@
+{#
+ # Available Variables:
+ # - accordion__heading
+ #
+ # Available Blocks:
+ # - accordion__items
+ #}
+
 {% set accordion__base_class = 'accordion' %}
 
 {% set expand_all__content %}
@@ -53,12 +61,14 @@
         {% endembed %}
       {% endblock %}
     {% endembed %}
-    {% for item in accordion__items %}
-      {% include "@molecules/accordion/_accordion-item.twig" with {
-        accordion__item__heading: item.accordion__item__heading,
-        accordion__item__content: item.accordion__item__content,
-        accordion__item__heading__level: accordion__heading ? '3' : '2',
-      } %}
-    {% endfor %}
+    {% block accordion__items %}
+      {% for item in accordion__items %}
+        {% include "@molecules/accordion/_accordion-item.twig" with {
+          accordion__item__heading: item.accordion__item__heading,
+          accordion__item__content: item.accordion__item__content,
+          accordion__item__heading__level: accordion__heading ? '3' : '2',
+        } %}
+      {% endfor %}
+    {% endblock %}
   </div>
 </div>

--- a/components/02-molecules/menu/_menu-item.twig
+++ b/components/02-molecules/menu/_menu-item.twig
@@ -1,5 +1,3 @@
-{% import "@molecules/menu/menu.twig" as menus %}
-
 {% set item__modifiers = ['level-' ~ menu__level] %}
 {% set item__attributes = item__attributes|default({}) %}
 
@@ -60,6 +58,9 @@
   list__item__attributes: item__attributes,
 } %}
 {% block list__item__content %}
+  {# This import needs to be inside the block for it to work in Drupal #}
+  {% import "@molecules/menu/menu.twig" as menus %}
+
   {{- list__item -}}
   {% if item.below %}
     {% if menu__level == 0 and  menu__level__toggle %}
@@ -70,7 +71,7 @@
         aria_expanded: 'false',
       } %}
     {% endif %}
-    {{ menus.menu_links(item.below, attributes, menu__level + 1, menu__base_class, menu__modifiers, menu__blockname, menu__list__type, menu__level__toggle, item__base_class, item__modifiers, item__blockname) }}
+    {{ menus.menu_links(item.below, attributes, menu__level + 1, menu__base_class, menu__modifiers, menu__blockname, menu__list__type, menu__level__toggle, item__base_class, item__modifiers, item__blockname, directory) }}
   {% endif %}
 {% endblock %}
 {% endembed %}

--- a/components/02-molecules/text-with-image/text-with-image.twig
+++ b/components/02-molecules/text-with-image/text-with-image.twig
@@ -11,6 +11,9 @@
  # - text_with_image__text
  # - text_with_image__link__content (optional)
  # - text_with_image__link__url (optional)
+ #
+ # Available blocks:
+ # - text_with_image__image
  #}
 
 {% set text_with_image__base_class = 'text-with-image' %}

--- a/components/03-organisms/menu/primary-nav/_primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_primary-nav.scss
@@ -148,7 +148,7 @@
   }
 
   &:hover {
-    color: var(--color-link);
+    color: var(--menu-link-color);
   }
 
   &--level-0 {
@@ -190,7 +190,7 @@
   }
 
   &:hover {
-    color: var(--color-link);
+    color: var(--menu-link-color);
   }
 
   &--level-0 {


### PR DESCRIPTION
## This PR addresses the following tickets:
- [YALB-250: Wire Text with Media](https://yaleits.atlassian.net/browse/YALB-250)
- [YALB-238: Wire Accordion and Accordion Item](https://yaleits.atlassian.net/browse/YALB-238)

### Relates to the following PRs:
- https://github.com/yalesites-org/yalesites_profile/pull/15
- https://github.com/yalesites-org/atomic/pull/2

### Description of work
- Fixes the main menu link hover color
- Fixes icon path for Drupal
- Fixes the menu nesting for Drupal
- Adds a block to accordion for Drupal's nesting

## Todo:
- [ ] Accordion Item has the Text Paragraph nested in it. I wasn't expecting that. The text paragraph has some styling that is causing issues inside an accordion.
- [ ] Accordion is missing a heading field
- [ ] Need a way (preprocess?) to tell accordion items whether or not the parent accordion has a heading (for semantics)