### PR TITLE
YALB-945: CSS issue on News & Event page

### DIFF
--- a/components/03-organisms/card-collection/_yds-card-collection.scss
+++ b/components/03-organisms/card-collection/_yds-card-collection.scss
@@ -23,6 +23,10 @@
     @include list.primary;
   }
 
+  [data-collection-type='grid'] & {
+    align-items: flex-start;
+  }
+
   [data-collection-type='grid'][data-collection-featured='true'] & {
     @include grid.primary;
   }


### PR DESCRIPTION
## [YALB-945: CSS issue on News & Event page](https://yaleits.atlassian.net/browse/YALB-945)

### Description of work
- When UI cards weren't equal in size, they would be awkwardly aligned. Adding flex box styling has mended this issue.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI
- [x] Confirm that when News and Events cards are not equal in length in story book (add text with the inspector), the cards are aligned at the top like so: 
![image](https://user-images.githubusercontent.com/119528620/213481225-662308fa-0f8c-4a2d-807b-ad4b82012843.png)
![image](https://user-images.githubusercontent.com/119528620/213481387-e7996dce-b8a6-409d-a360-04fb0a66735d.png)

Before changes:
![image](https://user-images.githubusercontent.com/119528620/213482149-a751ff9d-5fdf-4981-9b1d-1092cb17dad6.png)

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
