### PR TITLE
YALB-627: hiding breadcrumbs short trails

### DIFF
--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs.twig
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs.twig
@@ -12,6 +12,7 @@
 {% set parent_count = breadcrumbs__items.length - 2 %}
 {% set parent_label = breadcrumbs__items[parent_count].title %}
 
+{% if breadcrumbs__items.2 %}
 <div {{ add_attributes(breadcrumbs__attributes) }}>
   {% set control__content %}
     <span {{ bem('visually-hidden') }}>Show all breadcrumbs</span>
@@ -37,3 +38,4 @@
     } %}
   </div>
 </div>
+{% endif %}


### PR DESCRIPTION
## [YALB-627: hiding breadcrumbs short trails](https://yaleits.atlassian.net/browse/YALB-627)

### Description of work
- Will not display breadcrumbs if there are only 2 segments. Only if 3 or more levels deep.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-121--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
