### PR TITLE
fix(yalb-1145): update link colors for header and footer

### DIFF
--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -48,6 +48,12 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
       background-color: var(--color-site-footer-background-color);
       color: var(--color-site-footer-text-color);
       border-color: var(--color-site-footer-border-color);
+
+      // set hover for footer links to override the variable from
+      // components/01-atoms/controls/text-link/_yds-text-link.scss
+      .link--footer-link {
+        --color-link-hover: var(--color-text);
+      }
     }
   }
 

--- a/components/03-organisms/site-footer/yds-site-footer.twig
+++ b/components/03-organisms/site-footer/yds-site-footer.twig
@@ -59,12 +59,14 @@
           link__content: 'Accessibility at Yale',
           link__url: "https://usability.yale.edu/web-accessibility/accessibility-yale",
           link__style: 'no-underline',
+          link__modifiers: ['footer-link'],
         } %}
         <span {{ bem('divider', [], site_footer__base_class) }}>|</span>
         {% include "@atoms/controls/text-link/yds-text-link.twig" with {
           link__content: 'Privacy Policy',
           link__url: "https://privacy.yale.edu/resources/privacy-statement",
           link__style: 'no-underline',
+          link__modifiers: ['footer-link'],
         } %}
         <span {{ bem('divider', [], site_footer__base_class) }}>|</span>
         <span>Copyright © {{ 'now'|date('Y') }} Yale University. All rights reserved.</span>

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -54,6 +54,7 @@ $global-site-themes: map.deep-get(tokens.$tokens, 'global-themes');
       --color-heading: var(--color-site-header-text);
       --color-link-base: var(--color-site-header-text);
       --color-link-hover: var(--color-site-header-link-hover);
+      --menu-link-color: var(--color-site-header-link-hover);
       --color-navigation-border: var(--color-site-header-border-color);
       --color-background: var(--color-site-header-background);
 
@@ -85,14 +86,12 @@ $global-site-themes: map.deep-get(tokens.$tokens, 'global-themes');
   &[data-header-theme='one'] {
     --color-site-header-border-color: var(--color-slot-one);
     --color-site-header-background: var(--color-basic-white);
-    --color-site-header-text: var(--color-slot-one);
     --color-site-header-link-hover: var(--color-slot-two);
   }
 
   &[data-header-theme='two'] {
     --color-site-header-border-color: var(--color-slot-three);
     --color-site-header-background: var(--color-gray-100);
-    --color-site-header-text: var(--color-slot-two);
     --color-site-header-link-hover: var(--color-slot-two);
   }
 


### PR DESCRIPTION
## [YALB1145: Levers form: Add icons and custom controls](https://yaleits.atlassian.net/browse/YALB-1145)

### Description of work
- Themes the global theme color palette options
- Themes the component options
- Dynamically reads the currentTheme and applies the currentTheme to the appropriate css styles

### Functional testing steps:
- [ ] Login here: https://pr-273-yalesites-platform.pantheonsite.io
- [ ] After logging in navigate to a page like https://pr-273-yalesites-platform.pantheonsite.io/components and click the "Theme Settings"
- [ ] Change the color palette and observe how the change affects the visual representation of each component lever
