### PR TITLE
YALB-1280: Bug: Media gallery link hover style

### DIFF
--- a/components/03-organisms/galleries/media-grid/_yds-media-grid-modal.scss
+++ b/components/03-organisms/galleries/media-grid/_yds-media-grid-modal.scss
@@ -177,6 +177,10 @@ $modal-speed: var(--animation-speed-slow);
 
   a {
     @include atoms.plain-link;
+
+    &:hover {
+      color: var(--color-gray-300);
+    }
   }
 }
 


### PR DESCRIPTION
## [YALB-1280: Bug: Media gallery link hover style](https://yaleits.atlassian.net/browse/YALB-1280)

### Description of work
- Fixes the link hover style for media gallery to display as a shade of gray in Drupal.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/organisms-galleries--interactive-grid)

### Functional Review Steps
- [ ] Create a new page and add the Media Gallery block with a link.
- [ ] Verify the link turns gray when hovered over.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements

<img width="1463" alt="Screenshot 2023-06-16 at 4 10 14 PM" src="https://github.com/yalesites-org/component-library-twig/assets/65790558/0eb2201c-9cde-4346-97d7-daea6bf3e9e8">
<img width="1465" alt="Screenshot 2023-06-16 at 4 10 43 PM" src="https://github.com/yalesites-org/component-library-twig/assets/65790558/690c02ba-c6dd-4094-8e2e-585a9a3eec91">
