### PR TITLE
YALB 1282: Bug: Heading color in tab content

### DIFF
--- a/components/01-atoms/images/image/_yds-image.scss
+++ b/components/01-atoms/images/image/_yds-image.scss
@@ -1,4 +1,5 @@
 @use '../../../00-tokens/tokens';
+@use '../../controls/text-link/yds-text-link' as link;
 
 img,
 picture {
@@ -20,6 +21,13 @@ figure {
 
   > p:last-child {
     margin-bottom: 0;
+  }
+
+  a {
+    @include link.plain-link;
+
+    // Override hover variable, it shouldn't use global-theme slots.
+    --color-link-hover: var(--color-link-base);
   }
 }
 

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -53,21 +53,18 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
     --color-tabs-accent: var(--color-slot-one);
     --color-tabs-action: var(--color-slot-one);
     --color-tabs-background: var(--color-basic-white);
-    --color-heading: var(--color-gray-700);
   }
 
   &[data-component-theme='two'] {
     --color-tabs-accent: var(--color-slot-two);
     --color-tabs-action: var(--color-slot-two);
     --color-tabs-background: var(--color-basic-white);
-    --color-heading: var(--color-gray-700);
   }
 
   &[data-component-theme='three'] {
     --color-tabs-accent: var(--color-slot-five);
     --color-tabs-action: var(--color-slot-five);
     --color-tabs-background: var(--color-basic-white);
-    --color-heading: var(--color-gray-700);
   }
 }
 

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -53,18 +53,21 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
     --color-tabs-accent: var(--color-slot-one);
     --color-tabs-action: var(--color-slot-one);
     --color-tabs-background: var(--color-basic-white);
+    --color-heading: var(--color-gray-700);
   }
 
   &[data-component-theme='two'] {
     --color-tabs-accent: var(--color-slot-two);
     --color-tabs-action: var(--color-slot-two);
     --color-tabs-background: var(--color-basic-white);
+    --color-heading: var(--color-gray-700);
   }
 
   &[data-component-theme='three'] {
     --color-tabs-accent: var(--color-slot-five);
     --color-tabs-action: var(--color-slot-five);
     --color-tabs-background: var(--color-basic-white);
+    --color-heading: var(--color-gray-700);
   }
 }
 


### PR DESCRIPTION
## [YALB-1282: Bug: Heading color in tab content ](https://yaleits.atlassian.net/browse/YALB-1282)

### Description of work
- fixes the heading color for headings in the content area of the Tabs block.

### Functional Review Steps
- [ ] create a page and add the "Tabs" block to it.
- [ ] Add a Heading to the content area and verify that it displays as the same color as the text.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements

<img width="1457" alt="Screenshot 2023-06-09 at 5 13 58 PM" src="https://github.com/yalesites-org/component-library-twig/assets/65790558/fc4b4f4e-1c36-4573-9eb1-ea7b5efc2e33">
