### PR TITLE
YALB-1272: Bug: Button style inverted | YALB-905: Links: Inconsistent treatment

### DIFF
--- a/components/02-molecules/banner/action/yds-action-banner.twig
+++ b/components/02-molecules/banner/action/yds-action-banner.twig
@@ -64,6 +64,7 @@
                 cta__content: banner__link__content,
                 cta__href: banner__link__url,
                 cta__blockname: banner__base_class,
+                cta__style: 'outline',
               } %}
             {% endif %}
           {% endif %}

--- a/components/02-molecules/callout/_yds-callout.twig
+++ b/components/02-molecules/callout/_yds-callout.twig
@@ -32,6 +32,7 @@
           cta__content: callout__link__content,
           cta__href: callout__link__url,
           cta__blockname: callout__base_class,
+          cta__style: 'outline',
         } %}
       {% endif %}
     {% endif %}

--- a/components/02-molecules/quick-links/_yds-quick-links--links.twig
+++ b/components/02-molecules/quick-links/_yds-quick-links--links.twig
@@ -1,13 +1,10 @@
 {% set quick_links__base_class = 'quick-links' %}
 
-{% if quick_links__variation == 'promotional' %}
-  {% set cta__style = 'outline' %}
-{% endif %}
-
 <li {{ bem('list-item', [], quick_links__base_class) }}>
   {% include "@atoms/controls/cta/yds-cta.twig" with {
     cta__content: quick_links__link__content|default(link.quick_links__link__content),
     cta__href: quick_links__link__url|default(link.quick_links__link__url),
     cta__blockname: quick_links__base_class,
+    cta__style: 'outline'
   } %}
 </li>

--- a/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
+++ b/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
@@ -1,4 +1,5 @@
 @use '../../00-tokens/tokens';
+@use '../../01-atoms/atoms';
 
 $wrapped-image-offset-max: 1550px;
 
@@ -29,6 +30,12 @@ $wrapped-image-offset-max: 1550px;
   [data-component-width='site'] & {
     width: 100%;
     max-width: var(--size-component-layout-width-site);
+  }
+}
+
+.wrapped-image__text {
+  a {
+    @include atoms.link;
   }
 }
 


### PR DESCRIPTION
## [YALB-1272: Bug: Button style inverted](https://yaleits.atlassian.net/browse/YALB-1272) | [YALB-905: Links: Inconsistent treatment](https://yaleits.atlassian.net/browse/YALB-905)

### Description of work
- YALB-1272: Bug: Button style inverted
  - Fixes button style for `callouts` and `banners`
  - This also fixes part of https://yaleits.atlassian.net/browse/YALB-1290
- YALB-905: Links: Inconsistent treatment
  - Adds link functionality to `wrapped-image` component
     
### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
#### Testing YALB-1272: Bug: Button style inverted
- [ ] Verify that the following components all show button style `outline` instead of `filled`
  - [ ] https://deploy-preview-262--dev-component-library-twig.netlify.app/?path=/story/molecules-banners--action-banner
  - [ ] https://deploy-preview-262--dev-component-library-twig.netlify.app/?path=/story/molecules-callout--callout
  - [ ] https://deploy-preview-262--dev-component-library-twig.netlify.app/?path=/story/molecules-quick-links--quick-links
- [ ] You can also test this locally by checking out this branch and testing in Drupal. Just checkout the branch and run `npm run local:cl-dev`. 
![Screenshot-20230703122330-2539x1229](https://github.com/yalesites-org/component-library-twig/assets/366413/54ce9528-3ce4-41e2-a669-f19c2ee88680)

  
![Screenshot-20230703122339-2534x1172](https://github.com/yalesites-org/component-library-twig/assets/366413/fe33eeb7-ce1f-4efd-9db1-90751f042dc5)

  
---

#### Testing YALB-905: Links: Inconsistent treatment
- [ ] Visit https://deploy-preview-262--dev-component-library-twig.netlify.app/?path=/story/molecules-wrapped-image--wrapped-image
- [ ] Using the web inspector, inspect the `wrapped-image` component, edit the text "as html" and verify the link receives the proper link and link hover treatment instead of providing the browser default colors/behavior. 

https://github.com/yalesites-org/component-library-twig/assets/366413/260b70b2-fe84-415f-b750-151e6c142cd4



