### PR TITLE
YALB-1364 - Bug: Alert banner height (FE)

### DIFF
--- a/components/02-molecules/alert/_yds-alert.scss
+++ b/components/02-molecules/alert/_yds-alert.scss
@@ -15,8 +15,7 @@ $alert-fade-speed: var(--animation-speed-slow);
   z-index: 3;
   background-color: var(--color-alert-background);
   color: var(--color-alert-text);
-  height: 100%;
-  max-height: 7rem;
+  max-height: 25rem; // we need to set a max-height to animate the alert close state.
   opacity: 1;
   overflow: hidden;
 

--- a/components/02-molecules/alert/alert.stories.js
+++ b/components/02-molecules/alert/alert.stories.js
@@ -38,6 +38,7 @@ const alertResetInstructions = `
 ${ctaTwig({
   cta__content: 'Reset dismissed alerts',
   cta__attributes: { onClick: 'resetAlerts();' },
+  cta__component_theme: 'one',
 })}
 `;
 


### PR DESCRIPTION
## [YALB-1364 - Bug: Alert banner height (FE)](https://yaleits.atlassian.net/browse/YALB-1364)

### Description of work
- removes `height: 100%`
- Increases `max-height` to `25rem`
- add component theme to the reset button in Storybook 

### Testing Link(s)
- [x] Navigate to the [Alert Component Story](https://deploy-preview-256--dev-component-library-twig.netlify.app/?path=/story/molecules-alert--alert-examples)


### Functional Review Steps
- [x] Navigate to the [Alert Component Story](https://deploy-preview-256--dev-component-library-twig.netlify.app/?path=/story/molecules-alert--alert-examples)
- [x] Verify that, using your browser's inspector, if you increase the amount of content entered into the alert heading or into the alert content, the alert height increases. 
- [x] Verify that, if you dismiss an alert, they still animate (in height) and fade away.  
- Note: we need to set a `max-height` for the alert to be able to be animated. I set it to a large value (`25rem` / `400px`) in hopes that it is large enough. We can adjust this value as needed.

https://github.com/yalesites-org/component-library-twig/assets/366413/c9b7c7d0-7b4f-42ae-9448-1413211f4737


