### PR TITLE
fix: update to latest tokens release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6491,9 +6491,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.18.1",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.1/e84ea772a7dd71028b725e740fe1b4064d243577",
-      "integrity": "sha512-gmuqMI8E5gINO3sciXiUk4k4WBNwMux2lea1qY18PwDoddkyJErK4vnO7ruSt3EMA7I2kEP/lN9pa9JW7MYo1w=="
+      "version": "1.18.2",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.2/63b7e40ccf0a78c83b287ef97435b3121b6b89e0",
+      "integrity": "sha512-MLmRcuIC5P06AUt+gc+8/B/tIdz+qMNaOW4dU8042U4vDE3gLJAwKY0rGfkaMKjFTZY3ZnNM904WjaZAr7LfhQ=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -35979,9 +35979,9 @@
       "requires": {}
     },
     "@yalesites-org/tokens": {
-      "version": "1.18.1",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.1/e84ea772a7dd71028b725e740fe1b4064d243577",
-      "integrity": "sha512-gmuqMI8E5gINO3sciXiUk4k4WBNwMux2lea1qY18PwDoddkyJErK4vnO7ruSt3EMA7I2kEP/lN9pa9JW7MYo1w=="
+      "version": "1.18.2",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.2/63b7e40ccf0a78c83b287ef97435b3121b6b89e0",
+      "integrity": "sha512-MLmRcuIC5P06AUt+gc+8/B/tIdz+qMNaOW4dU8042U4vDE3gLJAwKY0rGfkaMKjFTZY3ZnNM904WjaZAr7LfhQ=="
     },
     "accepts": {
       "version": "1.3.8",


### PR DESCRIPTION
### Description of work
- Updates `tokens` package to latest version to pull the line-height updates into the latest release branch
- https://deploy-preview-179--dev-component-library-twig.netlify.app/?path=/story/tokens-typography--body-styles (note the line-height changes are in place)