### PR TITLE
YALB-789 -  image wrapped variations

### DIFF
--- a/components/00-tokens/layout/_layout.scss
+++ b/components/00-tokens/layout/_layout.scss
@@ -55,8 +55,8 @@ $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
 // The spacing-page-inner mixin should be applied to components that are
 // "content-like." They generally accompany other components within a "section."
 @mixin spacing-page-inner {
-  &.no-page-spacing + .wrapped-image {
-    margin-top: 1em;
+  .no-page-spacing + & {
+    margin-top: var(--font-spacing-paragraph);
   }
 
   &:not(.no-page-spacing) {

--- a/components/00-tokens/layout/_layout.scss
+++ b/components/00-tokens/layout/_layout.scss
@@ -55,6 +55,10 @@ $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
 // The spacing-page-inner mixin should be applied to components that are
 // "content-like." They generally accompany other components within a "section."
 @mixin spacing-page-inner {
+  &.no-page-spacing + .wrapped-image {
+    margin-top: 1em;
+  }
+
   &:not(.no-page-spacing) {
     margin-bottom: var(--spacing-page-inner);
   }

--- a/components/01-atoms/typography/text/_yds-text.scss
+++ b/components/01-atoms/typography/text/_yds-text.scss
@@ -1,5 +1,5 @@
 p {
-  margin-block: 0 1em;
+  margin-block: 0 var(--font-spacing-paragraph);
 }
 
 .text {

--- a/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
+++ b/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
@@ -21,9 +21,34 @@
   @media (min-width: tokens.$break-l) {
     top: 0;
     width: 50%;
-    float: left;
-    transform: translateX(-20%);
-    margin-right: -5%;
     margin-bottom: var(--size-spacing-7);
+
+    // floated
+    [data-component-image-style='floated'][data-component-image-alignment='left']
+      & {
+      float: left;
+      margin-right: 5%;
+    }
+
+    [data-component-image-style='floated'][data-component-image-alignment='right']
+      & {
+      float: right;
+      margin-left: 5%;
+    }
+
+    // offset
+    [data-component-image-style='offset'][data-component-image-alignment='left']
+      & {
+      float: left;
+      transform: translateX(-20%);
+      margin-right: -5%;
+    }
+
+    [data-component-image-style='offset'][data-component-image-alignment='right']
+      & {
+      float: right;
+      transform: translateX(20%);
+      margin-left: -5%;
+    }
   }
 }

--- a/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
+++ b/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
@@ -24,27 +24,26 @@
     margin-bottom: var(--size-spacing-7);
 
     // floated
-    [data-component-image-style='floated'][data-component-image-alignment='left']
+    [data-wrapped-image-style='floated'][data-wrapped-image-alignment='left']
       & {
       float: left;
       margin-right: 5%;
     }
 
-    [data-component-image-style='floated'][data-component-image-alignment='right']
+    [data-wrapped-image-style='floated'][data-wrapped-image-alignment='right']
       & {
       float: right;
       margin-left: 5%;
     }
 
     // offset
-    [data-component-image-style='offset'][data-component-image-alignment='left']
-      & {
+    [data-wrapped-image-style='offset'][data-wrapped-image-alignment='left'] & {
       float: left;
       transform: translateX(-20%);
       margin-right: -5%;
     }
 
-    [data-component-image-style='offset'][data-component-image-alignment='right']
+    [data-wrapped-image-style='offset'][data-wrapped-image-alignment='right']
       & {
       float: right;
       transform: translateX(20%);

--- a/components/02-molecules/wrapped-image/wrapped-image.stories.js
+++ b/components/02-molecules/wrapped-image/wrapped-image.stories.js
@@ -18,16 +18,30 @@ export default {
       type: 'string',
       defaultValue: 'This is the caption for the 16:9 image above.',
     },
+    imageAlignment: {
+      name: 'Image Alignment',
+      type: 'select',
+      options: ['left', 'right'],
+      defaultValue: 'left',
+    },
+    imageStyle: {
+      name: 'Image Style',
+      type: 'select',
+      options: ['floated', 'offset'],
+      defaultValue: 'floated',
+    },
   },
 };
 
-export const WrappedImage = ({ caption }) => `
+export const WrappedImage = ({ caption, imageAlignment, imageStyle }) => `
   ${textFieldTwig({
     text_field__content: WrappedImageData.text_one,
   })}
   ${wrappedImageTwig({
     ...imageData.responsive_images['3x2'],
     wrapped_image__caption: caption,
+    wrapped_image__alignment: imageAlignment,
+    wrapped_image__style: imageStyle,
     wrapped_image__content: WrappedImageData.text_two,
   })}
 `;

--- a/components/02-molecules/wrapped-image/yds-wrapped-image.twig
+++ b/components/02-molecules/wrapped-image/yds-wrapped-image.twig
@@ -13,6 +13,8 @@
 
 {% set wrapped_image__attributes = {
   'data-component-width': wrapped_image__width|default('content'),
+  'data-component-image-style': wrapped_image__style|default('floated'),
+  'data-component-image-alignment': wrapped_image__alignment|default('left'),
   'class': bem(wrapped_image__base_class),
 } %}
 

--- a/components/02-molecules/wrapped-image/yds-wrapped-image.twig
+++ b/components/02-molecules/wrapped-image/yds-wrapped-image.twig
@@ -13,8 +13,8 @@
 
 {% set wrapped_image__attributes = {
   'data-component-width': wrapped_image__width|default('content'),
-  'data-component-image-style': wrapped_image__style|default('floated'),
-  'data-component-image-alignment': wrapped_image__alignment|default('left'),
+  'data-wrapped-image-style': wrapped_image__style|default('floated'),
+  'data-wrapped-image-alignment': wrapped_image__alignment|default('left'),
   'class': bem(wrapped_image__base_class),
 } %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6491,9 +6491,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.18.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.0/ffed4551993cd39114cae6593e3ab0e1240af280",
-      "integrity": "sha512-tt7vkayTKqNOt/7FQDp9r+uXabUG/PCiCw2G2xjW6vBY2LP7G+NVgChF0R1QEDK7qjTQ0eivp7Boug9p/r8ixg=="
+      "version": "1.18.1",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.1/e84ea772a7dd71028b725e740fe1b4064d243577",
+      "integrity": "sha512-gmuqMI8E5gINO3sciXiUk4k4WBNwMux2lea1qY18PwDoddkyJErK4vnO7ruSt3EMA7I2kEP/lN9pa9JW7MYo1w=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -35979,9 +35979,9 @@
       "requires": {}
     },
     "@yalesites-org/tokens": {
-      "version": "1.18.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.0/ffed4551993cd39114cae6593e3ab0e1240af280",
-      "integrity": "sha512-tt7vkayTKqNOt/7FQDp9r+uXabUG/PCiCw2G2xjW6vBY2LP7G+NVgChF0R1QEDK7qjTQ0eivp7Boug9p/r8ixg=="
+      "version": "1.18.1",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.1/e84ea772a7dd71028b725e740fe1b4064d243577",
+      "integrity": "sha512-gmuqMI8E5gINO3sciXiUk4k4WBNwMux2lea1qY18PwDoddkyJErK4vnO7ruSt3EMA7I2kEP/lN9pa9JW7MYo1w=="
     },
     "accepts": {
       "version": "1.3.8",


### PR DESCRIPTION
## [YALB-789 -  image wrapped variations](https://yaleits.atlassian.net/browse/YALB-789)

### Description of work
- Adds image style - `floated` (default) or `offset`
- Adds image alignment - `left` (default) or `right`

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-172--dev-component-library-twig.netlify.app/?path=/story/molecules-wrapped-image--wrapped-image)

### Functional Review Steps
- [ ] Verify you can select/change image style and image alignment
- [ ] Verify the options are themed as they should be (note the token for `--font-spacing-paragraph` doesn't seem to be connecting from the `tokens` repository, but there should be space between the wrapped image component and the `p` element above it. Also, the `no-page-space` class is getting removed in Storybook when you toggle between `left`, `right`, `floated`, `offset`. Hoping it's just isolated to Storybook.). 

![yalb-789](https://user-images.githubusercontent.com/366413/201122280-450e2afb-279e-454e-ba3c-336085ebce00.gif)


### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
