### PR TITLE
YALB-471: fix accordion icon size

### DIFF
--- a/components/02-molecules/accordion/_accordion.scss
+++ b/components/02-molecules/accordion/_accordion.scss
@@ -80,6 +80,7 @@
 
   height: 1em;
   width: 1em;
+  flex-shrink: 0;
 
   [aria-expanded='true'] > & {
     transform: rotate(180deg);


### PR DESCRIPTION
## [YALB-471: fix accordion icon size](https://yaleits.atlassian.net/browse/YALB-471)

### Description of work
- Fixes accordion drop down arrow to not shrink after heading exceeds 3 lines.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-471--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)
