### PR TITLE
fix: alert dismissal wasn't preserved on page refresh if all alerts on a page had not been interacted with

### DIFF
--- a/components/02-molecules/alert/yds-alert.js
+++ b/components/02-molecules/alert/yds-alert.js
@@ -67,6 +67,9 @@ Drupal.behaviors.alert = {
     }
 
     if (storageAvailable('localStorage')) {
+      const alertCount = alerts.length;
+      let newAlerts = 0;
+
       alerts.forEach((alert) => {
         const id = alert.getAttribute(alertId);
         const type = alert.getAttribute('data-alert-type');
@@ -77,7 +80,7 @@ Drupal.behaviors.alert = {
 
         // If the current alert has no state, clear other values from storage.
         if (state == null) {
-          resetAlerts();
+          newAlerts += 1;
         }
 
         // If the alert was dismissed, keep it dismissed.
@@ -101,6 +104,10 @@ Drupal.behaviors.alert = {
           return dismiss(alert, id);
         });
       });
+
+      if (alertCount === newAlerts) {
+        resetAlerts();
+      }
     }
   },
 };


### PR DESCRIPTION
### Description of work
- fix: alert dismissal wasn't preserved on page refresh if all alerts on a page had not been interacted with.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [x] Checkout branch and run `npm run local:cl-dev` from project root
- [x] Navigate to Storybook Alert story: http://localhost:6006/?path=/story/molecules-alert--alert-examples
- [x] Dismiss one of the alerts
- [x] Refresh the page and verify the previously dismissed alert is still dismissed
- [x] Dismiss another alert, refresh, and verify it, too, is persistently dismissed. 

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
