### PR TITLE
YALB-1277: fixes link styles in image captions

### DIFF
--- a/components/01-atoms/images/image/_yds-image.scss
+++ b/components/01-atoms/images/image/_yds-image.scss
@@ -1,4 +1,5 @@
 @use '../../../00-tokens/tokens';
+@use '../../controls/text-link/yds-text-link' as link;
 
 img,
 picture {
@@ -20,6 +21,13 @@ figure {
 
   > p:last-child {
     margin-bottom: 0;
+  }
+
+  a {
+    @include link.plain-link;
+
+    // Override hover variable, it shouldn't use global-theme slots.
+    --color-link-hover: var(--color-link-base);
   }
 }
 


### PR DESCRIPTION
## [YALB-XX: Title](https://yaleits.atlassian.net/browse/YALB-XX)

### Description of work
- Fixes caption styles for "image" and "wrapped image" components.

### Functional Review Steps
- [ ] create a page content type and add an image block and a wrapped image block.
- [ ] add a link to both blocks and verify they are using the correct link styles.
- [ ] See attached screenshots for hover and no hover styles.


### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
<img width="512" alt="Screenshot 2023-06-09 at 4 03 10 PM" src="https://github.com/yalesites-org/component-library-twig/assets/65790558/0ee9742f-51ba-4577-8402-75626084ed67">
<img width="508" alt="Screenshot 2023-06-09 at 4 03 37 PM" src="https://github.com/yalesites-org/component-library-twig/assets/65790558/7c761c88-1c9e-468c-9938-e9884169f6ee">
