### PR TITLE
YALB-562 and YALB-563: Header and Footer spacing

### DIFF
--- a/components/00-tokens/colors/_color-pairings.scss
+++ b/components/00-tokens/colors/_color-pairings.scss
@@ -1,7 +1,7 @@
 @use '~@yalesites-org/tokens/build/scss/tokens';
-@use 'sass:map';
+@use '../functions/map';
 
-$themes: map.get(tokens.$tokens, 'component-themes');
+$themes: map.deep-get(tokens.$tokens, 'component-themes');
 
 @each $theme, $value in $themes {
   [data-component-theme='#{$theme}'] {

--- a/components/00-tokens/functions/_map.scss
+++ b/components/00-tokens/functions/_map.scss
@@ -3,6 +3,7 @@
 @use 'sass:meta';
 
 /// Map deep get
+/// Reference: https://stackoverflow.com/a/66004582/17322403
 /// @param {Map} $map - Map
 /// @param {Arglist} $keys - Key chain
 /// @return {*} - Desired value

--- a/components/00-tokens/layout/_layout.scss
+++ b/components/00-tokens/layout/_layout.scss
@@ -74,13 +74,38 @@ $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
 
   @if $flush-top == true {
     &:first-child {
-      margin-top: 0;
+      --main-content-top-margin: 0;
     }
   }
 
   @if $flush-bottom == true {
     &:last-child {
-      margin-bottom: 0;
+      --main-content-bottom-margin: 0;
     }
   }
+}
+
+// The first item inside the `.main-content` area should have some space between
+// it and the site header (size-spacing-7 and 9 below) - unless it is designated
+// as `$flush-top` above. Then it will have no top-margin separating it from the
+// site header.
+.main-content > *:first-child {
+  --main-content-top-margin-default: var(--size-spacing-7);
+
+  margin-top: var(
+    --main-content-top-margin,
+    var(--main-content-top-margin-default)
+  );
+
+  @media (min-width: tokens.$break-mobile) {
+    --main-content-top-margin-default: var(--size-spacing-9);
+  }
+}
+
+// The last item inside the `.main-content` area should have some space between
+// it and the site footer (size-spacing-12 below) - unless it is designated as
+// `$flush-bottom` above. Then it will have no bottom-margin separating it from
+// the site footer.
+.main-content > *:last-child {
+  margin-bottom: var(--main-content-bottom-margin, var(--size-spacing-12));
 }

--- a/components/00-tokens/layout/_layout.scss
+++ b/components/00-tokens/layout/_layout.scss
@@ -84,28 +84,3 @@ $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
     }
   }
 }
-
-// The first item inside the `.main-content` area should have some space between
-// it and the site header (size-spacing-7 and 9 below) - unless it is designated
-// as `$flush-top` above. Then it will have no top-margin separating it from the
-// site header.
-.main-content > *:first-child {
-  --main-content-top-margin-default: var(--size-spacing-7);
-
-  margin-top: var(
-    --main-content-top-margin,
-    var(--main-content-top-margin-default)
-  );
-
-  @media (min-width: tokens.$break-mobile) {
-    --main-content-top-margin-default: var(--size-spacing-9);
-  }
-}
-
-// The last item inside the `.main-content` area should have some space between
-// it and the site footer (size-spacing-12 below) - unless it is designated as
-// `$flush-bottom` above. Then it will have no bottom-margin separating it from
-// the site footer.
-.main-content > *:last-child {
-  margin-bottom: var(--main-content-bottom-margin, var(--size-spacing-12));
-}

--- a/components/00-tokens/layout/_layout.scss
+++ b/components/00-tokens/layout/_layout.scss
@@ -32,11 +32,6 @@
   }
 }
 
