### PR TITLE
YALB-844: Capture "bottom-only" shadow as token

### DIFF
--- a/components/00-tokens/effects/cl-effects.scss
+++ b/components/00-tokens/effects/cl-effects.scss
@@ -1,7 +1,8 @@
 @use '~@yalesites-org/tokens/build/scss/tokens.scss' as break;
 
 $effects-gap: var(--size-spacing-6);
-$shadow-levels: 'level-1', 'level-2', 'level-3', 'level-4';
+$shadow-levels: 'level-1', 'level-1-bottom-shadow-only', 'level-2', 'level-3',
+  'level-4';
 
 .cl-shadows__list,
 .cl-radii__list,
@@ -22,14 +23,19 @@ $shadow-levels: 'level-1', 'level-2', 'level-3', 'level-4';
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-align: center;
 
   @media (min-width: break.$break-l) {
-    flex-basis: 10%;
+    flex-basis: 20%;
   }
 }
 
 .cl-shadows__item {
   @include cl-list-item;
+
+  &:last-child {
+    max-width: 20%;
+  }
 
   @each $level in $shadow-levels {
     &[data-shadow-level='#{$level}'] {

--- a/components/00-tokens/effects/effects.stories.js
+++ b/components/00-tokens/effects/effects.stories.js
@@ -17,7 +17,7 @@ export default {
 
 export const Shadows = () => `
   <h2>Shadows should only be used as hover or interaction effect</h2>
-  <p>The four levels are displayed below. Hover over each box to see the shadow effect.</p>
+  <p>The five levels are displayed below. Hover over each box to see the shadow effect.</p>
   ${shadowsTwig(shadowsData)}
 `;
 

--- a/components/00-tokens/effects/shadows.twig
+++ b/components/00-tokens/effects/shadows.twig
@@ -4,10 +4,17 @@
 <div {{ bem(shadows__base_class) }}>
   <ul {{ bem('list', [], shadows__base_class) }}>
   {% for shadow, value in _context.shadows %}
-    {% set variable = prefix ~ shadow|lower|replace({' ': '-'}) %}
+
+    {% set tempShadowVariable = shadow|lower|replace({' ': '-'}) %}
+
+    {# For those variables with names in this way: "Level Number - Variant" #}
+    {% set shadowVariable = tempShadowVariable|replace({'---': '-'}) %}
+
+    {% set variable =  prefix ~ shadowVariable %}
+
     {% set shadow_item__attributes = {
       class: bem("item", [], shadows__base_class),
-      'data-shadow-level': shadow|lower|replace({' ': '-'}),
+      'data-shadow-level': shadowVariable,
       'data-component-theme': 'blue-yale',
     } %}
       <li {{ add_attributes(shadow_item__attributes) }}>

--- a/components/02-molecules/search-result/_yds-search-result.scss
+++ b/components/02-molecules/search-result/_yds-search-result.scss
@@ -23,13 +23,7 @@
   }
 
   &:hover {
-    // @TODO: Temporary styles until we create a token
-    // This shadow is hard coded because it has to be adjusted to make it
-    // appear as though it's a shadow on only the border-bottom element.
-    // There isn't currently anything else that looks like this. If there ever
-    // Is, perhaps it should be captured as a token in a new drop-shadow set.
-    // @LINK: https://yaleits.atlassian.net/browse/YALB-844.
-    box-shadow: 0 8px 6px -6px hsl(0deg 0% 0% / 16%);
+    box-shadow: var(--drop-shadow-level-1-bottom-shadow-only);
   }
 }
 

--- a/components/03-organisms/_list-mixins.scss
+++ b/components/03-organisms/_list-mixins.scss
@@ -17,13 +17,7 @@
     border-bottom: var(--border-thickness-1) solid var(--color-divider-subtle);
 
     &:hover {
-      // @TODO: Temporary styles until we create a token
-      // This shadow is hard coded because it has to be adjusted to make it
-      // appear as though it's a shadow on only the border-bottom element.
-      // There isn't currently anything else that looks like this. If there ever
-      // Is, perhaps it should be captured as a token in a new drop-shadow set.
-      // @LINK: https://yaleits.atlassian.net/browse/YALB-844.
-      box-shadow: 0 8px 6px -6px hsl(0deg 0% 0% / 16%);
+      box-shadow: var(--drop-shadow-level-1-bottom-shadow-only);
     }
   }
 }

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -166,14 +166,7 @@ $menu-sub-max-width: 19rem;
     [data-menu-variation='basic'] & {
       @media (min-width: tokens.$break-mobile) {
         column-count: 1;
-
-        // @TODO: Temporary styles until we create a token
-        // This shadow is hard coded because it has to be adjusted to make it
-        // appear as though it's a shadow on only the border-bottom element.
-        // There isn't currently anything else that looks like this. If there ever
-        // Is, perhaps it should be captured as a token in a new drop-shadow set.
-        // @LINK: https://yaleits.atlassian.net/browse/YALB-844.
-        box-shadow: 0 8px 6px -6px hsl(0deg 0% 0% / 16%);
+        box-shadow: var(--drop-shadow-level-1-bottom-shadow-only);
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6491,9 +6491,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.18.2",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.2/63b7e40ccf0a78c83b287ef97435b3121b6b89e0",
-      "integrity": "sha512-MLmRcuIC5P06AUt+gc+8/B/tIdz+qMNaOW4dU8042U4vDE3gLJAwKY0rGfkaMKjFTZY3ZnNM904WjaZAr7LfhQ=="
+      "version": "1.19.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.19.0/4373c19fd524b440a2dc1654f0b6c17b802fbfef",
+      "integrity": "sha512-5NNpWgIM2SCc55JjFLgOk/IuTYyPThPa78yN2H01ltk+t2fTCfF6oXxBZH4zyCvvZdS3Q56EN93ObTks2XINRA=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -35979,9 +35979,9 @@
       "requires": {}
     },
     "@yalesites-org/tokens": {
-      "version": "1.18.2",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.18.2/63b7e40ccf0a78c83b287ef97435b3121b6b89e0",
-      "integrity": "sha512-MLmRcuIC5P06AUt+gc+8/B/tIdz+qMNaOW4dU8042U4vDE3gLJAwKY0rGfkaMKjFTZY3ZnNM904WjaZAr7LfhQ=="
+      "version": "1.19.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.19.0/4373c19fd524b440a2dc1654f0b6c17b802fbfef",
+      "integrity": "sha512-5NNpWgIM2SCc55JjFLgOk/IuTYyPThPa78yN2H01ltk+t2fTCfF6oXxBZH4zyCvvZdS3Q56EN93ObTks2XINRA=="
     },
     "accepts": {
       "version": "1.3.8",


### PR DESCRIPTION
## [YALB-844: Capture "bottom-only" shadow as token](https://yaleits.atlassian.net/browse/YALB-844)

### Description of work
- Adds a token for the bottom-only shadow
- Replaces custom box-shadow with the new token for bottom-only shadow in some components

### Testing Link(s)
- [x] Navigate to the [Effects/Shadow](https://deploy-preview-196--dev-component-library-twig.netlify.app/?path=/story/tokens-effects--shadows)
- [x] Navigate to the [Primary Nav](https://deploy-preview-196--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-primary-nav--primary-nav)
- [x] Navigate to the [Search Result](https://deploy-preview-196--dev-component-library-twig.netlify.app/?path=/story/molecules-search-result--search-result)


### Functional Review Steps
- [x] Verify there is a new card in Effects/Shadows for the 'Level 1 - Bottom Shadow Only' with the correct values
- [x] For the other components, verify the new token is being used instead of the custom box-shadow
