### PR TITLE
YALB-1285: fixes utility menu font weights

### DIFF
--- a/components/02-molecules/menu/_yds-menu.scss
+++ b/components/02-molecules/menu/_yds-menu.scss
@@ -13,7 +13,7 @@
 
   color: var(--color-text);
   text-decoration: none;
-  font-weight: var(--font-weights-mallory-medium);
+  font-weight: var(--font-weights-mallory-book);
   letter-spacing: 0.2px;
 
   &:hover {


### PR DESCRIPTION
## [YALB-1285: Bug_Utility Menu Font Weights](https://yaleits.atlassian.net/browse/YALB-1285)

### Description of work
- Adds the same font weight to the utility nav as the primary nav. 

### Testing Link(s)
- [x] Navigate to the [Component Story](https://deploy-preview-248--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-utility-nav--utility-nav)

### Functional Review Steps
- [x] Navigate to the component story link [here](https://deploy-preview-248--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-utility-nav--utility-nav)
- [x] Verify the utility nav uses the same font weight as the primary nav.

### Design Review
- [x] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [x] Verify the component meets Accessibility requirements
<img width="1924" alt="Screenshot 2023-06-06 at 3 49 27 PM" src="https://github.com/yalesites-org/component-library-twig/assets/65790558/e94c139c-66a2-45c4-9e2d-c7db675a8c38">
<img width="1921" alt="Screenshot 2023-06-06 at 3 47 00 PM" src="https://github.com/yalesites-org/component-library-twig/assets/65790558/db40f66b-1d43-48da-bcc2-a39d5bbc497d">
