### PR TITLE
YALB-648: adds line height to paragraphs

### DIFF
--- a/components/00-tokens/typography/_typography.scss
+++ b/components/00-tokens/typography/_typography.scss
@@ -2,6 +2,7 @@ body {
   background-color: var(--color-background);
   color: var(--color-text);
   font: var(--font-style-body-default);
+  line-height: 40px;
 }
 
 code {

--- a/components/01-atoms/typography/text/_yds-text.scss
+++ b/components/01-atoms/typography/text/_yds-text.scss
@@ -5,5 +5,6 @@ p {
 .text {
   p:last-child {
     margin-bottom: 0;
+    line-height: 40px;
   }
 }

--- a/components/01-atoms/typography/text/_yds-text.scss
+++ b/components/01-atoms/typography/text/_yds-text.scss
@@ -5,6 +5,5 @@ p {
 .text {
   p:last-child {
     margin-bottom: 0;
-    line-height: 40px;
   }
 }


### PR DESCRIPTION
## [YALB-648: adds line height to paragraphs](https://yaleits.atlassian.net/browse/YALB-648)

### Description of work
- increases the line height of paragraphs to 40px.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-129--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
