### PR TITLE
YALB-647: updates page title spacing

### DIFF
--- a/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
+++ b/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin: var(--size-spacing-6) 0 var(--size-spacing-7);
+  margin-bottom: var(--size-spacing-7);
 }
 
 .breadcrumbs__button {

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -25,6 +25,7 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
   position: relative;
   z-index: 2;
+  margin-bottom: var(--size-spacing-7);
 
   // Component themes
   @each $theme, $value in $site-header-themes {

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -64,6 +64,7 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
   @media (min-width: tokens.$break-mobile) {
     border-bottom: var(--site-header-border-bottom);
+    margin-bottom: var(--size-spacing-7);
   }
 }
 

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -25,7 +25,7 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
   position: relative;
   z-index: 2;
-  margin-bottom: var(--size-spacing-7);
+  margin-bottom: var(--size-spacing-9);
 
   // Component themes
   @each $theme, $value in $site-header-themes {

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -25,7 +25,7 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
   position: relative;
   z-index: 2;
-  margin-bottom: var(--size-spacing-9);
+  margin-bottom: var(--size-spacing-7);
 
   // Component themes
   @each $theme, $value in $site-header-themes {
@@ -64,7 +64,7 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
   @media (min-width: tokens.$break-mobile) {
     border-bottom: var(--site-header-border-bottom);
-    margin-bottom: var(--size-spacing-7);
+    margin-bottom: var(--size-spacing-9);
   }
 }
 


### PR DESCRIPTION
## [YALB-647: updates page title spacing](https://yaleits.atlassian.net/browse/YALB-647)

### Description of work
- Fixes the spacing to make a wider gap above the page title.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-128--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [x] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [x] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
