### PR TITLE
YALB-1051: Accordion spacing

### DIFF
--- a/components/02-molecules/text/yds-text-field.twig
+++ b/components/02-molecules/text/yds-text-field.twig
@@ -3,7 +3,7 @@
  # - text_field__content
  #}
 
-{% set text_field__base_class = 'text-field' %}
+{% set text_field__base_class = text_field__base_class|default('text-field') %}
 
 {% set text_field__attributes = {
   'data-component-width': text_field__width|default('site'),


### PR DESCRIPTION
## [YALB-1051: Feedback: Accordion spacing](https://yaleits.atlassian.net/browse/YALB-1051)

### Description of work
- Adds an available variable for `text_field__base_class` in the `yds-text-field.twig` to get it other base class from `paragraph--text.html.twig` of the `Accordion item` to avoid a margin-bottom because of the class `text-field`.

### Functional Review Steps
- [x] To review this, you has to review it with this [Pull Request](https://github.com/yalesites-org/atomic/pull/104) in your local. In the root of the project `yalesites-project` run `npm run local:review-with-atomic-and-cl-branch yalb-1051--fix-acorrdion-spacing yalb-1051--fix-acorrdion-spacing`
- [x] Add an `Accordion` in a Standard Page and confirm the space between the expanded text block and the divider line looks as expected in the [design](https://deploy-preview-213--dev-component-library-twig.netlify.app/iframe.html?id=page-examples-standard-pages--with-banner-left-align&viewMode=story)
