### PR TITLE
YALB-635: Wire Breadcrumbs

### DIFF
--- a/components/02-molecules/menu/_menu-item.twig
+++ b/components/02-molecules/menu/_menu-item.twig
@@ -33,18 +33,18 @@
         'aria-current': 'page',
       }) %}
     {% endif %}
-    {% if directory %}
+    {% if directory and not menu__contextual %}
       {% set link__url = item.url.toString %}
     {% else %}
       {% set link__url = item.url %}
     {% endif %}
-      {% include "@atoms/controls/text-link/text-link.twig" with {
-        link__content: item.title,
-        link__base_class: 'link',
-        link__blockname: menu__base_class,
-        link__modifiers: item__modifiers,
-        link__attributes: link__attributes,
-      } %}
+    {% include "@atoms/controls/text-link/text-link.twig" with {
+      link__content: item.title,
+      link__base_class: 'link',
+      link__blockname: menu__base_class,
+      link__modifiers: item__modifiers,
+      link__attributes: link__attributes,
+    } %}
   {% endif %}
 {% endset %}
 
@@ -77,7 +77,7 @@
         aria_expanded: 'false',
       } %}
     {% endif %}
-    {{ menus.menu_links(item.below, attributes, menu__level + 1, menu__base_class, menu__modifiers, menu__blockname, menu__list__type, menu__level__toggle, item__base_class, item__modifiers, item__blockname, directory) }}
+    {{ menus.menu_links(item.below, attributes, menu__level + 1, menu__base_class, menu__modifiers, menu__blockname, menu__list__type, menu__level__toggle, menu__contextual, item__base_class, item__modifiers, item__blockname, directory) }}
   {% endif %}
 {% endblock %}
 {% endembed %}

--- a/components/02-molecules/menu/menu.twig
+++ b/components/02-molecules/menu/menu.twig
@@ -40,7 +40,7 @@
   We call a macro which calls itself to render the full tree.
   @see http://twig.sensiolabs.org/doc/tags/macro.html
 #}
-{% macro menu_links(items, attributes, menu__level, menu__base_class, menu__modifiers, menu__blockname, menu__list__type, menu__level__toggle, item__base_class, item__modifiers, item__blockname, directory) %}
+{% macro menu_links(items, attributes, menu__level, menu__base_class, menu__modifiers, menu__blockname, menu__list__type, menu__level__toggle, menu__contextual, item__base_class, item__modifiers, item__blockname, directory) %}
   {% import _self as menus %}
   {% if items %}
     {% set menu__modifiers = ['level-' ~ menu__level] %}
@@ -54,6 +54,6 @@
 
 <nav {{ add_attributes(menu__attributes) }}>
   {% block menu_prefix %}{% endblock %}
-  {{ menus.menu_links(items, attributes, 0, menu__base_class, menu__modifiers, menu__blockname, menu__list__type, menu__level__toggle, item__base_class, item__modifiers, item__blockname, directory) }}
+  {{ menus.menu_links(items, attributes, 0, menu__base_class, menu__modifiers, menu__blockname, menu__list__type, menu__level__toggle, menu__contextual, item__base_class, item__modifiers, item__blockname, directory) }}
   {% block menu_suffix %}{% endblock %}
 </nav>


### PR DESCRIPTION
## [YALB-635: Wire Breadcrumbs](https://yaleits.atlassian.net/browse/YALB-635)

### Description of work
- Passes menu__contextual to items so that Drupal uses the right stuff

### Testing Link(s)
- [ ] Navigate to any [example page](https://deploy-preview-119--dev-component-library-twig.netlify.app/?path=/story/page-examples-events--event-page)

### Functional Review Steps
- [ ] Verify the breadcrumbs still function as expected

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
