### PR TITLE
YALB-668: Feedback: First Tab selection on page load

### DIFF
--- a/components/02-molecules/tabs/_yds-tab-label.twig
+++ b/components/02-molecules/tabs/_yds-tab-label.twig
@@ -1,5 +1,5 @@
 {% if key == 0 %}
-  {% set aria_selected = 'aria-selected="true"' %}
+  {% set aria_selected = 'aria-selected=true' %}
 {% else %}
   {% set tab_index = 'tabindex="-1"' %}
 {% endif %}


### PR DESCRIPTION
## [YALB-668: Feedback: First Tab selection on page load](https://yaleits.atlassian.net/browse/YALB-668)

### Description of work
- Removes quotes that break Drupal

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-131--dev-component-library-twig.netlify.app/?path=/story/molecules-tabs--tabs)

### Functional Review Steps
- [x] Verify the tabs still look correct on load in Storybook
- [x] Create a page (in Drupal) and add a tabs component. Add a couple of tabs, and verify that when you save it, the first tab is indicated as active (underlined) on initial page load.