### PR TITLE
chore(YALB-1042): document percy auto-approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ View the status of any build here: https://percy.io/95144ff9/component-library-t
 
 ### Running Visreg Tests
 
+**NOTE: Percy is temporarily auto-approving all branches for now. (Original was only auto-approving `main`)  This will be reverted once we have a better handle on how to manage the visreg tests.**
+
 Visual regression tests are automatically run on Percy any time a PR is changed from "Draft" state to "Ready for Review". So there are a few things to keep in mind when creating PRs.
 
 - When you initially create a PR that needs visreg tests, click the "Create draft PR" button instead of the "Create Pull Request" button.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ View the status of any build here: https://percy.io/95144ff9/component-library-t
 
 ### Running Visreg Tests
 
-**NOTE: Percy is temporarily auto-approving all branches for now. (Original was only auto-approving `main`)  This will be reverted once we have a better handle on how to manage the visreg tests.**
+**NOTE:** Percy is temporarily auto-approving all branches for now. (Original was only auto-approving `main`)  This will be reverted once we have a better handle on how to manage the visreg tests.
 
 Visual regression tests are automatically run on Percy any time a PR is changed from "Draft" state to "Ready for Review". So there are a few things to keep in mind when creating PRs.
 


### PR DESCRIPTION
## [YALB-1042: DevOps: Disable Percy.io for component library](https://yaleits.atlassian.net/browse/YALB-1042)

Percy was not really being utilized right now, so in an event to keep the workflow for use in the future, changes have been made in the Percy.io site project settings that instead of only auto-approving the `main` branch, we auto-approve all branches.

When reverting this, just change it back to `main`.

### Description of work
- Change Percy.io project settings to auto-approve all branches of component library
- Update documentation to convey to the user that this has been temporarily auto-approved

### Testing Link(s)
- [ ] Create a PR in the same way we always have

### Functional Review Steps
- [ ] Verify that upon creating a PR that VisReg tests pass