### PR TITLE
YALB-1198: Exposed filters on dynamic list (BE)

### DIFF
--- a/components/01-atoms/forms/_yds-form.scss
+++ b/components/01-atoms/forms/_yds-form.scss
@@ -37,3 +37,18 @@
 .webform-submission-form {
   max-width: 80rem;
 }
+
+// Used for exposed filter forms
+.ys-filter-form {
+  align-items: flex-end;
+  display: flex;
+  gap: 0 1rem;
+
+  .form-item {
+    margin-bottom: 0;
+  }
+
+  .form-select {
+    height: 3.25rem;
+  }
+}

--- a/components/01-atoms/forms/_yds-form.scss
+++ b/components/01-atoms/forms/_yds-form.scss
@@ -50,5 +50,6 @@
 
   .form-select {
     height: 3.25rem;
+    padding: 0 0.5rem;
   }
 }

--- a/components/03-organisms/card-collection/yds-card-collection.twig
+++ b/components/03-organisms/card-collection/yds-card-collection.twig
@@ -30,6 +30,8 @@
         heading: card_collection__heading,
       } %}
     {% endif %}
+    {% block card_collection__filters %}
+    {% endblock %}
     <ul {{ bem('cards', [], card_collection__base_class) }}>
       {% block card_collection__cards %}
         {% for card in card_collection__cards %}


### PR DESCRIPTION
## [YALB-1198: Exposed filters on dynamic list (BE)](https://yaleits.atlassian.net/browse/YALB-1198)

### Description of work
- Adds css for the exposed filter form
- Adds a twig block to the card collection to insert exposed filters, if set.
- Main repo, testing instructions, and multidev here: https://github.com/yalesites-org/yalesites-project/pull/276

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
