### PR TITLE
YALB-1326): Bug: Accessibility issues with figure captions

### DIFF
--- a/components/01-atoms/images/image/yds-image.twig
+++ b/components/01-atoms/images/image/yds-image.twig
@@ -8,7 +8,6 @@
 {# Render the image in a <figure> if there is a caption provided. #}
 {% if figure__caption %}
   {% set figure__attributes = {
-    'aria-label': figure__caption,
     'class': bem('figure'),
   } %}
 


### PR DESCRIPTION
## [YALB-1326: Bug: Accessibility issues with figure captions](https://yaleits.atlassian.net/browse/YALB-1326)

### Description of work
- Removes the `aria-label` from `figure` tags as the caption is already in the DOM and screens readers were reading the HTML tags in the `aria-label`

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
