### PR TITLE
YALB-913: Bug: Search results page

### DIFF
--- a/components/01-atoms/controls/cta/_yds-cta.scss
+++ b/components/01-atoms/controls/cta/_yds-cta.scss
@@ -136,6 +136,10 @@ $cta-outline-weights: (
 
 .cta {
   @include cta;
+
+  .form--inline & {
+    height: 100%;
+  }
 }
 
 // @TODO: Temporary place for this

--- a/components/01-atoms/forms/textfields/_yds-textfields.scss
+++ b/components/01-atoms/forms/textfields/_yds-textfields.scss
@@ -20,10 +20,6 @@ $form-item-icon-size: 1.7rem;
   }
 }
 
-.search-form--page.form--inline {
-  margin-bottom: var(--size-spacing-8);
-}
-
 .form-item__label {
   display: block;
   margin-bottom: var(--size-spacing-1);

--- a/components/01-atoms/forms/textfields/_yds-textfields.scss
+++ b/components/01-atoms/forms/textfields/_yds-textfields.scss
@@ -14,6 +14,14 @@ $form-item-icon-size: 1.7rem;
   margin-bottom: var(--size-spacing-7);
   max-width: $form-item-max-width;
   clear: both;
+
+  .form--inline & {
+    margin-bottom: unset;
+  }
+}
+
+.search-form--page.form--inline {
+  margin-bottom: var(--size-spacing-8);
 }
 
 .form-item__label {
@@ -36,6 +44,10 @@ $form-item-icon-size: 1.7rem;
   padding: var(--size-spacing-4);
   width: 100%;
   max-width: 100%;
+
+  .form--inline & {
+    height: 100%;
+  }
 
   // TODO: change this to token style, when tokens update is merged.
   line-height: 1.4;

--- a/components/02-molecules/search-result/_yds-search-result.scss
+++ b/components/02-molecules/search-result/_yds-search-result.scss
@@ -10,6 +10,7 @@
 .search-form--page {
   display: flex;
   gap: var(--size-spacing-5);
+  margin-bottom: var(--size-spacing-8);
 }
 
 .search-result {


### PR DESCRIPTION
## [YALB-913: Bug: Search results page](https://yaleits.atlassian.net/browse/YALB-913)

### Description of work
- Added padding underneath search page form
- Increases height of text input within search page form
- Before: 
![image](https://user-images.githubusercontent.com/119528620/211667143-81b42178-682e-4f1f-9e6d-8b5b8181755f.png)
- After:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/119528620/211667248-6588825b-97c2-471c-8015-a8e1436913b3.png">
- Companion PR in atomic: https://github.com/yalesites-org/atomic/pull/79

##Design review
- Figma:
<img width="815" alt="image" src="https://user-images.githubusercontent.com/119528620/211669016-b3d4da17-5af9-4cfa-a4f4-337da89cd503.png">
- This branch:
<img width="815" alt="image" src="https://user-images.githubusercontent.com/119528620/211669094-e99e42da-5ad0-4865-b8d6-b384334fbbce.png">
