### PR TITLE
YALB 968: Bug - Search form style

### DIFF
--- a/components/03-organisms/menu/utility-nav/yds-utility-nav.twig
+++ b/components/03-organisms/menu/utility-nav/yds-utility-nav.twig
@@ -8,7 +8,7 @@
   {# Search #}
   {% if utility_nav__search %}
     <div {{ bem('search', [], utility_nav__base_class) }}>
-      <form action="/search" method="get" id="header-search-form" accept-charset="UTF-8">
+      <form action="/search" class="form--inline" method="get" id="header-search-form" accept-charset="UTF-8">
         <div class="form-item form-item-keywords">
           <label for="edit-keywords--header-search-form">
             {% include "@atoms/images/icons/_yds-icon.twig" with {


### PR DESCRIPTION
## [YALB-968: Bug - Search form style](https://yaleits.atlassian.net/browse/YALB-968)

### Description of work
- Removes margin bottom from search input in utility nav component, fixing gross spacing and styling

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-968--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Confirm that the bottom margin is gone and the component is no longer silly looking

before:
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/119528620/216124790-c48975fc-9d12-4dcd-b02a-b83a4b5c22bd.png">

after:
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/119528620/216124831-a9519832-ad0f-49da-a710-9c89d700433a.png">

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
