### PR TITLE
YALB-784: Remove aria attribute

### DIFF
--- a/components/02-molecules/tabs/yds-tabs.twig
+++ b/components/02-molecules/tabs/yds-tabs.twig
@@ -1,6 +1,12 @@
 {# @TODO: Look into refactoring this to use the list component, if possible. #}
 {# @LINK: https://yaleits.atlassian.net/browse/YALB-658 #}
 {#
+ # Available Props:
+ # - tabs__component: boolean. The Drupal editorial "tabs" are not a true
+ #    tablist, so, while they share the visual styles, they should not share all
+ #    of the a11y/semantic markup. This allows us to "turn off" those featuers
+ #    that should not be there in that case.
+ #
  # Available Variables:
  # - tabs__id: unique ID used to differentiate multiple tab sets on a page.
  # - tabs: Array of tabs with the following properties.
@@ -10,6 +16,7 @@
 
 {% set tabs__base_class = 'tabs' %}
 {% set tabs__id = tabs__id|default(random()) %}
+{% set tablist = tabs__component == 'false' ? '' : 'role="tablist"' %}
 
 {% set icon_left %}
   {% include "@atoms/images/icons/_yds-icon.twig" with {
@@ -46,7 +53,7 @@
         'tabindex': '-1',
       },
     } %}
-    <ul {{ bem('nav', [], tabs__base_class) }} role="tablist">
+    <ul {{ bem('nav', [], tabs__base_class) }} {{ tablist }}>
       {% block tab__label %}
         {% for key, tab in tabs %}
           {% include "@molecules/tabs/_yds-tab-label.twig" %}


### PR DESCRIPTION
## [YALB-784: Remove aria attribute](https://yaleits.atlassian.net/browse/YALB-784)

### Description of work
- Makes the `role="tablist"` attribute a variable that can be disabled

### Functional Review Steps
- [x] Navigate to the [Tabs Story](https://deploy-preview-156--dev-component-library-twig.netlify.app/?path=/story/molecules-tabs--tabs) and verify the attribute is present on the `<ul>` element.
- [x] Follow the review steps in the [Related Atomic PR](https://github.com/yalesites-org/atomic/pull/56)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
