### PR TITLE
YALB-974 - Breadcrumb: Home link broken

### DIFF
--- a/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
+++ b/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
@@ -74,6 +74,7 @@
       opacity: 1;
     }
 
+    [data-scroll-indicator='none'],
     [data-scroll-indicator='right'] & {
       @include tokens.animate-hidden;
     }
@@ -88,6 +89,7 @@
       opacity: 1;
     }
 
+    [data-scroll-indicator='none'] &,
     [data-scroll-indicator='left'] & {
       @include tokens.animate-hidden;
     }
@@ -169,5 +171,9 @@
     color: var(--color-basic-brown-gray);
     font-weight: var(--font-weights-mallory-book);
     cursor: default;
+  }
+
+  [data-scroll-indicator='none'] & {
+    z-index: 1;
   }
 }

--- a/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
+++ b/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
@@ -68,10 +68,12 @@
 
   &--left {
     left: 0;
+    z-index: -1;
 
     [data-scroll-indicator='left'] &,
     [data-scroll-indicator='both'] & {
       opacity: 1;
+      z-index: 0;
     }
 
     [data-scroll-indicator='none'],
@@ -83,10 +85,12 @@
   &--right {
     right: 0;
     transform: rotate(-180deg);
+    z-index: -1;
 
     [data-scroll-indicator='right'] &,
     [data-scroll-indicator='both'] & {
       opacity: 1;
+      z-index: 0;
     }
 
     [data-scroll-indicator='none'] &,
@@ -171,9 +175,5 @@
     color: var(--color-basic-brown-gray);
     font-weight: var(--font-weights-mallory-book);
     cursor: default;
-  }
-
-  [data-scroll-indicator='none'] & {
-    z-index: 1;
   }
 }


### PR DESCRIPTION
## [YALB-974 - Breadcrumb: Home link broken](https://yaleits.atlassian.net/jira/software/projects/YALB/boards/368?selectedIssue=YALB-974)

### Description of work
- fix(yalb-974): animate-hidden and z-index on breadcrumbs navigational arrow buttons if [data-scroll-indicator='none']

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-204--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-breadcrumbs--breadcrumbs)

### Functional Review Steps
- [ ] Checkout this branch locally
- [ ] in the root run `npm run local:cl-dev`
- [ ] When it finishes, clear cache
- [ ] In Drupal, navigate to a page like: https://yalesites-platform.lndo.site/standard-page-one/child-page
  - [ ] Verify you can hover/click the `home` link
  
![yalb-974-drupal](https://user-images.githubusercontent.com/366413/217106122-b9876a86-b76d-4b30-b88a-472c16ec80c6.gif)
