### PR TITLE
YALB-702: Search: Hide search form

### DIFF
--- a/components/03-organisms/menu/utility-nav/yds-utility-nav.twig
+++ b/components/03-organisms/menu/utility-nav/yds-utility-nav.twig
@@ -6,7 +6,6 @@
     {% include "@organisms/menu/utility-nav/_utility-nav--menu.twig" %}
   {% endblock %}
   {# Search #}
-  {% set utility_nav__search = true %}
   {% if utility_nav__search %}
     <div {{ bem('search', [], utility_nav__base_class) }}>
       {% block site_header__search %}


### PR DESCRIPTION
## [YALB-702: Search: Hide search form](https://yaleits.atlassian.net/browse/YALB-702)

### Description of work
- Adds the ability to show or hide the search box in the utility navigation area
- Note: This requires [PR-120 from yalesites-project](https://github.com/yalesites-org/yalesites-project/pull/120) and [PR-49 from atomic](https://github.com/yalesites-org/atomic/pull/49) to work

### Functional testing steps:
- [ ] Import config ```drush cim```
- [ ] Visit any page and note the utility navigation area
- [ ] Visit the settings form at ```admin/yalesites/settings```, toggle the enable search form and save
- [ ] Visit any page and note that the search form can be enabled and disabled

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-149--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-utility-nav--utility-nav)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
