### PR TITLE
YALB-908 - Bug: Text link style bug for Callout

### DIFF
--- a/components/02-molecules/callout/_yds-callout.scss
+++ b/components/02-molecules/callout/_yds-callout.scss
@@ -84,11 +84,7 @@ $callout-themes: map.deep-get(sass-tokens.$tokens, callout-themes);
   @include tokens.body-default-condensed;
 
   a {
-    color: var(--color-text);
-  }
-
-  a:hover {
-    text-decoration: none;
+    @include atoms.link;
   }
 
   p:last-child {

--- a/components/02-molecules/callout/_yds-callout.scss
+++ b/components/02-molecules/callout/_yds-callout.scss
@@ -83,6 +83,14 @@ $callout-themes: map.deep-get(sass-tokens.$tokens, callout-themes);
 .callout__text {
   @include tokens.body-default-condensed;
 
+  a {
+    color: var(--color-text);
+  }
+
+  a:hover {
+    text-decoration: none;
+  }
+
   p:last-child {
     margin-bottom: 0;
   }

--- a/components/02-molecules/cards/custom-card/_yds-custom-card.scss
+++ b/components/02-molecules/cards/custom-card/_yds-custom-card.scss
@@ -86,6 +86,14 @@
   > *:last-child {
     margin-bottom: 0;
   }
+
+  a {
+    color: var(--color-text);
+  }
+
+  a:hover {
+    text-decoration: none;
+  }
 }
 
 .custom-card__image {

--- a/components/02-molecules/cards/custom-card/_yds-custom-card.scss
+++ b/components/02-molecules/cards/custom-card/_yds-custom-card.scss
@@ -88,11 +88,7 @@
   }
 
   a {
-    color: var(--color-text);
-  }
-
-  a:hover {
-    text-decoration: none;
+    @include atoms.link;
   }
 }
 


### PR DESCRIPTION
## [YALB-908 - Bug: Text link style bug for Callout](https://yaleits.atlassian.net/browse/YALB-908)

### Description of work
- fix: `a` element coloring in callouts/cards
- The scope of this ticket was for callouts, but I figured we might as well do the same for custom cards, just in case :+1: 


### Testing Link(s)
- [ ] This PR includes changes to the callout and card components, but we don't have an example in the component library for `a` elements used inside of `callout` or `card` content. 

### Functional Review Steps
- [ ] To test these changes, you can either test by checking out this branch and using Drupal to add/edit a page node (or test in Storybook, details below), and add a `callout` and `card` component to the content. If you do that, you should see this: 

![yalb-908](https://user-images.githubusercontent.com/366413/211920438-6a0a0b2f-5440-441a-921d-ab58adda372b.gif)

- [ ] You could also test these changes by navigating to: https://deploy-preview-187--dev-component-library-twig.netlify.app/?path=/story/molecules-callout--callout
- [ ] And, using the controls options in Storybook, pasting a link in the `text` content, like this: 
`<p>Designed for those who intend to pursue graduate and those who wish to <a href="https://google.com">immediately enter a career</a> in which broad scientific training is beneficial.</p>`
- [ ] Then you could do the same for the `custom-card`: https://deploy-preview-187--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--custom-card 
![yalb-908-hover-storybook](https://user-images.githubusercontent.com/366413/211929851-7ce332dc-f7ac-4344-b8b0-ce5e1b0a7ff3.gif)


