### PR TITLE
YALB-1418: Bug: All events created are showing as past events

### DIFF
--- a/components/02-molecules/meta/event-meta/yds-event-meta.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta.twig
@@ -30,7 +30,7 @@
 {% set event_meta__base_class = 'event-meta' %}
 
 {# Check if event has passed #}
-{% set event_has_passed = event_meta__date_end < "now"|date("Y-m-d") %}
+{% set event_has_passed = event_meta__date_end < "now"|date("U") %}
 
 {# Set the event status based on event_has_passed variable #}
 {% set event_status = event_has_passed ? 'passed' : 'current' %}

--- a/components/02-molecules/meta/meta.stories.js
+++ b/components/02-molecules/meta/meta.stories.js
@@ -4,6 +4,11 @@ import basicMetaTwig from './basic-meta/yds-basic-meta.twig';
 import eventMetaTwig from './event-meta/yds-event-meta.twig';
 import dateTimeTwig from '../../01-atoms/date-time/yds-date-time.twig';
 
+// Utility to convert dates to unix timestamps
+const toUnixTimeStamp = (date) => {
+  return Math.floor(Date.parse(date) / 1000);
+};
+
 /**
  * Storybook Definition.
  */
@@ -34,8 +39,8 @@ export const Event = ({
 }) =>
   eventMetaTwig({
     event_title__heading: pageTitle,
-    event_meta__date_start: startDate,
-    event_meta__date_end: endDate,
+    event_meta__date_start: toUnixTimeStamp(startDate),
+    event_meta__date_end: toUnixTimeStamp(endDate),
     event_meta__format: format,
     event_meta__address: address,
     event_meta__cta_primary__content: ctaText,

--- a/components/05-page-examples/events/events.stories.js
+++ b/components/05-page-examples/events/events.stories.js
@@ -17,6 +17,11 @@ import socialLinksData from '../../02-molecules/social-links/social-links.yml';
 // JavaScript.
 import '../../00-tokens/layout/yds-layout';
 
+// Utility to convert dates to unix timestamps
+const toUnixTimeStamp = (date) => {
+  return Math.floor(Date.parse(date) / 1000);
+};
+
 /**
  * Storybook Definition.
  */
@@ -82,8 +87,8 @@ export const EventPage = ({
     utility_nav__search: utilityNavSearch,
     breadcrumbs__items: breadcrumbData.items,
     ...imageData.responsive_images['4x3'],
-    event_meta__date_start: startDate,
-    event_meta__date_end: endDate,
+    event_meta__date_start: toUnixTimeStamp(startDate),
+    event_meta__date_end: toUnixTimeStamp(endDate),
     event_meta__format: format,
     event_meta__address: address,
     event_meta__cta_primary__content: ctaText,


### PR DESCRIPTION
## [YALB-1418: Bug: All events created are showing as past events](https://yaleits.atlassian.net/browse/YALB-1418)

### Description of work
- Change date format of `now` to use unix timestamps over human readable

### Testing Link(s)
- [ ] Navigate to the [Event Meta Component Story](http://localhost:6006/?path=/story/molecules-meta--event)
- [ ] Navigate to the [Event Page Component Story](http://localhost:6006/?path=/story/page-examples-events--event-page)
- [ ] Use a local YaleSites instance to test that it works with Drupal's data as well.

### Functional Review Steps
- [ ] In Storybook links
  - [ ] Change the dates to ensure that it only says past event when it is a past event
- [ ] In local YaleSites instance
  - [ ] Create a new event, making the date/time occur in the future, and save
  - [ ] Verify that it does not say it is a past event
  - [ ] Create or modify an event, making the date/time occur in the past, and save
  - [ ] Verify that it does say it is a past event
