### PR TITLE
YALB-1277: Fixes animation to link styles

### DIFF
--- a/components/01-atoms/images/image/_yds-image.scss
+++ b/components/01-atoms/images/image/_yds-image.scss
@@ -24,6 +24,7 @@ figure {
   }
 
   a {
+    // @include link.link;
     @include link.plain-link;
 
     // Override hover variable, it shouldn't use global-theme slots.

--- a/components/01-atoms/images/image/_yds-image.scss
+++ b/components/01-atoms/images/image/_yds-image.scss
@@ -28,7 +28,9 @@ figure {
     @include link.plain-link;
 
     // Override hover variable, it shouldn't use global-theme slots.
-    --color-link-hover: var(--color-link-base);
+    &:hover {
+      color: var(--color-gray-800);
+    }
   }
 }
 

--- a/components/01-atoms/images/image/_yds-image.scss
+++ b/components/01-atoms/images/image/_yds-image.scss
@@ -24,7 +24,7 @@ figure {
   }
 
   a {
-    // @include link.link;
+    @include link.link;
     @include link.plain-link;
 
     // Override hover variable, it shouldn't use global-theme slots.

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -53,21 +53,18 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
     --color-tabs-accent: var(--color-slot-one);
     --color-tabs-action: var(--color-slot-one);
     --color-tabs-background: var(--color-basic-white);
-    --color-heading: var(--color-gray-700);
   }
 
   &[data-component-theme='two'] {
     --color-tabs-accent: var(--color-slot-two);
     --color-tabs-action: var(--color-slot-two);
     --color-tabs-background: var(--color-basic-white);
-    --color-heading: var(--color-gray-700);
   }
 
   &[data-component-theme='three'] {
     --color-tabs-accent: var(--color-slot-five);
     --color-tabs-action: var(--color-slot-five);
     --color-tabs-background: var(--color-basic-white);
-    --color-heading: var(--color-gray-700);
   }
 }
 


### PR DESCRIPTION
## [YALB-1277: Bug: Link styles in captions](https://yaleits.atlassian.net/browse/YALB-1277)

### Description of work
- adds the underline animation to the caption links for image and wrapped image blocks.

### Functional Review Steps
- [ ] create a new page and add image/wrapped image blocks with links in the captions.
- [ ] Verify links have underline animation.
- [ ] May have to check allow restricted HML for wrapped images. structure/block layout/block types/wrapped images/manage fields/field_captions/edit.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
