### PR TITLE
fix(YALB-1195): format now displays on string and array

### DIFF
--- a/components/02-molecules/cards/reference-card/event/_yds-event-format.twig
+++ b/components/02-molecules/cards/reference-card/event/_yds-event-format.twig
@@ -1,5 +1,5 @@
 {% if format.1 -%}
   Hybrid
 {%- else %}
-  {{ format }}
+  {{ format.0|default(format) }}
 {% endif %}

--- a/components/02-molecules/meta/event-meta/yds-event-meta.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta.twig
@@ -40,7 +40,7 @@
       {% if event_meta__format.0 or event_meta__address %}
         <div {{ bem('location', [], event_meta__base_class) }}>
           {# Format #}
-          {% if event_meta__format.0 %}
+          {% if event_meta__format.0 or event_meta__format %}
             <p {{ bem('format', [], event_meta__base_class) }}>
               {% include "@molecules/cards/reference-card/event/_yds-event-format.twig" with {
                 format: event_meta__format,


### PR DESCRIPTION
## [YALB-1195: Events: Add to calendar link (BE)](https://yaleits.atlassian.net/browse/YALB-1195)

This PR has linked future PRs for atomic and yalesites-project.

The component was not rendering the format unless it was an array type, although other pieces like storybook had a default that was a string type. This change allows it to reference the 0th element if it's a single element array, or the string text if it was passed.

My only question is: was this not done because an empty string is truthy? So if they pass an empty string, would it think there was a format and display it?

### Description of work
- Allows format check to pass an array or string to allow default storybook value to show
- Allows fallback in format if array doesn't exist to string representation

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-237--dev-component-library-twig.netlify.app/?path=/story/molecules-meta--event)

### Functional Review Steps
- [ ] Verify that "In-Person" is displayed on the component
- [ ] Change the control for format from only "In-Person" to both "In-Person" and "Online"
- [ ] Verify that the display now says "Hybrid"
- [ ] Change the control for format from both "In-Person" and "Online" to only "Online"
- [ ] Verify that the display now says "Online"
- [ ] Change the control for format from "Online" to "In-Person"
- [ ] Verify that the display now says "In-Person"

### Design Review
- No design changes have been made

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements