### PR TITLE
YALB-933: Menu: Active trail styles

### DIFF
--- a/components/02-molecules/menu/_yds-menu-item.twig
+++ b/components/02-molecules/menu/_yds-menu-item.twig
@@ -12,7 +12,7 @@
 {% set link__attributes = link__attributes|default({}) %}
 
 {# Item Modifiers #}
-{% if item.in_active_trail == TRUE %}
+{% if item.is_active == TRUE %}
   {% set item__modifiers = item__modifiers|merge(['active']) %}
 {% endif %}
 {% if item.below %}

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -6,6 +6,8 @@
   --color-muted: var(--color-gray-600);
   --color-navigation-border: var(--color-blue-yale);
   --color-navigation-expanded-item: var(--color-basic-brown-gray);
+  --color-navigation-active-item-link-background: var(--color-blue-light);
+  --color-navigation-active-item-link-opacity: 0.1;
 }
 
 $menu-sub-max-width: 19rem;
@@ -14,6 +16,8 @@ $menu-sub-max-width: 19rem;
   --color-muted: var(--color-gray-300);
   --color-navigation-border: var(--color-gray-300);
   --color-navigation-expanded-item: var(--color-gray-300);
+  --color-navigation-active-item-link-background: var(--color-blue-medium);
+  --color-navigation-active-item-link-opacity: 0.13;
 }
 
 @mixin primary-nav-item-level-0 {
@@ -258,8 +262,9 @@ $menu-sub-max-width: 19rem;
     margin-bottom: var(--size-spacing-3);
 
     [data-menu-variation='basic'] & {
-      padding: var(--size-spacing-2) var(--size-spacing-6) var(--size-spacing-4);
+      padding: var(--size-spacing-5) var(--size-spacing-6) var(--size-spacing-4);
       position: relative;
+      margin-bottom: var(--size-spacing-0);
 
       // basic menu items have a bottom border
       &::after {
@@ -274,7 +279,8 @@ $menu-sub-max-width: 19rem;
     }
 
     [data-menu-variation='mega'] & {
-      padding: var(--size-spacing-2) var(--size-spacing-5);
+      padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
+        calc(var(--size-spacing-2) + var(--size-spacing-1));
     }
 
     :last-child > & {
@@ -294,7 +300,35 @@ $menu-sub-max-width: 19rem;
   &--level-2 {
     font: var(--font-style-nav-primary-2);
     color: var(--color-muted);
-    padding: var(--size-spacing-1) var(--size-spacing-5);
+    padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
+      calc(var(--size-spacing-2) + var(--size-spacing-1));
+  }
+}
+
+// Active trail styles.
+.primary-nav__link.primary-nav__link--active {
+  color: var(--menu-link-color);
+}
+
+.primary-nav__link:not(.primary-nav__link--level-0).primary-nav__link--active {
+  position: relative;
+  border-left: var(--border-thickness-4) solid var(--color-navigation-border);
+
+  &::before {
+    content: ' ';
+    display: block;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    opacity: var(--color-navigation-active-item-link-opacity);
+    background-color: var(--color-navigation-active-item-link-background);
+  }
+
+  @media (max-width: tokens.$break-mobile-max) {
+    // prettier-ignore
+    border-left: var(--border-thickness-2) solid var(--color-navigation-border);
   }
 }
 

--- a/components/03-organisms/menu/primary-nav/primary-nav.yml
+++ b/components/03-organisms/menu/primary-nav/primary-nav.yml
@@ -13,7 +13,7 @@ items:
         below:
           - title: 'Combating Racism'
             url: '#'
-            is_active: true
+            in_active_trail: true
           - title: 'Changing Faces of YDS'
             url: '#'
       - title: 'Strategic Plan'
@@ -33,6 +33,7 @@ items:
         url: '#'
       - title: 'Staff Directory'
         url: '#'
+        in_active_trail: true
       - title: 'Mission & History'
         url: '#'
         below:
@@ -48,6 +49,7 @@ items:
         url: '#'
   - title: 'Academics'
     url: '#'
+    in_active_trail: true
   - title: 'Admission & Aid'
     url: '#'
     below:

--- a/components/03-organisms/menu/primary-nav/primary-nav.yml
+++ b/components/03-organisms/menu/primary-nav/primary-nav.yml
@@ -13,7 +13,7 @@ items:
         below:
           - title: 'Combating Racism'
             url: '#'
-            in_active_trail: true
+            is_active: true
           - title: 'Changing Faces of YDS'
             url: '#'
       - title: 'Strategic Plan'
@@ -33,7 +33,7 @@ items:
         url: '#'
       - title: 'Staff Directory'
         url: '#'
-        in_active_trail: true
+        is_active: true
       - title: 'Mission & History'
         url: '#'
         below:
@@ -49,7 +49,7 @@ items:
         url: '#'
   - title: 'Academics'
     url: '#'
-    in_active_trail: true
+    is_active: true
   - title: 'Admission & Aid'
     url: '#'
     below:


### PR DESCRIPTION
## [YALB-933: Menu: Active trail styles](https://yaleits.atlassian.net/browse/YALB-933)

### Description of work
- Add styles for menu links to indicate the active menu trail. 

### Functional Review Steps
- [x] Navigate to the [Primary Nav](https://deploy-preview-211--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-primary-nav--primary-nav)
- [x] There is an active sub-item for the first item in the menu. Also, the second menu item is active too (just to show it should look when a menu item is active and doesnt have subitems)
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/G4sJ0BLu4jCJpGzW82JHE8/YaleSites-Components?node-id=7454%3A22634&t=zhrHhcJnEv2ZXKI0-0)
- [ ] To test in the site, you sould run in your local `npm run local:review-with-cl-branch yalb-933--menu-active-trail-styles` from the `[yalesites-project](https://github.com/yalesites-org/yalesites-project) repo` (check you have the latest changes from atomic)
- [ ] Visit a page from the menu, and confirm there active trail styles
