### PR TITLE
YALB-1052: Feedback: H1 spacing

### DIFF
--- a/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
+++ b/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
@@ -6,7 +6,6 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin-bottom: var(--size-spacing-7);
 
   [data-embedded-components] & {
     margin-bottom: 0;

--- a/components/04-page-layouts/page-layouts.scss
+++ b/components/04-page-layouts/page-layouts.scss
@@ -28,7 +28,13 @@ body[data-body-frozen] {
 }
 
 .main-content .page-title {
-  margin-top: var(--size-spacing-7); // 2rem
+  margin-top: var(--size-spacing-10); // 4rem
+}
+
+// Subtract 2rem to the 4rem to have a negative number so that the margin-top of
+// the page title does not affect the spacing when there are breadcrumbs.
+.main-content .breadcrumbs__wrapper {
+  margin-bottom: calc(var(--size-spacing-7) - var(--size-spacing-10));
 }
 
 // The last item inside the `.main-content` area should have some space between

--- a/components/04-page-layouts/page-layouts.scss
+++ b/components/04-page-layouts/page-layouts.scss
@@ -27,6 +27,10 @@ body[data-body-frozen] {
   margin-top: var(--main-content-top-margin, var(--size-spacing-6));
 }
 
+.main-content .page-title {
+  margin-top: var(--size-spacing-7); // 2rem
+}
+
 // The last item inside the `.main-content` area should have some space between
 // it and the site footer (size-spacing-12 below) - unless it is designated as
 // `$flush-bottom` above. Then it will have no bottom-margin separating it from

--- a/components/04-page-layouts/page-layouts.scss
+++ b/components/04-page-layouts/page-layouts.scss
@@ -29,12 +29,31 @@ body[data-body-frozen] {
 
 .main-content .page-title {
   margin-top: var(--size-spacing-10); // 4rem
+
+  @media (max-width: tokens.$break-l) {
+    margin-top: var(--size-spacing-8); // 2.5rem large breakpoints
+  }
+
+  @media (max-width: tokens.$break-s) {
+    margin-top: var(--size-spacing-7); // 2rem small breakpoints
+  }
 }
 
-// Subtract 2rem to the 4rem to have a negative number so that the margin-top of
-// the page title does not affect the spacing when there are breadcrumbs.
+// Subtract to have a negative numbers so that the margin-top of the page
+// title does not affect the spacing when there are breadcrumbs.
 .main-content .breadcrumbs__wrapper {
+  // Subtract 2rem to the 4rem
   margin-bottom: calc(var(--size-spacing-7) - var(--size-spacing-10));
+
+  // Subtract 1.5rem to the 2.5rem
+  @media (max-width: tokens.$break-l) {
+    margin-bottom: calc(1.5rem - var(--size-spacing-8));
+  }
+
+  // Subtract 1rem to the 2rem
+  @media (max-width: tokens.$break-s) {
+    margin-bottom: calc(var(--size-spacing-5) - var(--size-spacing-7));
+  }
 }
 
 // The last item inside the `.main-content` area should have some space between

--- a/components/05-page-examples/events/event-page.twig
+++ b/components/05-page-examples/events/event-page.twig
@@ -3,13 +3,15 @@
     {% include "@organisms/site-header/yds-site-header.twig" %}
   {% endblock %}
   {% block page__content %}
-    {% include "@organisms/menu/breadcrumbs/yds-breadcrumbs.twig" with {
-      breadcrumbs__items: [
-        {title: 'Home', url: '#'},
-        {title: 'Events', url: '#'},
-        {title: page_title__heading, url: '#', is_active: true},
-      ],
-    } %}
+    {% if show_breadcrumbs %}
+      {% include "@organisms/menu/breadcrumbs/yds-breadcrumbs.twig" with {
+        breadcrumbs__items: [
+          {title: 'Home', url: '#'},
+          {title: 'Events', url: '#'},
+          {title: page_title__heading, url: '#', is_active: true},
+        ],
+      } %}
+    {% endif %}
     {% embed "@molecules/page-title/yds-page-title.twig" %}
       {% block page_title__meta %}
         {% include "@molecules/meta/event-meta/yds-event-meta.twig" %}

--- a/components/05-page-examples/events/events.stories.js
+++ b/components/05-page-examples/events/events.stories.js
@@ -34,6 +34,11 @@ export default {
       defaultValue:
         'Parlika (2016) film screening + Q&A with film director Sahraa Karimi',
     },
+    showBreadcrumbs: {
+      name: 'Breadcrumbs',
+      type: 'boolean',
+      defaultValue: true,
+    },
   },
 };
 
@@ -57,6 +62,7 @@ export const EventPage = ({
   format,
   address,
   ctaText,
+  showBreadcrumbs,
 }) =>
   eventPageTwig({
     site_name: siteName,
@@ -83,6 +89,7 @@ export const EventPage = ({
     event_meta__cta_secondary__content: 'Add to calendar',
     event_meta__cta_secondary__href: '#',
     ...socialLinksData,
+    show_breadcrumbs: showBreadcrumbs,
   });
 EventPage.argTypes = {
   pageTitle: {


### PR DESCRIPTION
## [YALB-1053: Feedback: H1 spacing](https://yaleits.atlassian.net/browse/YALB-1052)

### Description of work
- Add more space between heading and header for pages withouth breadcrumbs

### Functional Review Steps in Preview
- [x] Navigate to the [Page Example Story](https://deploy-preview-214--dev-component-library-twig.netlify.app/?path=/story/page-examples-events--event-page) with controls to hide the breadcrumbs
- [x] Confirm the space between the header, breadcrumbs and page title is still the same.
- [x] Hide the breadcrumbs, and confirm there is a space of `2rem` between the header and the heading.

### Functional Review Steps in Local
- [x] To test this for pages without breadcrumbs, in your local run `npm run local:review-with-cl-branch YALB-1052--h1-spacing-fix` to review with the changes from this branch
- [x] Visit the site and go to any page without breadcrumbs. For example: https://yalesites-platform.lndo.site/faqs
- [x] Confirm there is a space of `2rem` between the header and the heading.
- [x] Now visit a page with breadcrumbs, for example: https://yalesites-platform.lndo.site/top-goal-site/asdasdasd
- [x] And confirm the space still looks good

