### PR TITLE
YALB-461 - Link: Focus indicator in Firefox

### DIFF
--- a/components/01-atoms/controls/button/_yds-button.scss
+++ b/components/01-atoms/controls/button/_yds-button.scss
@@ -1,3 +1,5 @@
+@use '../../../00-tokens/tokens';
+
 // This reset mixin is used to remove browser default styles for button
 // elements that shouldn't look like a traditional "button".
 @mixin reset {
@@ -5,4 +7,10 @@
   background: transparent;
   padding: 0;
   color: inherit;
+}
+
+// In FireFox, button:focus-visible is picking up the normalize.css styles
+// and making outlines dotted. This makes sure it uses our styles.
+button:focus-visible {
+  @include tokens.focus-styles;
 }


### PR DESCRIPTION
## [YALB-461 - Link: Focus indicator in Firefox](https://yaleits.atlassian.net/browse/YALB-461)

### Description of work
- fix: focus-visible button styles

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-194--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-primary-nav--primary-nav)

### Functional Review Steps
- [ ] Observe the issue: using Firefox, use `tab` keyboard navigation on this page: https://yalesites-org.github.io/component-library-twig/?path=/story/organisms-menu-primary-nav--primary-nav
- [ ] Verify that you see the following issue (gray dotted border on `:focus-visible`): 
 
![yalb-461-issue](https://user-images.githubusercontent.com/366413/213532043-6f596c7b-0209-4e8e-8e76-f8867247c171.gif)

- [ ] Observe the fix: using Firefox, use `tab` keyboard navigation on this page: https://deploy-preview-194--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-primary-nav--primary-nav
- [ ] Verify that you see the following: 

![yalb-461-solution](https://user-images.githubusercontent.com/366413/213532169-2a0a7ba8-2a1e-4f1f-ad75-e327d9a2c5c1.gif)

