### PR TITLE
YALB-888: Feedback: Update Footer links

### DIFF
--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -73,6 +73,11 @@ $site-footer-border-thickness: map.deep-get(tokens.$tokens, border, thickness);
   }
 }
 
+.site-footer__site-branding {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
 .site-footer__meta {
   @include typography.body-xs;
 

--- a/components/03-organisms/site-footer/yds-site-footer.twig
+++ b/components/03-organisms/site-footer/yds-site-footer.twig
@@ -26,7 +26,13 @@
       {# Branding #}
       <div {{ bem('branding', [], site_footer__base_class) }}>
         <div {{ bem('logo', [], site_footer__base_class) }}>
-          &#XF2A2;
+          {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+            link__content: '&#XF2A2',
+            link__url: ' http://yale.edu',
+            link__base_class: 'site-branding',
+            link__modifiers: ['primary'],
+            link__blockname: site_footer__base_class,
+          } %}
         </div>
         {% block site_footer__text %}
           {% include "@page-layouts/placeholder/yds-placeholder.twig" with {
@@ -63,7 +69,7 @@
         <span {{ bem('divider', [], site_footer__base_class) }}>|</span>
         {% include "@atoms/controls/text-link/yds-text-link.twig" with {
           link__content: 'Privacy Policy',
-          link__url: "https://www.yale.edu/privacy-policy",
+          link__url: "https://privacy.yale.edu/resources/privacy-statement",
           link__style: 'no-underline',
         } %}
         <span {{ bem('divider', [], site_footer__base_class) }}>|</span>

--- a/components/03-organisms/site-footer/yds-site-footer.twig
+++ b/components/03-organisms/site-footer/yds-site-footer.twig
@@ -28,7 +28,7 @@
         <div {{ bem('logo', [], site_footer__base_class) }}>
           {% include "@atoms/controls/text-link/yds-text-link.twig" with {
             link__content: '&#XF2A2',
-            link__url: ' http://yale.edu',
+            link__url: 'https://yale.edu',
             link__base_class: 'site-branding',
             link__modifiers: ['primary'],
             link__blockname: site_footer__base_class,


### PR DESCRIPTION
## [YALB-888: Feedback: Update Footer links](https://yaleits.atlassian.net/browse/YALB-888)

### Description of work
- Update Privacy Policy link
- Make Yale workmark in the footer as a link

### Testing Link(s)
- [ ] Navigate to the [Site Footer](https://deploy-preview-190--dev-component-library-twig.netlify.app/?path=/story/organisms-site-footer--footer)

### Functional Review Steps
- [ ] Verify the Privacy Policy link goes to https://privacy.yale.edu/resources/privacy-statement
- [ ] Verify the Yale workmark is now a link that goes to https://yale.edu
