### PR TITLE
YALB-1163 - Create Button Link component

### DIFF
--- a/components/01-atoms/controls/cta/yds-cta.twig
+++ b/components/01-atoms/controls/cta/yds-cta.twig
@@ -36,4 +36,5 @@
   control__attributes: cta__attributes,
   control__url: cta__href,
   control__content: cta__content,
+  control__element: cta__element,
 } %}

--- a/components/01-atoms/videos/video-background/yds-video-background.scss
+++ b/components/01-atoms/videos/video-background/yds-video-background.scss
@@ -104,7 +104,7 @@ $break-video-banner-max: $break-video-banner - 0.05;
     height: 100%;
     width: 100%;
     background-color: var(--color-video-background);
-    opacity: 0.6;
+    opacity: 0.85;
     z-index: -1;
   }
 

--- a/components/01-atoms/videos/video-background/yds-video-background.scss
+++ b/components/01-atoms/videos/video-background/yds-video-background.scss
@@ -16,6 +16,8 @@ $break-video-banner-max: $break-video-banner - 0.05;
   video {
     display: block;
     width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 
   // Component themes defaults: iterate over each component theme to establish

--- a/components/01-atoms/videos/video-background/yds-video-background.scss
+++ b/components/01-atoms/videos/video-background/yds-video-background.scss
@@ -1,5 +1,8 @@
 @use '../../../00-tokens/tokens';
+@use '../../../00-tokens/functions/map';
 
+$global-video-bg-themes: map.deep-get(tokens.$tokens, 'global-themes');
+$component-video-bg-themes: map.deep-get(tokens.$tokens, 'component-themes');
 $video-background-icon-size: 2rem;
 $video-background-icon-size-sm: 1.4rem;
 $break-video-banner: tokens.$break-m;
@@ -13,6 +16,44 @@ $break-video-banner-max: $break-video-banner - 0.05;
   video {
     display: block;
     width: 100%;
+  }
+
+  // Component themes defaults: iterate over each component theme to establish
+  // default variables.
+  @each $theme, $value in $component-video-bg-themes {
+    &[data-component-theme='#{$theme}'] {
+      --color-backgound: var(--color-video-background);
+    }
+  }
+
+  // Global themes: set color slots for each theme
+  // This establishes `--color-slot-` variables name-spaced to the selector
+  // in which it is used. We can map component-level variables to global-level
+  // `--color-slot-` variables.
+  @each $globalTheme, $value in $global-video-bg-themes {
+    [data-global-theme='#{$globalTheme}'] & {
+      --color-slot-one: var(--global-themes-#{$globalTheme}-colors-slot-one);
+      --color-slot-two: var(--global-themes-#{$globalTheme}-colors-slot-two);
+      --color-slot-three: var(
+        --global-themes-#{$globalTheme}-colors-slot-three
+      );
+      --color-slot-four: var(--global-themes-#{$globalTheme}-colors-slot-four);
+      --color-slot-five: var(--global-themes-#{$globalTheme}-colors-slot-five);
+    }
+  }
+
+  // Component theme overrides: set specific component themes overrides
+  /// define component name spaced variables and map them to global theme slots.
+  &[data-component-theme='one'] {
+    --color-video-background: var(--color-slot-one);
+  }
+
+  &[data-component-theme='two'] {
+    --color-video-background: var(--color-slot-four);
+  }
+
+  &[data-component-theme='three'] {
+    --color-video-background: var(--color-slot-five);
   }
 }
 
@@ -62,7 +103,7 @@ $break-video-banner-max: $break-video-banner - 0.05;
     left: 0;
     height: 100%;
     width: 100%;
-    background-color: var(--color-background);
+    background-color: var(--color-video-background);
     opacity: 0.6;
     z-index: -1;
   }

--- a/components/01-atoms/videos/video-background/yds-video-background.scss
+++ b/components/01-atoms/videos/video-background/yds-video-background.scss
@@ -23,6 +23,7 @@ $break-video-banner-max: $break-video-banner - 0.05;
   @each $theme, $value in $component-video-bg-themes {
     &[data-component-theme='#{$theme}'] {
       --color-backgound: var(--color-video-background);
+      --color-video-svg: var(--color-basic-white);
     }
   }
 
@@ -46,14 +47,17 @@ $break-video-banner-max: $break-video-banner - 0.05;
   /// define component name spaced variables and map them to global theme slots.
   &[data-component-theme='one'] {
     --color-video-background: var(--color-slot-one);
+    --color-video-svg: var(--color-basic-white);
   }
 
   &[data-component-theme='two'] {
     --color-video-background: var(--color-slot-four);
+    --color-video-svg: var(--color-gray-800);
   }
 
   &[data-component-theme='three'] {
     --color-video-background: var(--color-slot-five);
+    --color-video-svg: var(--color-basic-white);
   }
 }
 
@@ -82,7 +86,7 @@ $break-video-banner-max: $break-video-banner - 0.05;
   }
 
   svg {
-    fill: var(--color-basic-white);
+    fill: var(--color-video-svg);
     width: $video-background-icon-size-sm;
     height: $video-background-icon-size-sm;
 

--- a/components/01-atoms/videos/video-background/yds-video-background.twig
+++ b/components/01-atoms/videos/video-background/yds-video-background.twig
@@ -10,7 +10,7 @@
 #}
 
 {% set video_background__base_class = video_background__base_class|default('video-background') %}
-{% set video_background__button__background_color = video_background__button__background_color|default('gray-800') %}
+{% set video_background__button__background_color = video_background__button__background_color|default('one') %}
 
 <div {{ bem(video_background__base_class, video_background__modifiers, video_background__blockname) }} data-component-theme={{ video_background__button__background_color }}>
   {% block video_background__content %}

--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -243,4 +243,8 @@ $break-grand-hero-banner: tokens.$break-m;
   @include atoms.plain-link;
 
   width: fit-content;
+
+  [data-component-theme] & {
+    --color-link-hover: var(--color-grand-hero-text);
+  }
 }

--- a/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
+++ b/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
@@ -63,13 +63,25 @@ $wrapped-image-max: '1470px';
     // offset
     [data-wrapped-image-style='offset'][data-wrapped-image-alignment='left'] & {
       float: left;
+      margin-right: 5%;
+    }
+
+    [data-wrapped-image-style='offset'][data-wrapped-image-alignment='right']
+      & {
+      float: right;
+      margin-left: 5%;
+    }
+  }
+
+  // offset at min-width 1470px
+  @media (min-width: $wrapped-image-max) {
+    [data-wrapped-image-style='offset'][data-wrapped-image-alignment='left'] & {
       transform: translateX(-20%);
       margin-right: -5%;
     }
 
     [data-wrapped-image-style='offset'][data-wrapped-image-alignment='right']
       & {
-      float: right;
       transform: translateX(20%);
       margin-left: -5%;
     }

--- a/components/03-organisms/component-wrapper/_yds-component-wrapper.scss
+++ b/components/03-organisms/component-wrapper/_yds-component-wrapper.scss
@@ -2,6 +2,10 @@
 
 .component-wrapper {
   @include tokens.spacing-page-section;
+
+  &--no-top-margin {
+    margin-top: 0;
+  }
 }
 
 .component-wrapper__heading {


### PR DESCRIPTION
## [YALB-1163 - Create Button Link component](https://yaleits.atlassian.net/browse/YALB-1163) | [YALB-1146 - Bug: Short grand hero banner is too short](https://yaleits.atlassian.net/browse/YALB-1146)

### Description of work
- YALB-1163 - feat: changes the cta component to enable `control__element` from the control component to be passed through the `cta__element` so that we can use the `a` element in Drupal (`control__element: cta__element, cta__element: 'a'` in Atomic).
- YALB-1146 - fix:  `yds-video-background.twig` changes default theme from `gray-800` to `one` so that the video background play/pause button gets the correct background-color.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/267
- [ ] Verify code changes in this repository are solid

