### PR TITLE
YALB-1095: Add darker background for media gallery

### DIFF
--- a/components/03-organisms/galleries/media-grid/yds-media-grid.twig
+++ b/components/03-organisms/galleries/media-grid/yds-media-grid.twig
@@ -40,7 +40,7 @@
     </ul>
   </div>
   {% if media_grid__variation == 'interactive' %}
-    <div {{ bem('modal', [], media_grid__base_class) }} data-component-theme="gray-700">
+    <div {{ bem('modal', [], media_grid__base_class) }} data-component-theme="gray-800">
       {% block media_grid__modal %}
         {% include "@organisms/galleries/media-grid/_yds-media-grid-modal-item.twig" %}
       {% endblock %}


### PR DESCRIPTION
## [YALB-1095: Feedback: Darker background for media gallery](https://yaleits.atlassian.net/browse/YALB-1095)

### Description of work
- Adds darker background for media gallery

### Design Review
- [x] Verify the grey color behind the [Interactive Grid component](https://deploy-preview-217--dev-component-library-twig.netlify.app/?path=/story/organisms-galleries--interactive-grid) is darker than it was [before](https://yalesites-org.github.io/component-library-twig/iframe.html?id=organisms-galleries--interactive-grid&viewMode=story).
