### PR TITLE
YALB-1093: Fix accordion animation

### DIFF
--- a/components/02-molecules/accordion/_yds-accordion.scss
+++ b/components/02-molecules/accordion/_yds-accordion.scss
@@ -98,7 +98,7 @@
 }
 
 .accordion-item__content {
-  @include tokens.animate(max-height, var(--animation-speed-slow));
+  @include tokens.animate(all, var(--animation-speed-slow));
 
   max-height: var(--accordion-item-height);
   overflow: hidden;


### PR DESCRIPTION
## [YALB-1093: Accordion animation not smooth](https://yaleits.atlassian.net/browse/YALB-1093)

### Description of work
- Fixes the property animation for accordion, instead of take in count the `max-weight` property in the trasition, it uses all. The animation was looking good when there were a lot of information in the accordion content, but when the content was short, the animation didn't look smooth, so this fixes.

### Functional Review Steps
- [x] To review this, you will need to run in your local `npm run local:review-with-cl-branch yalb-1093--fix-accordion-animitaion-to-make-it-smooth`
- [x] Visit a page with an `Accordion` or add an `Accordion` in a page, similar to the one in this [page](https://dev-yalesites-platform.pantheonsite.io/example-page-long-title-wraps-another-line/collections)
- [x] Try to add items with a lot of content and other items with little content, for example: `<p><strong>SHIH-HUI CHEN:</strong>&nbsp;This award was established by the C. F. Peters Corporation, music publishers, in 1984, and is given for the publication of a work by a gifted composer.</p>`
- [x] Confirm the accordion animation looks smooth as expected. There should not be like a jump or something when the item is being collapsed and the content is short. For example: In this [page](https://dev-yalesites-platform.pantheonsite.io/example-page-long-title-wraps-another-line/collections) there's like a tiny jump when collapsing the item, this should not happen anymore.

**** Note: There is a lot of space than expecting between the content and the border, but this is fixed in another PR.
