### PR TITLE
YALB-1322 - Bug: Gallery Block - closing x gets cut off (FE)

### DIFF
--- a/components/03-organisms/galleries/media-grid/_yds-media-grid-modal.scss
+++ b/components/03-organisms/galleries/media-grid/_yds-media-grid-modal.scss
@@ -205,6 +205,7 @@ $modal-speed: var(--animation-speed-slow);
 
   svg {
     height: var(--size-click-target-minimum);
+    width: var(--size-click-target-minimum);
   }
 
   &--previous {


### PR DESCRIPTION
## [YALB-1322 - Bug: Gallery Block - closing x gets cut off (FE)](https://yaleits.atlassian.net/browse/YALB-1322)

### Description of work
- Adds a `width` to the `svg`s in the media gallery component so that they render in Safari.  

### Testing Link(s)
- [ ] Navigate to the [Interactive Gallery Component Story](https://deploy-preview-257--dev-component-library-twig.netlify.app/?path=/story/organisms-galleries--interactive-grid)

### Functional Review Steps
- [ ] Using Safari, verify the `close' and 'arrow' icons render for the media interactive gallery component: https://deploy-preview-257--dev-component-library-twig.netlify.app/?path=/story/organisms-galleries--interactive-grid
- [ ] Compare to the live version here: https://yalesites-org.github.io/component-library-twig/?path=/story/organisms-galleries--interactive-grid



https://github.com/yalesites-org/component-library-twig/assets/366413/63259ec2-a7a6-4a74-bb63-eed430164f73