-// "Freeze" the body when a modal is open to prevent background scrolling.
-body[data-modal-active='true'] {
-  overflow: hidden;
-}
-
 $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
 
 [data-component-width] {

--- a/components/02-molecules/banner/action/_yds-action-banner.scss
+++ b/components/02-molecules/banner/action/_yds-action-banner.scss
@@ -4,7 +4,7 @@
 $break-cta-banner: tokens.$break-m;
 
 .cta-banner {
-  @include tokens.spacing-page-section($flush-top: true);
+  @include tokens.spacing-page-section($flush-top: true, $flush-bottom: true);
 
   padding: 0;
 }

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -1,5 +1,4 @@
 @use '../../00-tokens/functions/map';
-@use 'sass:map' as sass-map;
 @use '../../00-tokens/tokens';
 
 $site-header-themes: map.deep-get(tokens.$tokens, site-header-themes);
@@ -25,7 +24,6 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
   position: relative;
   z-index: 2;
-  margin-bottom: var(--size-spacing-7);
 
   // Component themes
   @each $theme, $value in $site-header-themes {
@@ -64,7 +62,6 @@ $site-header-layout: map.deep-get(tokens.$tokens, 'site-header-layout');
 
   @media (min-width: tokens.$break-mobile) {
     border-bottom: var(--site-header-border-bottom);
-    margin-bottom: var(--size-spacing-9);
   }
 }
 

--- a/components/04-page-layouts/page-layouts.scss
+++ b/components/04-page-layouts/page-layouts.scss
@@ -5,3 +5,26 @@ body[data-body-frozen] {
     overflow: hidden;
   }
 }
+
+// The first item inside the `.main-content` area should have some space between
+// it and the site header (size-spacing-7 and 9 below) - unless it is designated
+// as `$flush-top` above. Then it will have no top-margin separating it from the
+// site header.
+.main-content > *:first-child {
+  --main-content-top-margin-default: var(--size-spacing-7);
+
+  // prettier-ignore
+  margin-top: var(--main-content-top-margin, var(--main-content-top-margin-default));
+
+  @media (min-width: tokens.$break-mobile) {
+    --main-content-top-margin-default: var(--size-spacing-9);
+  }
+}
+
+// The last item inside the `.main-content` area should have some space between
+// it and the site footer (size-spacing-12 below) - unless it is designated as
+// `$flush-bottom` above. Then it will have no bottom-margin separating it from
+// the site footer.
+.main-content > *:last-child {
+  margin-bottom: var(--main-content-bottom-margin, var(--size-spacing-12));
+}

--- a/components/04-page-layouts/page-layouts.scss
+++ b/components/04-page-layouts/page-layouts.scss
@@ -1,5 +1,18 @@
 @use '../00-tokens/tokens';
 
+// @LINK: https://yaleits.atlassian.net/browse/YALB-814
+// @TODO: These two methods of "freezing" the body could probably be
+// consolidated. The menu one could probably add and remove the attribute based
+// on screen size, and then remove the media query here. And the modal active
+// one could probably be refactored to just use the `[data-body-frozen]`
+// attribute.
+
+// "Freeze" the body when a modal is open to prevent background scrolling.
+body[data-modal-active='true'] {
+  overflow: hidden;
+}
+
+// "Freeze" the body on large screens when the mobile menu is open.
 body[data-body-frozen] {
   @media (max-width: tokens.$break-mobile-max) {
     overflow: hidden;


### PR DESCRIPTION
## [YALB-562: Footer spacing](https://yaleits.atlassian.net/browse/YALB-562)
## [YALB-563: Header spacing](https://yaleits.atlassian.net/browse/YALB-563)

### Description of work
- Updates logic for spacing under header, and above footer

### Testing Link(s)
- [x] Navigate to the [Page with Banner](https://deploy-preview-159--dev-component-library-twig.netlify.app/?path=/story/page-examples-standard-pages--with-banner)

### Functional Review Steps
- [x] This is a little tricky since the breadcrumbs haven't been moved yet, so for review, just delete them in your browser dev tools.
	- [x] Verify that the banner is "flush" with the page header
	- [x] Verify that the first `.text-field` component after it does not have a top-margin
	- [x] Verify the `.callouts` at the bottom of the page is "flush" with the page footer
	- [x] Verify the `.text-field` component right above it has `margin-bottom: var(--spacing-page-inner);`
- [x] Using the dev-tools, delete (or move) both the banner at the top, and the callouts at the bottom so they are not the first, nor last items in the `.main-content` div
	- [x] Verify that the first `.text-field` now has a margin-top of `size-7` on small screens, and `size-9` on large screens
	- [x] Verify that the last `.text-field` now has a margin-bottom of `size-12`

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
