### PR TITLE
YALB-1440: Create and theme profile-meta component (FE) | YALB-1436: Create new display modes (FE)

### DIFF
--- a/components/01-atoms/controls/text-link/yds-text-link.js
+++ b/components/01-atoms/controls/text-link/yds-text-link.js
@@ -19,7 +19,7 @@ Drupal.behaviors.textLink = {
           }
           const text =
             event.target.parentNode.querySelector(
-              '.link__pre-text',
+              '.pre-text__text',
             ).textContent;
           try {
             navigator.clipboard.writeText(text);

--- a/components/01-atoms/controls/text-link/yds-text-link.twig
+++ b/components/01-atoms/controls/text-link/yds-text-link.twig
@@ -35,7 +35,9 @@
 
 {% if link__pre_text %}
   <div {{ bem('inner', [], link__base_class) }}>
-    <span {{ bem('pre-text', [], link__base_class) }}>
+   {# set these bem classes so that they can't be changed. 
+      the JS in `./yds-text-link.js` is looking for `pre-text__text` #}
+    <span {{ bem('text', [], 'pre-text') }}>
       {{link__pre_text}}
     </span>
 {% endif %}

--- a/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
+++ b/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
@@ -1,0 +1,92 @@
+@use '../../../00-tokens/tokens';
+@use '../../../01-atoms/atoms';
+
+$break-directory-card-collection-max: tokens.$break-m - 0.05;
+$break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
+
+.directory-listing-card {
+  --color-text-shadow: var(--color-basic-white);
+
+  display: flex;
+  flex-flow: column-reverse;
+  gap: var(--size-spacing-4);
+
+  // from small to media, both grid and list render using a horizontal layout.
+  [data-collection-type='directory'] & {
+    @media (min-width: tokens.$break-s) and (max-width: $break-directory-card-collection-max) {
+      flex-flow: row-reverse nowrap;
+      gap: var(--size-spacing-6);
+      align-items: flex-start;
+    }
+  }
+}
+
+.directory-listing-card__image {
+  @media (max-width: $break-directory-card-collection-list-image-max) {
+    [data-collection-type='directory'] & {
+      max-width: 50%;
+    }
+  }
+
+  @media (min-width: tokens.$break-mobile) {
+    [data-collection-type='directory'] & {
+      aspect-ratio: 3/2;
+    }
+  }
+}
+
+.directory-listing-card__content {
+  width: 100%;
+
+  @media (min-width: tokens.$break-s) and (max-width: $break-directory-card-collection-max) {
+    [data-collection-type='directory'][data-collection-featured='true'] & {
+      flex: 1 0 50%;
+    }
+
+    [data-collection-type='directory'][data-collection-featured='false'] & {
+      flex: 1 0 66%;
+    }
+  }
+}
+
+.directory-listing-card__heading {
+  [data-collection-featured='false'] & {
+    @include tokens.h5-yale-new;
+
+    font-weight: var(--font-weights-yalenew-bold);
+  }
+
+  [data-collection-type='directory'][data-collection-featured='true'] & {
+    @include tokens.h4-yale-new;
+
+    font-weight: var(--font-weights-yalenew-bold);
+  }
+}
+
+.directory-listing-card__subheading {
+  @include tokens.body-default-condensed;
+
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: var(--size-spacing-3);
+
+  > *:not(:first-child) {
+    margin-left: var(--size-spacing-5);
+    padding-left: var(--size-spacing-5);
+    position: relative;
+
+    &::before {
+      position: absolute;
+      content: '|';
+      left: -0.225rem;
+    }
+  }
+}
+
+.directory-listing-card__snippet {
+  margin-top: var(--size-spacing-3);
+
+  [data-collection-featured='false'] & {
+    @include tokens.body-default-condensed;
+  }
+}

--- a/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
+++ b/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
@@ -71,8 +71,6 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
 }
 
 .directory-listing-card__subheading {
-  @include tokens.body-default-condensed;
-
   display: flex;
   flex-wrap: wrap;
   margin-top: var(--size-spacing-3);
@@ -87,6 +85,14 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
       content: '|';
       left: -0.225rem;
     }
+  }
+
+  [data-collection-featured='false'] & {
+    @include tokens.body-default-condensed;
+  }
+
+  [data-collection-featured='true'] & {
+    @include tokens.h5-yale-new;
   }
 }
 

--- a/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
+++ b/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
@@ -56,11 +56,18 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
     font-weight: var(--font-weights-yalenew-bold);
   }
 
-  [data-collection-type='directory'][data-collection-featured='true'] & {
+  [data-collection-featured='true'] & {
     @include tokens.h4-yale-new;
 
     font-weight: var(--font-weights-yalenew-bold);
   }
+}
+
+.directory-listing-card__heading-link {
+  @include atoms.link('no-underline');
+
+  color: currentcolor;
+  font-weight: inherit;
 }
 
 .directory-listing-card__subheading {

--- a/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
+++ b/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
@@ -51,6 +51,17 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
   }
 }
 
+.directory-listing-card__overline {
+  @include tokens.body-s;
+
+  margin-bottom: var(--size-spacing-3);
+  color: var(--color-gray-500);
+  font-variant-caps: small-caps;
+  font-variant-numeric: oldstyle-nums;
+  text-transform: lowercase;
+  letter-spacing: 0.5px;
+}
+
 .directory-listing-card__heading {
   [data-collection-featured='false'] & {
     @include tokens.h5-yale-new;
@@ -96,6 +107,11 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
   [data-collection-featured='true'] & {
     @include tokens.h5-yale-new;
   }
+
+  [data-collection-type='profile-directory'][data-collection-featured='false']
+    & {
+    @include tokens.body-s-condensed;
+  }
 }
 
 .directory-listing-card__snippet {
@@ -103,5 +119,28 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
 
   [data-collection-featured='false'] & {
     @include tokens.body-default-condensed;
+  }
+
+  [data-collection-type='profile-directory'][data-collection-featured='false']
+    & {
+    @include tokens.body-s-condensed;
+  }
+}
+
+.directory-listing-card__email {
+  @include tokens.body-default-condensed;
+
+  [data-collection-type='profile-directory'][data-collection-featured='false']
+    & {
+    @include tokens.body-s-condensed;
+  }
+}
+
+.directory-listing-card__phone {
+  @include tokens.body-default-condensed;
+
+  [data-collection-type='profile-directory'][data-collection-featured='false']
+    & {
+    @include tokens.body-s-condensed;
   }
 }

--- a/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
+++ b/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
@@ -12,7 +12,7 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
   gap: var(--size-spacing-4);
 
   // from small to media, both grid and list render using a horizontal layout.
-  [data-collection-type='directory'] & {
+  [data-collection-type='directory-listing'] & {
     @media (min-width: tokens.$break-s) and (max-width: $break-directory-card-collection-max) {
       flex-flow: row-reverse nowrap;
       gap: var(--size-spacing-6);
@@ -23,13 +23,13 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
 
 .directory-listing-card__image {
   @media (max-width: $break-directory-card-collection-list-image-max) {
-    [data-collection-type='directory'] & {
+    [data-collection-type='directory-listing'] & {
       max-width: 50%;
     }
   }
 
   @media (min-width: tokens.$break-mobile) {
-    [data-collection-type='directory'] & {
+    [data-collection-type='directory-listing'] & {
       aspect-ratio: 3/2;
     }
   }
@@ -39,11 +39,13 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
   width: 100%;
 
   @media (min-width: tokens.$break-s) and (max-width: $break-directory-card-collection-max) {
-    [data-collection-type='directory'][data-collection-featured='true'] & {
+    [data-collection-type='directory-listing'][data-collection-featured='true']
+      & {
       flex: 1 0 50%;
     }
 
-    [data-collection-type='directory'][data-collection-featured='false'] & {
+    [data-collection-type='directory-listing'][data-collection-featured='false']
+      & {
       flex: 1 0 66%;
     }
   }

--- a/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
+++ b/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
@@ -60,7 +60,7 @@ export const ProfileCardDirectoryListing = ({
   email,
   phone,
 }) => `
-<div class='card-collection' data-component-width='site' data-collection-type='directory-listing' data-collection-featured="${featured}">
+<div class='card-collection' data-component-width='site' data-collection-type='profile-directory' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
       ${directoryCardTwig({

--- a/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
+++ b/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
@@ -22,19 +22,8 @@ export default {
       type: 'string',
       defaultValue: directoryCardData.directory_listing_card__snippet,
     },
-    collectionType: {
-      name: 'Collection Type',
-      type: 'select',
-      options: ['directory'],
-      defaultValue: 'directory',
-    },
     featured: {
       name: 'Featured',
-      type: 'boolean',
-      defaultValue: true,
-    },
-    withImage: {
-      name: 'With Image',
       type: 'boolean',
       defaultValue: true,
     },
@@ -42,13 +31,13 @@ export default {
 };
 
 export const ProfileDirectoryListingCard = ({ collectionType, featured }) => `
-<div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
+<div class='card-collection' data-component-width='site' data-collection-type='directory' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
       ${directoryCardTwig({
         card_example_type: 'profile',
         card_collection__type: collectionType,
-        ...imageData.responsive_images['3x2'],
+        ...imageData.responsive_images['1x1'],
         directory_listing_card__heading:
           directoryCardData.directory_listing_card__heading,
         directory_listing_card__subheading:

--- a/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
+++ b/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
@@ -17,6 +17,11 @@ export default {
       type: 'string',
       defaultValue: directoryCardData.directory_listing_card__heading,
     },
+    subheading: {
+      name: 'Subheading',
+      type: 'string',
+      defaultValue: directoryCardData.directory_listing_card__subheading,
+    },
     snippet: {
       name: 'Snippet',
       type: 'string',
@@ -27,10 +32,22 @@ export default {
       type: 'boolean',
       defaultValue: true,
     },
+    overline: {
+      name: 'Overline',
+      type: 'string',
+      defaultValue: directoryCardData.directory_listing_card__overline,
+    },
   },
 };
 
-export const ProfileDirectoryListingCard = ({ collectionType, featured }) => `
+export const ProfileDirectoryListingCard = ({
+  collectionType,
+  featured,
+  heading,
+  subheading,
+  snippet,
+  overline,
+}) => `
 <div class='card-collection' data-component-width='site' data-collection-type='directory' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
@@ -38,12 +55,10 @@ export const ProfileDirectoryListingCard = ({ collectionType, featured }) => `
         card_example_type: 'profile',
         card_collection__type: collectionType,
         ...imageData.responsive_images['1x1'],
-        directory_listing_card__heading:
-          directoryCardData.directory_listing_card__heading,
-        directory_listing_card__subheading:
-          directoryCardData.directory_listing_card__subheading,
-        directory_listing_card__snippet:
-          directoryCardData.directory_listing_card__snippet,
+        directory_listing_card__overline: overline,
+        directory_listing_card__heading: heading,
+        directory_listing_card__subheading: subheading,
+        directory_listing_card__snippet: snippet,
         directory_listing_card__url:
           directoryCardData.directory_listing_card__url,
       })}

--- a/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
+++ b/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
@@ -1,0 +1,64 @@
+import directoryCardTwig from './yds-directory-listing-card.twig';
+
+import directoryCardData from './yds-directory-listing-card.yml';
+import imageData from '../../../01-atoms/images/image/image.yml';
+
+/**
+ * Storybook Definition.
+ */
+export default {
+  title: 'Molecules/Cards',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    heading: {
+      name: 'Heading',
+      type: 'string',
+      defaultValue: directoryCardData.directory_listing_card__heading,
+    },
+    snippet: {
+      name: 'Snippet',
+      type: 'string',
+      defaultValue: directoryCardData.directory_listing_card__snippet,
+    },
+    collectionType: {
+      name: 'Collection Type',
+      type: 'select',
+      options: ['directory'],
+      defaultValue: 'directory',
+    },
+    featured: {
+      name: 'Featured',
+      type: 'boolean',
+      defaultValue: true,
+    },
+    withImage: {
+      name: 'With Image',
+      type: 'boolean',
+      defaultValue: true,
+    },
+  },
+};
+
+export const ProfileDirectoryListingCard = ({ collectionType, featured }) => `
+<div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
+  <div class='card-collection__inner'>
+    <ul class='card-collection__cards'>
+      ${directoryCardTwig({
+        card_example_type: 'profile',
+        card_collection__type: collectionType,
+        ...imageData.responsive_images['3x2'],
+        directory_listing_card__heading:
+          directoryCardData.directory_listing_card__heading,
+        directory_listing_card__subheading:
+          directoryCardData.directory_listing_card__subheading,
+        directory_listing_card__snippet:
+          directoryCardData.directory_listing_card__snippet,
+        directory_listing_card__url:
+          directoryCardData.directory_listing_card__url,
+      })}
+    </ul>
+  </div>
+</div>
+`;

--- a/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
+++ b/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
@@ -50,7 +50,7 @@ export default {
   },
 };
 
-export const ProfileDirectoryListingCard = ({
+export const ProfileCardDirectoryListing = ({
   collectionType,
   featured,
   heading,
@@ -60,7 +60,7 @@ export const ProfileDirectoryListingCard = ({
   email,
   phone,
 }) => `
-<div class='card-collection' data-component-width='site' data-collection-type='directory' data-collection-featured="${featured}">
+<div class='card-collection' data-component-width='site' data-collection-type='directory-listing' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
       ${directoryCardTwig({

--- a/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
+++ b/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
@@ -27,6 +27,16 @@ export default {
       type: 'string',
       defaultValue: directoryCardData.directory_listing_card__snippet,
     },
+    email: {
+      name: 'Email',
+      type: 'string',
+      defaultValue: directoryCardData.directory_listing_card__email,
+    },
+    phone: {
+      name: 'Phone',
+      type: 'string',
+      defaultValue: directoryCardData.directory_listing_card__phone,
+    },
     featured: {
       name: 'Featured',
       type: 'boolean',
@@ -47,6 +57,8 @@ export const ProfileDirectoryListingCard = ({
   subheading,
   snippet,
   overline,
+  email,
+  phone,
 }) => `
 <div class='card-collection' data-component-width='site' data-collection-type='directory' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
@@ -59,6 +71,8 @@ export const ProfileDirectoryListingCard = ({
         directory_listing_card__heading: heading,
         directory_listing_card__subheading: subheading,
         directory_listing_card__snippet: snippet,
+        directory_listing_card__email: email,
+        directory_listing_card__phone: phone,
         directory_listing_card__url:
           directoryCardData.directory_listing_card__url,
       })}

--- a/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
+++ b/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
@@ -1,0 +1,50 @@
+{#
+  # Available Props:
+  # - directory_listing_card__image: boolean used to evaluate whether or not to show the image
+  #
+  # Available Variables:
+  # - directory_listing_card__overline
+  # - directory_listing_card__heading
+  # - directory_listing_card__subheading
+  # - directory_listing_card__url
+  # - directory_listing_card__snippet
+  #
+  # Available Blocks:
+  # - directory_listing_card__image
+  #}
+ 
+ {% set directory_listing_card__base_class = 'directory-listing-card' %}
+ {% set directory_listing_card__image = directory_listing_card__image|default('true') %}
+ 
+ <li {{ bem(directory_listing_card__base_class) }}>
+   <div {{ bem('content', [], directory_listing_card__base_class) }}>
+     {% include "@atoms/typography/headings/yds-heading.twig" with {
+       heading__level: directory_listing_card__heading_level|default('3'),
+       heading__blockname: directory_listing_card__base_class,
+       heading: directory_listing_card__heading,
+       heading__url: directory_listing_card__url,
+     } %}
+     {% if directory_listing_card__subheading %}
+       {% include "@atoms/typography/text/yds-text.twig" with {
+         text__blockname: directory_listing_card__base_class,
+         text__base_class: 'subheading',
+         text__content: directory_listing_card__subheading,
+       } %}
+     {% endif %}
+     {% if directory_listing_card__snippet %}
+       {% include "@atoms/typography/text/yds-text.twig" with {
+         text__base_class: 'snippet',
+         text__blockname: directory_listing_card__base_class,
+         text__content: directory_listing_card__snippet,
+       } %}
+     {% endif %}
+   </div>
+   {% if directory_listing_card__image == 'true' %}
+     <div {{ bem('image', [], directory_listing_card__base_class) }}>
+       {% block directory_listing_card__image %}
+         {% include "@atoms/images/image/_responsive-image.twig" %}
+       {% endblock %}
+     </div>
+   {% endif %}
+ </li>
+ 

--- a/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
+++ b/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
@@ -17,7 +17,7 @@
  {% set directory_listing_card__image = directory_listing_card__image|default('true') %}
  
  <li {{ bem(directory_listing_card__base_class) }}>
-   <div {{ bem('content', [], directory_listing_card__base_class) }}>
+    <div {{ bem('content', [], directory_listing_card__base_class) }}>
     {% if directory_listing_card__overline %}
       {% include "@atoms/typography/text/yds-text.twig" with {
         text__base_class: 'overline',
@@ -25,27 +25,41 @@
         text__content: directory_listing_card__overline,
       } %}
     {% endif %}
-     {% include "@atoms/typography/headings/yds-heading.twig" with {
-       heading__level: directory_listing_card__heading_level|default('3'),
-       heading__blockname: directory_listing_card__base_class,
-       heading: directory_listing_card__heading,
-       heading__url: directory_listing_card__url,
-     } %}
-     {% if directory_listing_card__subheading %}
-       {% include "@atoms/typography/text/yds-text.twig" with {
-         text__blockname: directory_listing_card__base_class,
-         text__base_class: 'subheading',
-         text__content: directory_listing_card__subheading,
-       } %}
-     {% endif %}
-     {% if directory_listing_card__snippet %}
-       {% include "@atoms/typography/text/yds-text.twig" with {
-         text__base_class: 'snippet',
-         text__blockname: directory_listing_card__base_class,
-         text__content: directory_listing_card__snippet,
-       } %}
-     {% endif %}
-   </div>
+      {% include "@atoms/typography/headings/yds-heading.twig" with {
+        heading__level: directory_listing_card__heading_level|default('3'),
+        heading__blockname: directory_listing_card__base_class,
+        heading: directory_listing_card__heading,
+        heading__url: directory_listing_card__url,
+      } %}
+      {% if directory_listing_card__subheading %}
+        {% include "@atoms/typography/text/yds-text.twig" with {
+          text__blockname: directory_listing_card__base_class,
+          text__base_class: 'subheading',
+          text__content: directory_listing_card__subheading,
+        } %}
+      {% endif %}
+      {% if directory_listing_card__snippet %}
+        {% include "@atoms/typography/text/yds-text.twig" with {
+          text__base_class: 'snippet',
+          text__blockname: directory_listing_card__base_class,
+          text__content: directory_listing_card__snippet,
+        } %}
+      {% endif %}
+      {% if directory_listing_card__email %}
+        {% include "@atoms/typography/text/yds-text.twig" with {
+          text__base_class: 'email',
+          text__blockname: directory_listing_card__base_class,
+          text__content: directory_listing_card__email,
+        } %}
+      {% endif %}
+      {% if directory_listing_card__phone %}
+        {% include "@atoms/typography/text/yds-text.twig" with {
+          text__base_class: 'phone',
+          text__blockname: directory_listing_card__base_class,
+          text__content: directory_listing_card__phone,
+        } %}
+      {% endif %}
+    </div>
    {% if directory_listing_card__image == 'true' %}
      <div {{ bem('image', [], directory_listing_card__base_class) }}>
        {% block directory_listing_card__image %}

--- a/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
+++ b/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
@@ -18,6 +18,13 @@
  
  <li {{ bem(directory_listing_card__base_class) }}>
    <div {{ bem('content', [], directory_listing_card__base_class) }}>
+    {% if directory_listing_card__overline %}
+      {% include "@atoms/typography/text/yds-text.twig" with {
+        text__base_class: 'overline',
+        text__blockname: directory_listing_card__base_class,
+        text__content: directory_listing_card__overline,
+      } %}
+    {% endif %}
      {% include "@atoms/typography/headings/yds-heading.twig" with {
        heading__level: directory_listing_card__heading_level|default('3'),
        heading__blockname: directory_listing_card__base_class,

--- a/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.yml
+++ b/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.yml
@@ -1,3 +1,4 @@
+directory_listing_card__overline: Humanities
 directory_listing_card__heading: Person Namerton
 directory_listing_card__subheading: Professional Title and Professor of Subject
 directory_listing_card__snippet: Subtitle/Lede

--- a/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.yml
+++ b/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.yml
@@ -1,0 +1,4 @@
+directory_listing_card__heading: Person Namerton
+directory_listing_card__subheading: Professional Title and Professor of Subject
+directory_listing_card__snippet: Subtitle/Lede
+directory_listing_card__url: '#'

--- a/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.yml
+++ b/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.yml
@@ -3,3 +3,5 @@ directory_listing_card__heading: Person Namerton
 directory_listing_card__subheading: Professional Title and Professor of Subject
 directory_listing_card__snippet: Subtitle/Lede
 directory_listing_card__url: '#'
+directory_listing_card__email: person.name.@yale.edu
+directory_listing_card__phone: '203.565.7777'

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -31,6 +31,12 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
       align-items: flex-start;
     }
   }
+
+  [data-collection-type='condensed'] & {
+    padding-bottom: var(--size-spacing-5);
+    border-bottom: var(--border-thickness-1) solid var(--color-divider);
+    margin-bottom: var(--size-spacing-5);
+  }
 }
 
 .reference-card__image {
@@ -75,6 +81,8 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
 }
 
 .reference-card__content {
+  width: 100%;
+
   [data-collection-type='list'][data-collection-featured='false'] & {
     flex: 1 1 100%;
   }
@@ -132,6 +140,12 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
 
   [data-collection-type='list'][data-collection-featured='true'] & {
     @include tokens.h3-yale-new;
+
+    font-weight: var(--font-weights-yalenew-bold);
+  }
+
+  [data-collection-type='condensed'][data-collection-featured='true'] & {
+    @include tokens.h5-yale-new;
 
     font-weight: var(--font-weights-yalenew-bold);
   }

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -82,12 +82,12 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
   @media (min-width: tokens.$break-mobile) {
     [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='false']
       & {
-      flex: 0 1 10%;
+      flex-basis: 10%;
     }
 
     [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='true']
       & {
-      flex: 0 1 15%;
+      flex-basis: 15%;
     }
   }
 }
@@ -128,12 +128,12 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
   @media (min-width: tokens.$break-mobile) {
     [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='false']
       & {
-      flex: 0 1 90%;
+      flex-basis: 90%;
     }
 
     [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='true']
       & {
-      flex: 0 1 85%;
+      flex-basis: 85%;
     }
   }
 }

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -78,6 +78,18 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
       flex: 0 0 33%;
     }
   }
+
+  @media (min-width: tokens.$break-mobile) {
+    [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='false']
+      & {
+      flex: 0 1 10%;
+    }
+
+    [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='true']
+      & {
+      flex: 0 1 15%;
+    }
+  }
 }
 
 .reference-card__content {
@@ -110,6 +122,18 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
     [data-collection-type='list'][data-collection-featured='true'] & {
       flex: 0 1 71%;
       margin-inline: auto;
+    }
+  }
+
+  @media (min-width: tokens.$break-mobile) {
+    [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='false']
+      & {
+      flex: 0 1 90%;
+    }
+
+    [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='true']
+      & {
+      flex: 0 1 85%;
     }
   }
 }

--- a/components/02-molecules/cards/reference-card/examples/_card--examples.twig
+++ b/components/02-molecules/cards/reference-card/examples/_card--examples.twig
@@ -61,7 +61,10 @@
     {% set reference_card__overline = null %}
     {% set reference_card__snippet = null %}
     {% set reference_card__image = false %}
-    {% set reference_card__subheading = reference_card__date__formatted ~ reference_card__time__formatted %}
+    {% set format %}
+      <span class="format-inline">{{ format }}</span>
+    {% endset %}
+    {% set reference_card__subheading = reference_card__date__formatted ~ reference_card__time__formatted ~ format %}
   {% else %}
     {# If event and list put the date and time in the subheading. #}
     {% set reference_card__subheading = reference_card__date__formatted ~ reference_card__time__formatted %}

--- a/components/02-molecules/cards/reference-card/examples/_card--examples.twig
+++ b/components/02-molecules/cards/reference-card/examples/_card--examples.twig
@@ -58,8 +58,10 @@
     {% endif %}
   {# If event, and condensed, hide snippet and set image to false. #}
   {% elseif card_collection__type == 'condensed' %}
+    {% set reference_card__overline = null %}
     {% set reference_card__snippet = null %}
     {% set reference_card__image = false %}
+    {% set reference_card__subheading = reference_card__date__formatted ~ reference_card__time__formatted %}
   {% else %}
     {# If event and list put the date and time in the subheading. #}
     {% set reference_card__subheading = reference_card__date__formatted ~ reference_card__time__formatted %}

--- a/components/02-molecules/cards/reference-card/examples/_card--examples.twig
+++ b/components/02-molecules/cards/reference-card/examples/_card--examples.twig
@@ -20,6 +20,25 @@
     {% set reference_card__snippet = null %}
   {% endif %}
 
+  {# If post, and condensed, hide snippet and set image to false. #}
+  {% if card_collection__type == 'condensed' %}
+    {% set reference_card__snippet = null %}
+    {% set reference_card__image = false %}
+  {% endif %}
+
+{# Profile Card #}
+{% elseif card_example_type == 'profile' %}
+  {# If post, list, and not freatured, hide snippet. #}
+  {% if card_collection__type == 'list' and card_collection__featured == 'false' %}
+    {% set reference_card__subheading = null %}
+  {% endif %}
+
+  {# If post, and condensed, hide snippet and set image to false. #}
+  {% if card_collection__type == 'condensed' %}
+    {% set reference_card__image = false %}
+    {% set reference_card__snippet = null %}
+  {% endif %}
+
 {# Event Card #}
 {% elseif card_example_type == 'event' %}
   {# If a format is provided, put it in the overline #}
@@ -37,10 +56,18 @@
     {% if card_collection__featured == 'false' %}
       {% set reference_card__snippet = null %}
     {% endif %}
+  {# If event, and condensed, hide snippet and set image to false. #}
+  {% elseif card_collection__type == 'condensed' %}
+    {% set reference_card__snippet = null %}
+    {% set reference_card__image = false %}
   {% else %}
     {# If event and list put the date and time in the subheading. #}
     {% set reference_card__subheading = reference_card__date__formatted ~ reference_card__time__formatted %}
   {% endif %}
 {% endif %}
 
-{% include "@molecules/cards/reference-card/yds-reference-card.twig" %}
+{% if card_example_type == 'directory-listing' %}
+  {% include "@molecules/cards/directory-listing-card/yds-directory-listing-card.twig" %}
+{% else %}
+  {% include "@molecules/cards/reference-card/yds-reference-card.twig" %}
+{% endif %}

--- a/components/02-molecules/cards/reference-card/examples/profile-card.yml
+++ b/components/02-molecules/cards/reference-card/examples/profile-card.yml
@@ -1,0 +1,4 @@
+reference_card__heading: Person Namertone
+reference_card__subheading: Professional Title and Professor of Subject
+reference_card__snippet: Subtitle/Lede
+reference_card__url: '#'

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -114,13 +114,13 @@ EventCard.argTypes = {
 };
 
 export const ProfileCard = ({ collectionType, featured }) => `
-<div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
+<div class='card-collection' data-component-width='site' data-collection-source='profile' data-collection-type='${collectionType}' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
       ${referenceCardTwig({
         card_example_type: 'profile',
         card_collection__type: collectionType,
-        ...imageData.responsive_images['3x2'],
+        ...imageData.responsive_images['1x1'],
         reference_card__heading:
           referenceProfileCardData.reference_card__heading,
         reference_card__subheading:

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -1,6 +1,7 @@
 import referenceCardTwig from './examples/_card--examples.twig';
 
 import referenceCardData from './examples/post-card.yml';
+import referenceProfileCardData from './examples/profile-card.yml';
 import imageData from '../../../01-atoms/images/image/image.yml';
 
 import './yds-reference-card';
@@ -27,7 +28,7 @@ export default {
     collectionType: {
       name: 'Collection Type',
       type: 'select',
-      options: ['grid', 'list'],
+      options: ['grid', 'list', 'condensed'],
       defaultValue: 'grid',
     },
     featured: {
@@ -111,3 +112,24 @@ EventCard.argTypes = {
     defaultValue: 'In-person',
   },
 };
+
+export const ProfileCard = ({ collectionType, featured }) => `
+<div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
+  <div class='card-collection__inner'>
+    <ul class='card-collection__cards'>
+      ${referenceCardTwig({
+        card_example_type: 'profile',
+        card_collection__type: collectionType,
+        ...imageData.responsive_images['3x2'],
+        reference_card__heading:
+          referenceProfileCardData.reference_card__heading,
+        reference_card__subheading:
+          referenceProfileCardData.reference_card__subheading,
+        reference_card__snippet:
+          referenceProfileCardData.reference_card__snippet,
+        reference_card__url: referenceProfileCardData.reference_card__url,
+      })}
+    </ul>
+  </div>
+</div>
+`;

--- a/components/02-molecules/meta/meta.stories.js
+++ b/components/02-molecules/meta/meta.stories.js
@@ -66,7 +66,7 @@ export const Profile = ({
 }) =>
   profileMetaTwig({
     ...imageData.responsive_images['3x2'],
-    profile_title__heading: heading,
+    profile_meta__heading: heading,
     profile_meta__title_line: titleLine,
     profile_meta__subtitle_line: subTitle,
     profile_meta__department: department,

--- a/components/02-molecules/meta/meta.stories.js
+++ b/components/02-molecules/meta/meta.stories.js
@@ -1,8 +1,13 @@
+import tokens from '@yalesites-org/tokens/build/json/tokens.json';
 import { eventArgTypes } from '../../04-page-layouts/cl-page-args';
 
 import basicMetaTwig from './basic-meta/yds-basic-meta.twig';
 import eventMetaTwig from './event-meta/yds-event-meta.twig';
 import dateTimeTwig from '../../01-atoms/date-time/yds-date-time.twig';
+import profileMetaTwig from './profile-meta/yds-profile-meta.twig';
+import imageData from '../../01-atoms/images/image/image.yml';
+
+const colorPairingsData = Object.keys(tokens['component-themes']);
 
 // Utility to convert dates to unix timestamps
 const toUnixTimeStamp = (date) => {
@@ -50,4 +55,48 @@ export const Event = ({
   });
 Event.argTypes = {
   ...eventArgTypes,
+};
+
+export const Profile = ({
+  heading,
+  bgColor,
+  titleLine,
+  subTitle,
+  department,
+}) =>
+  profileMetaTwig({
+    ...imageData.responsive_images['3x2'],
+    profile_title__heading: heading,
+    profile_meta__title_line: titleLine,
+    profile_meta__subtitle_line: subTitle,
+    profile_meta__department: department,
+    profile_meta__background: bgColor,
+  });
+Profile.argTypes = {
+  heading: {
+    name: 'Heading',
+    type: 'string',
+    defaultValue: 'Person Namerton',
+  },
+  titleLine: {
+    name: 'Profile professional title',
+    type: 'string',
+    defaultValue: 'Professional Title',
+  },
+  subTitle: {
+    name: 'Profile subtitle',
+    type: 'string',
+    defaultValue: 'Subtitle',
+  },
+  department: {
+    name: 'Profile department',
+    type: 'string',
+    defaultValue: 'Department name',
+  },
+  bgColor: {
+    name: 'Component Theme (dial)',
+    type: 'select',
+    options: colorPairingsData,
+    defaultValue: 'one',
+  },
 };

--- a/components/02-molecules/meta/meta.stories.js
+++ b/components/02-molecules/meta/meta.stories.js
@@ -4,6 +4,11 @@ import basicMetaTwig from './basic-meta/yds-basic-meta.twig';
 import eventMetaTwig from './event-meta/yds-event-meta.twig';
 import dateTimeTwig from '../../01-atoms/date-time/yds-date-time.twig';
 
+// Utility to convert dates to unix timestamps
+const toUnixTimeStamp = (date) => {
+  return Math.floor(Date.parse(date) / 1000);
+};
+
 /**
  * Storybook Definition.
  */
@@ -34,8 +39,8 @@ export const Event = ({
 }) =>
   eventMetaTwig({
     event_title__heading: pageTitle,
-    event_meta__date_start: startDate,
-    event_meta__date_end: endDate,
+    event_meta__date_start: toUnixTimeStamp(startDate),
+    event_meta__date_end: toUnixTimeStamp(endDate),
     event_meta__format: format,
     event_meta__address: address,
     event_meta__cta_primary__content: ctaText,

--- a/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
+++ b/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
@@ -93,12 +93,15 @@ $break-profile-banner-max: $break-profile-banner - 0.05;
 
 .profile-meta__image {
   width: 100%;
-  max-width: 661px;
   flex: 0 auto;
   aspect-ratio: 3/2;
 
   @media (max-width: $break-profile-banner-max) {
     margin-bottom: var(--size-spacing-5);
+  }
+
+  @media (min-width: $break-profile-banner) {
+    max-width: 661px;
   }
 }
 

--- a/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
+++ b/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
@@ -88,6 +88,7 @@ $break-profile-banner-max: $break-profile-banner - 0.05;
 
   @media (min-width: $break-profile-banner) {
     flex-direction: row-reverse;
+    gap: var(--size-spacing-5);
   }
 }
 

--- a/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
+++ b/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
@@ -1,0 +1,120 @@
+@use '~@yalesites-org/tokens/build/scss/tokens' as sass-tokens;
+@use '../../../00-tokens/tokens';
+@use '../../../00-tokens/functions/map';
+@use '../../../01-atoms/atoms';
+
+$component-profile-themes: map.deep-get(tokens.$tokens, 'component-themes');
+$global-profile-themes: map.deep-get(tokens.$tokens, 'global-themes');
+$break-profile-banner: tokens.$break-l;
+$break-profile-banner-max: $break-profile-banner - 0.05;
+
+.profile-meta {
+  color: var(--color-text);
+  background-color: var(--color-profile-background);
+
+  // Component themes defaults: iterate over each component theme to establish
+  // default variables.
+  @each $theme, $value in $component-profile-themes {
+    &[data-component-theme='#{$theme}'] {
+      // prettier-ignore
+      --color-profile-background: var(--component-themes-#{$theme}-background);
+      --color-text-shadow: var(--component-themes-#{$theme}-background);
+      --color-slot-one: var(--component-themes-#{$theme}-slot-one);
+      --color-slot-two: var(--component-themes-#{$theme}-slot-two);
+      --color-slot-three: var(--component-themes-#{$theme}-slot-three);
+      --color-slot-four: var(--component-themes-#{$theme}-slot-four);
+      --color-slot-five: var(--component-themes-#{$theme}-slot-five);
+    }
+  }
+
+  // Global themes: set color slots for each theme
+  // This establishes `--color-slot-` variables name-spaced to the selector
+  // in which it is used. We can map component-level variables to global-level
+  // `--color-slot-` variables.
+  @each $globalTheme, $value in $global-profile-themes {
+    [data-global-theme='#{$globalTheme}'] & {
+      --color-slot-one: var(--global-themes-#{$globalTheme}-colors-slot-one);
+      --color-slot-two: var(--global-themes-#{$globalTheme}-colors-slot-two);
+      --color-slot-three: var(
+        --global-themes-#{$globalTheme}-colors-slot-three
+      );
+      --color-slot-four: var(--global-themes-#{$globalTheme}-colors-slot-four);
+      --color-slot-five: var(--global-themes-#{$globalTheme}-colors-slot-five);
+    }
+  }
+
+  // Component theme overrides: set specific component themes overrides
+  /// define component name spaced variables and map them to global theme slots.
+  &[data-component-theme='one'] {
+    --color-profile-background: var(--color-slot-one);
+    --color-text-shadow: var(--color-slot-one);
+    --color-text: var(--color-basic-white);
+    --color-heading: var(--color-basic-white);
+  }
+
+  &[data-component-theme='two'] {
+    --color-profile-background: var(--color-slot-four);
+    --color-text-shadow: var(--color-slot-one);
+    --color-text: var(--color-gray-800);
+    --color-heading: var(--color-gray-800);
+  }
+
+  &[data-component-theme='three'] {
+    --color-profile-background: var(--color-slot-five);
+    --color-text-shadow: var(--color-slot-one);
+    --color-text: var(--color-basic-white);
+    --color-heading: var(--color-basic-white);
+  }
+
+  @media (max-width: tokens.$break-mobile-max) {
+    @include tokens.body-s;
+
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.profile-meta__inner {
+  display: flex;
+  flex-direction: column-reverse;
+  width: 100%;
+  max-width: var(--size-component-layout-width-site);
+
+  @media (min-width: $break-profile-banner) {
+    flex-direction: row-reverse;
+  }
+}
+
+.profile-meta__image {
+  aspect-ratio: 3/2;
+  width: 100%;
+  max-width: 661px;
+  flex: 0 auto;
+
+  @media (max-width: $break-profile-banner-max) {
+    margin-bottom: var(--size-spacing-5);
+  }
+}
+
+.profile-meta__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 auto;
+  padding-block: var(--size-spacing-8);
+
+  @media (min-width: $break-profile-banner) {
+    max-width: calc(100% - 661px);
+  }
+}
+
+.profile-meta__title-line {
+  @include tokens.h3-yale-new;
+}
+
+.profile-meta__subtitle-line {
+  @include tokens.h4-yale-new;
+}
+
+.profile-meta__department-line {
+  margin-top: auto;
+}

--- a/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
+++ b/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
@@ -113,12 +113,20 @@ $break-profile-banner-max: $break-profile-banner - 0.05;
   }
 }
 
+.profile-title__page-title {
+  margin-bottom: var(--size-spacing-8);
+}
+
 .profile-meta__title-line {
   @include tokens.h3-yale-new;
+
+  margin-bottom: var(--size-spacing-6);
 }
 
 .profile-meta__subtitle-line {
   @include tokens.h4-yale-new;
+
+  margin-bottom: var(--size-spacing-6);
 }
 
 .profile-meta__department-line {

--- a/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
+++ b/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
@@ -106,7 +106,7 @@ $break-profile-banner-max: $break-profile-banner - 0.05;
   display: flex;
   flex-direction: column;
   flex: 1 auto;
-  padding-block: var(--size-spacing-8) var(--size-spacing-4);
+  padding-block: var(--size-spacing-8) var(--size-spacing-6);
 
   @media (min-width: $break-profile-banner) {
     max-width: calc(100% - 661px);

--- a/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
+++ b/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
@@ -9,6 +9,12 @@ $break-profile-banner: tokens.$break-l;
 $break-profile-banner-max: $break-profile-banner - 0.05;
 
 .profile-meta {
+  @include tokens.spacing-page-section(
+    $flush-top: true,
+    $flush-bottom: true,
+    $banner-spacing: true
+  );
+
   color: var(--color-text);
   background-color: var(--color-profile-background);
 
@@ -86,10 +92,10 @@ $break-profile-banner-max: $break-profile-banner - 0.05;
 }
 
 .profile-meta__image {
-  aspect-ratio: 3/2;
   width: 100%;
   max-width: 661px;
   flex: 0 auto;
+  aspect-ratio: 3/2;
 
   @media (max-width: $break-profile-banner-max) {
     margin-bottom: var(--size-spacing-5);
@@ -100,7 +106,7 @@ $break-profile-banner-max: $break-profile-banner - 0.05;
   display: flex;
   flex-direction: column;
   flex: 1 auto;
-  padding-block: var(--size-spacing-8);
+  padding-block: var(--size-spacing-8) var(--size-spacing-4);
 
   @media (min-width: $break-profile-banner) {
     max-width: calc(100% - 661px);

--- a/components/02-molecules/meta/profile-meta/yds-profile-meta.twig
+++ b/components/02-molecules/meta/profile-meta/yds-profile-meta.twig
@@ -23,8 +23,10 @@
 
     <div {{ bem('content', [], profile_meta__base_class) }}>
       {% include "@molecules/page-title/yds-page-title.twig" with {
-        page_title__heading: profile_title__heading,
+        page_title__heading: profile_meta__heading,
+        page_title__blockname: 'profile-title',
       }%}
+      
       {% if profile_meta__title_line %}
         {% include "@atoms/typography/text/yds-text.twig" with {
           text__blockname: profile_meta__base_class,
@@ -32,6 +34,7 @@
           text__base_class: 'title-line',
         } %}
       {% endif %}
+
       {% if profile_meta__subtitle_line %}
         {% include "@atoms/typography/text/yds-text.twig" with {
           text__blockname: profile_meta__base_class,

--- a/components/02-molecules/meta/profile-meta/yds-profile-meta.twig
+++ b/components/02-molecules/meta/profile-meta/yds-profile-meta.twig
@@ -1,0 +1,53 @@
+{#
+ # Available Variables:
+ # - event_meta__format: Multiselect. Options are 'In-person', 'Virtual', or both.
+ # - event_meta__address
+ #}
+
+{% set profile_meta__base_class = 'profile-meta' %}
+{% set profile_meta__background = profile_meta__background|default('one') %}
+
+{% set profile_meta__attributes = {
+  'data-component-width': profile_meta__width|default('site'),
+  class: bem(profile_meta__base_class, [], profile_meta__blockname, profile_meta__additional_classes),
+} %}
+
+<div {{ add_attributes(profile_meta__attributes) }} data-component-theme={{ profile_meta__background }} data-embedded-components>
+  <div {{ bem('inner', [], profile_meta__base_class) }}>
+
+    <div {{ bem('image', [], profile_meta__base_class) }}>
+      {% block profile__image %}
+        {% include "@atoms/images/image/_responsive-image.twig" %}
+      {% endblock %}
+    </div>
+
+    <div {{ bem('content', [], profile_meta__base_class) }}>
+      {% include "@molecules/page-title/yds-page-title.twig" with {
+        page_title__heading: profile_title__heading,
+      }%}
+      {% if profile_meta__title_line %}
+        {% include "@atoms/typography/text/yds-text.twig" with {
+          text__blockname: profile_meta__base_class,
+          text__content: profile_meta__title_line,
+          text__base_class: 'title-line',
+        } %}
+      {% endif %}
+      {% if profile_meta__subtitle_line %}
+        {% include "@atoms/typography/text/yds-text.twig" with {
+          text__blockname: profile_meta__base_class,
+          text__content: profile_meta__subtitle_line,
+          text__base_class: 'subtitle-line',
+        } %}
+      {% endif %}
+
+      {% if profile_meta__department %}
+        {% include "@atoms/typography/text/yds-text.twig" with {
+          text__blockname: profile_meta__base_class,
+          text__content: profile_meta__department,
+          text__base_class: 'department-line',
+        } %}
+      {% endif %}
+    </div>
+
+  </div>
+</div>

--- a/components/02-molecules/molecules.scss
+++ b/components/02-molecules/molecules.scss
@@ -3,6 +3,7 @@
 @forward './banner/action/yds-action-banner';
 @forward './callout/yds-callout';
 @forward './cards/reference-card/yds-reference-card';
+@forward './cards/directory-listing-card/yds-directory-listing-card';
 @forward './cards/custom-card/yds-custom-card';
 @forward './embed/yds-embed';
 @forward './image/yds-content-image';

--- a/components/02-molecules/molecules.scss
+++ b/components/02-molecules/molecules.scss
@@ -10,6 +10,7 @@
 @forward './menu/menu-toggle/yds-menu-toggle';
 @forward './meta/basic-meta/yds-basic-meta';
 @forward './meta/event-meta/yds-event-meta';
+@forward './meta/profile-meta/yds-profile-meta';
 @forward './page-title/yds-page-title';
 @forward './pager/yds-pager';
 @forward './wrapped-image/yds-wrapped-image';

--- a/components/03-organisms/_grid-mixins.scss
+++ b/components/03-organisms/_grid-mixins.scss
@@ -73,3 +73,35 @@
     }
   }
 }
+
+@mixin directory-primary {
+  --grid-gutter: var(--spacing-component-gutter);
+
+  @include base;
+
+  > * {
+    @media (min-width: tokens.$break-m) {
+      flex: 0 1 calc(33.33% - calc(var(--grid-gutter) / 2));
+    }
+
+    @media (min-width: tokens.$break-l) {
+      flex: 0 1 calc(14.88% - calc(var(--grid-gutter) * 2 / 6));
+    }
+  }
+}
+
+@mixin directory-secondary {
+  --grid-gutter: var(--spacing-component-gutter);
+
+  @include base;
+
+  > * {
+    @media (min-width: tokens.$break-m) {
+      flex: 0 1 calc(50% - calc(var(--grid-gutter) / 2));
+    }
+
+    @media (min-width: tokens.$break-l) {
+      flex: 0 1 calc(25% - calc(var(--grid-gutter) * 2 / 4));
+    }
+  }
+}

--- a/components/03-organisms/_grid-mixins.scss
+++ b/components/03-organisms/_grid-mixins.scss
@@ -85,7 +85,8 @@
     }
 
     @media (min-width: tokens.$break-l) {
-      flex: 0 1 calc(14.88% - calc(var(--grid-gutter) * 2 / 6));
+      flex: 0 1 calc(13.68% - calc(var(--grid-gutter) * 2 / 6));
+      max-width: 13.68%;
     }
   }
 }

--- a/components/03-organisms/_grid-mixins.scss
+++ b/components/03-organisms/_grid-mixins.scss
@@ -81,12 +81,17 @@
 
   > * {
     @media (min-width: tokens.$break-m) {
-      flex: 0 1 calc(33.33% - calc(var(--grid-gutter) / 2));
+      flex: 0 1 calc(33.33% - calc(var(--grid-gutter) * 2 / 3));
     }
 
     @media (min-width: tokens.$break-l) {
-      flex: 0 1 calc(13.68% - calc(var(--grid-gutter) * 2 / 6));
-      max-width: 13.68%;
+      flex: 0 1 calc(20% - calc(var(--grid-gutter) * 4 / 5));
+      max-width: calc(20% - calc(var(--grid-gutter) * 4 / 5));
+    }
+
+    @media (min-width: tokens.$break-2xl) {
+      flex: 0 1 calc(16.66% - calc(var(--grid-gutter) * 5 / 6));
+      max-width: calc(16.66% - calc(var(--grid-gutter) * 5 / 6));
     }
   }
 }
@@ -102,7 +107,7 @@
     }
 
     @media (min-width: tokens.$break-l) {
-      flex: 0 1 calc(24.1% - calc(var(--grid-gutter) * 2 / 4));
+      flex: 0 1 calc(25% - calc(var(--grid-gutter) * 3 / 4));
     }
   }
 }

--- a/components/03-organisms/_grid-mixins.scss
+++ b/components/03-organisms/_grid-mixins.scss
@@ -101,7 +101,7 @@
     }
 
     @media (min-width: tokens.$break-l) {
-      flex: 0 1 calc(25% - calc(var(--grid-gutter) * 2 / 4));
+      flex: 0 1 calc(24.1% - calc(var(--grid-gutter) * 2 / 4));
     }
   }
 }

--- a/components/03-organisms/block-wrapper/_yds-block-wrapper.scss
+++ b/components/03-organisms/block-wrapper/_yds-block-wrapper.scss
@@ -4,6 +4,10 @@
   @include tokens.spacing-page-section;
 
   margin-top: 0;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .block-wrapper__heading {

--- a/components/03-organisms/block-wrapper/_yds-block-wrapper.scss
+++ b/components/03-organisms/block-wrapper/_yds-block-wrapper.scss
@@ -1,0 +1,11 @@
+@use '../../00-tokens/tokens';
+
+.block-wrapper {
+  @include tokens.spacing-page-section;
+
+  margin-top: 0;
+}
+
+.block-wrapper__heading {
+  @include tokens.h4-yale-new;
+}

--- a/components/03-organisms/block-wrapper/block-wrapper.stories.js
+++ b/components/03-organisms/block-wrapper/block-wrapper.stories.js
@@ -1,0 +1,23 @@
+import blockWrapperTwig from './yds-block-wrapper.twig';
+
+/**
+ * Storybook Definition.
+ */
+export default {
+  title: 'Organisms/Block Wrapper',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    blockContent: {
+      name: 'Content',
+      type: 'string',
+      defaultValue:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sit amet consectetur adipiscing elit duis tristique sollicitudin nibh sit. Convallis convallis tellus id interdum velit laoreet id donec. Feugiat in ante metus dictum at. Massa eget egestas purus viverra accumsan in nisl nisi. Sed tempus urna et pharetra. Non nisi est sit amet. Leo urna molestie at elementum eu facilisis sed odio morbi. Sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper eget. Pharetra massa massa ultricies mi. Elementum curabitur vitae nunc sed velit dignissim sodales ut. Semper feugiat nibh sed pulvinar. Scelerisque eleifend donec pretium vulputate sapien nec sagittis aliquam malesuada. Id interdum velit laoreet id donec ultrices tincidunt arcu non. Mollis nunc sed id semper risus in. Placerat in egestas erat imperdiet sed. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio. In eu mi bibendum neque. Sit amet venenatis urna cursus eget nunc scelerisque.',
+    },
+  },
+};
+
+export const BlockWrapper = ({ blockContent }) => {
+  return blockWrapperTwig({ block_wrapper__content: blockContent });
+};

--- a/components/03-organisms/block-wrapper/yds-block-wrapper.twig
+++ b/components/03-organisms/block-wrapper/yds-block-wrapper.twig
@@ -1,0 +1,23 @@
+{% set block_wrapper__base_class = 'block-wrapper' %}
+
+{% set block_wrapper__attributes = {
+  class: bem(block_wrapper__base_class, block_wrapper__modifiers, block_wrapper__blockname, block_wrapper__extra_classes),
+} %}
+
+<div {{ add_attributes(block_wrapper__attributes) }}>
+  <div {{ bem('inner', [], 'block-wrapper') }}>
+    {% if block_wrapper__label %}
+      {% set block_wrapper__heading__level = 2 %}
+      {% include "@atoms/typography/headings/yds-heading.twig" with {
+        heading__level: block_wrapper__heading__level,
+        heading: block_wrapper__label,
+        heading__blockname: block_wrapper_heading__blockname|default(block_wrapper__base_class),
+        heading__modifiers: block_wrapper_label__modifiers,
+      } %}
+    {% endif %}
+
+    {% block block_wrapper__inner %}
+      {{ block_wrapper__content }}
+    {% endblock %}
+  </div>
+</div>

--- a/components/03-organisms/card-collection/_yds-card-collection.scss
+++ b/components/03-organisms/card-collection/_yds-card-collection.scss
@@ -42,4 +42,12 @@
   [data-collection-type='grid'][data-component-width='content'] & {
     @include grid.quaternary;
   }
+
+  [data-collection-type='directory'][data-collection-featured='false'] & {
+    @include grid.directory-primary;
+  }
+
+  [data-collection-type='directory'][data-collection-featured='true'] & {
+    @include grid.directory-secondary;
+  }
 }

--- a/components/03-organisms/card-collection/_yds-card-collection.scss
+++ b/components/03-organisms/card-collection/_yds-card-collection.scss
@@ -43,11 +43,13 @@
     @include grid.quaternary;
   }
 
-  [data-collection-type='directory'][data-collection-featured='false'] & {
+  [data-collection-type='profile-directory'][data-collection-featured='false']
+    & {
     @include grid.directory-primary;
   }
 
-  [data-collection-type='directory'][data-collection-featured='true'] & {
+  [data-collection-type='profile-directory'][data-collection-featured='true']
+    & {
     @include grid.directory-secondary;
   }
 }

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -25,11 +25,6 @@ export default {
       type: 'boolean',
       defaultValue: true,
     },
-    withImages: {
-      name: 'With Images',
-      type: 'boolean',
-      defaultValue: true,
-    },
   },
 };
 
@@ -53,6 +48,11 @@ export const PostCardCollection = ({
   });
 };
 PostCardCollection.argTypes = {
+  withImages: {
+    name: 'With Images',
+    type: 'boolean',
+    defaultValue: true,
+  },
   heading: {
     name: 'Heading',
     type: 'string',
@@ -81,6 +81,11 @@ export const EventCardCollection = ({
   });
 };
 EventCardCollection.argTypes = {
+  withImages: {
+    name: 'With Images',
+    type: 'boolean',
+    defaultValue: true,
+  },
   heading: {
     name: 'Heading',
     type: 'string',

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -93,7 +93,7 @@ EventCardCollection.argTypes = {
   },
 };
 
-export const DirectoryListingCardCollection = ({ featured, withImages }) => {
+export const DirectoryListingCardCollection = ({ featured, heading }) => {
   const items = featured ? [1, 2, 3, 4] : [1, 2, 3, 4, 5, 6];
 
   return cardCollectionTwig({
@@ -101,8 +101,8 @@ export const DirectoryListingCardCollection = ({ featured, withImages }) => {
     card_collection__type: 'directory',
     card_collection__heading: 'Directory Listing',
     card_collection__featured: featured ? 'true' : 'false',
-    card_collection__with_images: withImages ? 'true' : 'false',
     card_collection__cards: items,
+    directory_listing_card__heading: heading,
     ...directoryCardData,
     ...imageData.responsive_images['1x1'],
   });

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -98,7 +98,7 @@ export const DirectoryListingCardCollection = ({ featured, heading }) => {
 
   return cardCollectionTwig({
     card_example_type: 'directory-listing',
-    card_collection__type: 'directory',
+    card_collection__type: 'profile-directory',
     card_collection__heading: 'Directory Listing',
     card_collection__featured: featured ? 'true' : 'false',
     card_collection__cards: items,
@@ -116,7 +116,7 @@ DirectoryListingCardCollection.argTypes = {
   collectionType: {
     name: 'Collection Type',
     type: 'select',
-    options: ['directory'],
-    defaultValue: 'directory',
+    options: ['profile-directory'],
+    defaultValue: 'profile-directory',
   },
 };

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -1,7 +1,8 @@
 import cardCollectionTwig from './yds-card-collection.twig';
-
 import postCardData from '../../02-molecules/cards/reference-card/examples/post-card.yml';
 import eventCardData from '../../02-molecules/cards/reference-card/examples/event-card.yml';
+import directoryCardData from '../../02-molecules/cards/directory-listing-card/yds-directory-listing-card.yml';
+
 import imageData from '../../01-atoms/images/image/image.yml';
 
 /**
@@ -16,7 +17,7 @@ export default {
     collectionType: {
       name: 'Collection Type',
       type: 'select',
-      options: ['grid', 'list'],
+      options: ['grid', 'list', 'condensed'],
       defaultValue: 'grid',
     },
     featured: {
@@ -84,5 +85,33 @@ EventCardCollection.argTypes = {
     name: 'Heading',
     type: 'string',
     defaultValue: 'Event Card Grid Heading',
+  },
+};
+
+export const DirectoryListingCardCollection = ({ featured, withImages }) => {
+  const items = featured ? [1, 2, 3, 4] : [1, 2, 3, 4, 5, 6];
+
+  return cardCollectionTwig({
+    card_example_type: 'directory-listing',
+    card_collection__type: 'directory',
+    card_collection__heading: 'Directory Listing',
+    card_collection__featured: featured ? 'true' : 'false',
+    card_collection__with_images: withImages ? 'true' : 'false',
+    card_collection__cards: items,
+    ...directoryCardData,
+    ...imageData.responsive_images['1x1'],
+  });
+};
+DirectoryListingCardCollection.argTypes = {
+  heading: {
+    name: 'Heading',
+    type: 'string',
+    defaultValue: directoryCardData.directory_listing_card__heading,
+  },
+  collectionType: {
+    name: 'Collection Type',
+    type: 'select',
+    options: ['directory'],
+    defaultValue: 'directory',
   },
 };

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -2,6 +2,7 @@ import cardCollectionTwig from './yds-card-collection.twig';
 import postCardData from '../../02-molecules/cards/reference-card/examples/post-card.yml';
 import eventCardData from '../../02-molecules/cards/reference-card/examples/event-card.yml';
 import directoryCardData from '../../02-molecules/cards/directory-listing-card/yds-directory-listing-card.yml';
+import profileCardData from '../../02-molecules/cards/reference-card/examples/profile-card.yml';
 
 import imageData from '../../01-atoms/images/image/image.yml';
 
@@ -90,6 +91,38 @@ EventCardCollection.argTypes = {
     name: 'Heading',
     type: 'string',
     defaultValue: 'Event Card Grid Heading',
+  },
+};
+
+export const ProfileCardCollection = ({
+  heading,
+  collectionType,
+  featured,
+  withImages,
+}) => {
+  const items = featured ? [1, 2, 3] : [1, 2, 3, 4];
+
+  return cardCollectionTwig({
+    card_example_type: 'profile',
+    card_collection__type: collectionType,
+    card_collection__heading: heading,
+    card_collection__featured: featured ? 'true' : 'false',
+    card_collection__with_images: withImages ? 'true' : 'false',
+    card_collection__cards: items,
+    ...profileCardData,
+    ...imageData.responsive_images['1x1'],
+  });
+};
+ProfileCardCollection.argTypes = {
+  heading: {
+    name: 'Heading',
+    type: 'string',
+    defaultValue: 'Profile Card Grid Heading',
+  },
+  withImages: {
+    name: 'With Images',
+    type: 'boolean',
+    defaultValue: true,
   },
 };
 

--- a/components/03-organisms/card-collection/yds-card-collection.twig
+++ b/components/03-organisms/card-collection/yds-card-collection.twig
@@ -21,6 +21,12 @@
   class: bem(card_collection__base_class, card_collection__modifiers),
 } %}
 
+{% if card_example_type %}
+  {% set card_collection__attributes = card_collection__attributes|merge({
+    'data-collection-source': card_example_type,
+  }) %}
+{% endif %}
+
 <div {{ add_attributes(card_collection__attributes) }}>
   <div {{ bem('inner', [], card_collection__base_class) }}>
     {% if card_collection__heading %}

--- a/components/03-organisms/organisms.scss
+++ b/components/03-organisms/organisms.scss
@@ -1,5 +1,6 @@
 @forward './card-collection/yds-card-collection';
 @forward './component-wrapper/yds-component-wrapper';
+@forward './block-wrapper/yds-block-wrapper';
 @forward './custom-card-collection/yds-custom-card-collection';
 @forward './galleries/media-grid/yds-media-grid';
 @forward './galleries/media-grid/yds-media-grid-modal';

--- a/components/05-page-examples/events/events.stories.js
+++ b/components/05-page-examples/events/events.stories.js
@@ -17,6 +17,11 @@ import socialLinksData from '../../02-molecules/social-links/social-links.yml';
 // JavaScript.
 import '../../00-tokens/layout/yds-layout';
 
+// Utility to convert dates to unix timestamps
+const toUnixTimeStamp = (date) => {
+  return Math.floor(Date.parse(date) / 1000);
+};
+
 /**
  * Storybook Definition.
  */
@@ -82,8 +87,8 @@ export const EventPage = ({
     utility_nav__search: utilityNavSearch,
     breadcrumbs__items: breadcrumbData.items,
     ...imageData.responsive_images['4x3'],
-    event_meta__date_start: startDate,
-    event_meta__date_end: endDate,
+    event_meta__date_start: toUnixTimeStamp(startDate),
+    event_meta__date_end: toUnixTimeStamp(endDate),
     event_meta__format: format,
     event_meta__address: address,
     event_meta__cta_primary__content: ctaText,

--- a/components/05-page-examples/profiles/profile.twig
+++ b/components/05-page-examples/profiles/profile.twig
@@ -1,0 +1,108 @@
+{% extends "@page-layouts/yds-full-width.twig" %}
+  {% block page__content %}
+    {% include "@organisms/menu/breadcrumbs/yds-breadcrumbs.twig" %}
+    {% include "@molecules/page-title/yds-page-title.twig" with {
+      page_title__heading: 'Person Namerton',
+    }%}
+    {% embed "@organisms/layout/two-column/yds-two-column.twig" %}
+      {% block two_column__primary %}
+        {# -- text, image, video, quote, button link, divider, accordion, tabs #}
+
+        {% include "@molecules/text/yds-text-field.twig" with {
+          text_field__content: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sit amet consectetur adipiscing elit duis tristique sollicitudin nibh sit. Convallis convallis tellus id interdum velit laoreet id donec. Feugiat in ante metus dictum at. Massa eget egestas purus viverra accumsan in nisl nisi. Sed tempus urna et pharetra. Non nisi est sit amet. Leo urna molestie at elementum eu facilisis sed odio morbi. Sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper eget. Pharetra massa massa ultricies mi. Elementum curabitur vitae nunc sed velit dignissim sodales ut. Semper feugiat nibh sed pulvinar. Scelerisque eleifend donec pretium vulputate sapien nec sagittis aliquam malesuada. Id interdum velit laoreet id donec ultrices tincidunt arcu non. Mollis nunc sed id semper risus in. Placerat in egestas erat imperdiet sed. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio. In eu mi bibendum neque. Sit amet venenatis urna cursus eget nunc scelerisque.</p>',
+        } %}
+        {% include "@molecules/text/yds-text-field.twig" with {
+          text_field__content: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sit amet consectetur adipiscing elit duis tristique sollicitudin nibh sit. Convallis convallis tellus id interdum velit laoreet id donec. Feugiat in ante metus dictum at. Massa eget egestas purus viverra accumsan in nisl nisi. Sed tempus urna et pharetra. Non nisi est sit amet. Leo urna molestie at elementum eu facilisis sed odio morbi. Sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper eget. Pharetra massa massa ultricies mi. Elementum curabitur vitae nunc sed velit dignissim sodales ut. Semper feugiat nibh sed pulvinar. Scelerisque eleifend donec pretium vulputate sapien nec sagittis aliquam malesuada. Id interdum velit laoreet id donec ultrices tincidunt arcu non. Mollis nunc sed id semper risus in. Placerat in egestas erat imperdiet sed. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio. In eu mi bibendum neque. Sit amet venenatis urna cursus eget nunc scelerisque.</p>',
+        } %}
+        
+        {% include "@atoms/divider/yds-divider.twig" %}
+
+        {% include "@molecules/text/yds-text-field.twig" with {
+          text_field__content: '<h2>Section Heading</h2><p>Sit amet consectetur adipiscing elit duis tristique sollicitudin nibh sit. Convallis convallis tellus id interdum velit laoreet id donec. Feugiat in ante metus dictum at. Massa eget egestas purus viverra accumsan in nisl nisi. Sed tempus urna et pharetra. Non nisi est sit amet. Leo urna molestie at elementum eu facilisis sed odio morbi. Sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper eget. Pharetra massa massa ultricies mi. Elementum curabitur vitae nunc sed velit dignissim sodales ut. Semper feugiat nibh sed pulvinar. Scelerisque eleifend donec pretium vulputate sapien nec sagittis aliquam malesuada. Id interdum velit laoreet id donec ultrices tincidunt arcu non. Mollis nunc sed id semper risus in. Placerat in egestas erat imperdiet sed. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio. In eu mi bibendum neque. Sit amet venenatis urna cursus eget nunc scelerisque.</p>',
+        } %}
+
+        {% include "@atoms/controls/cta/yds-cta.twig" with {
+          cta__content: 'Button link',
+          cta__href: 'javascript:;',
+          cta__blockname: callout__base_class,
+          cta__component_theme: 'one',
+        } %}
+
+        {% include "@molecules/pull-quote/yds-pull-quote.twig" with {
+          pull_quote__alignment: 'left',
+          pull_quote__width: 'site',
+          pull_quote__quote: 'Our platform will transform our ability to study metabolic filaments and, coupled with biochemical and biophysical tools, manipulate enzyme structures and metabolic activity in cells.',
+        } %}
+
+        {% include "@atoms/divider/yds-divider.twig" %}
+
+        {% include "@molecules/text/yds-text-field.twig" with {
+          text_field__content: '<h2>Section Heading</h2><p>Feugiat in ante metus dictum at. Massa eget egestas purus viverra accumsan in nisl nisi. Sed tempus urna et pharetra. Non nisi est sit amet. Leo urna molestie at elementum eu facilisis sed odio morbi. Sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper eget. Pharetra massa massa ultricies mi. Elementum curabitur vitae nunc sed velit dignissim sodales ut. Semper feugiat nibh sed pulvinar. Scelerisque eleifend donec pretium vulputate sapien nec sagittis aliquam malesuada. Id interdum velit laoreet id donec ultrices tincidunt arcu non. Mollis nunc sed id semper risus in. Placerat in egestas erat imperdiet sed. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio. In eu mi bibendum neque. Sit amet venenatis urna cursus eget nunc scelerisque.</p>',
+        } %}
+
+        {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
+            component_wrapper__width: 'site',
+            component_wrapper__alignment: 'left',
+          } %}
+          {% block component_wrapper_inner %}
+            {% include "@molecules/tabs/yds-tabs.twig" %}
+          {% endblock %}
+        {% endembed %}
+
+
+
+        {% include "@molecules/text/yds-text-field.twig" with {
+          text_field__content: '<h2>Section Heading</h2><p>Feugiat in ante metus dictum at. Massa eget egestas purus viverra accumsan in nisl nisi. Sed tempus urna et pharetra. Non nisi est sit amet. Leo urna molestie at elementum eu facilisis sed odio morbi. Sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper eget. Pharetra massa massa ultricies mi. Elementum curabitur vitae nunc sed velit dignissim sodales ut. Semper feugiat nibh sed pulvinar. Scelerisque eleifend donec pretium vulputate sapien nec sagittis aliquam malesuada. Id interdum velit laoreet id donec ultrices tincidunt arcu non. Mollis nunc sed id semper risus in. Placerat in egestas erat imperdiet sed. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio. In eu mi bibendum neque. Sit amet venenatis urna cursus eget nunc scelerisque.</p>',
+        } %}
+
+	      {% include "@molecules/image/yds-content-image.twig" with {
+          content_image__width:'site',
+          content_image__alignment: 'left',
+        }%}
+
+        {% include "@molecules/accordion/yds-accordion.twig" with {
+            accordion__heading: 'Accordion Group - left align',
+            accordion__width: 'site',
+            accordion__alignment: 'left',
+            accordion__items: [
+              {
+                accordion__item__heading: accordion__item__heading,
+                accordion__item__content: accordion__item__content
+              },
+              {
+                accordion__item__heading: 'Books',
+                accordion__item__content: accordion__item__content
+              },
+              {
+                accordion__item__heading: 'Courses',
+                accordion__item__content: accordion__item__content
+              },
+              {
+                accordion__item__heading: 'Events',
+                accordion__item__content: accordion__item__content
+              },
+            ]
+        } %}
+      {% endblock %}
+      {% block two_column__secondary %}
+        {% include "@molecules/text/yds-text-field.twig" with {
+          text_field__content: '<h3>Contact Info</h3>',
+        } %}
+        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+          link__pre_text: 'person.name@yale.edu',
+          link__content: '(copy)',
+          link__type: 'email',
+          link__extra_class: ['copy-trigger'],
+          link__url: 'javascript:;',
+        } %}
+        <br />
+        {% include "@molecules/text/yds-text-field.twig" with {
+          text_field__content: '<h3>Section Heading</h3>',
+        } %}
+        {% include "@molecules/text/yds-text-field.twig" with {
+          text_field__content: '<ul><li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li><li>Feugiat in ante metus dictum</li><li>Massa eget egestas purus viverra accumsan in nisl nisi</li><li>Sed tempus urna et pharetra</li></ul>',
+        } %}
+      {% endblock %}
+    {% endembed %}
+
+  {% endblock %}

--- a/components/05-page-examples/profiles/profile.twig
+++ b/components/05-page-examples/profiles/profile.twig
@@ -1,5 +1,7 @@
 {% extends "@page-layouts/yds-full-width.twig" %}
   {% block page__content %} 
+      {% include "@organisms/menu/breadcrumbs/yds-breadcrumbs.twig" %}
+
     {% include "@molecules/meta/profile-meta/yds-profile-meta.twig" with {
       profile_meta__heading: 'Person Namerton',
       profile_meta__title_line: 'Profile Title',
@@ -7,10 +9,6 @@
       profile_meta__department: 'Department name',
     } %}
 
-    {% include "@organisms/menu/breadcrumbs/yds-breadcrumbs.twig" %}
-    {% include "@molecules/page-title/yds-page-title.twig" with {
-      page_title__heading: 'Person Namerton',
-    }%}
     {% embed "@organisms/layout/two-column/yds-two-column.twig" %}
       {% block two_column__primary %}
         {# -- text, image, video, quote, button link, divider, accordion, tabs #}

--- a/components/05-page-examples/profiles/profile.twig
+++ b/components/05-page-examples/profiles/profile.twig
@@ -1,5 +1,12 @@
 {% extends "@page-layouts/yds-full-width.twig" %}
-  {% block page__content %}
+  {% block page__content %} 
+    {% include "@molecules/meta/profile-meta/yds-profile-meta.twig" with {
+      profile_meta__heading: 'Person Namerton',
+      profile_meta__title_line: 'Profile Title',
+      profile_meta__subtitle_line: 'Profile Subtitle',
+      profile_meta__department: 'Department name',
+    } %}
+
     {% include "@organisms/menu/breadcrumbs/yds-breadcrumbs.twig" %}
     {% include "@molecules/page-title/yds-page-title.twig" with {
       page_title__heading: 'Person Namerton',
@@ -84,24 +91,45 @@
             ]
         } %}
       {% endblock %}
+
       {% block two_column__secondary %}
-        {% include "@molecules/text/yds-text-field.twig" with {
-          text_field__content: '<h3>Contact Info</h3>',
-        } %}
-        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
-          link__pre_text: 'person.name@yale.edu',
-          link__content: '(copy)',
-          link__type: 'email',
-          link__extra_class: ['copy-trigger'],
-          link__url: 'javascript:;',
-        } %}
-        <br />
-        {% include "@molecules/text/yds-text-field.twig" with {
-          text_field__content: '<h3>Section Heading</h3>',
-        } %}
-        {% include "@molecules/text/yds-text-field.twig" with {
-          text_field__content: '<ul><li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li><li>Feugiat in ante metus dictum</li><li>Massa eget egestas purus viverra accumsan in nisl nisi</li><li>Sed tempus urna et pharetra</li></ul>',
-        } %}
+
+        {% embed "@organisms/block-wrapper/yds-block-wrapper.twig" with {
+          block_wrapper__label: 'Contact Info',
+          block_wrapper__heading__level: 3,
+        }%}
+          {% block block_wrapper__inner %}
+            {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+              link__pre_text: 'person.name@yale.edu',
+              link__content: '(copy)',
+              link__type: 'email',
+              link__extra_class: ['copy-trigger'],
+              link__url: 'javascript:;',
+            } %}
+            <br/>
+            {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+              link__content: '(203) 593-0486',
+              link__url: 'tel:(203) 593-0486',
+              link__style: ['no-underline'],
+            } %}
+            {% include "@molecules/text/yds-text-field.twig" with {
+              text_field__content: '<br/>Building Name, Room 120<br/>Street Name<br/>City, ST 86753',
+            } %}
+          {% endblock %}
+          
+        {% endembed %}
+
+        {% embed "@organisms/block-wrapper/yds-block-wrapper.twig" with {
+          block_wrapper__label: 'Section Heading',
+          block_wrapper__heading__level: 3,
+          }%}
+          {% block block_wrapper__inner %}
+            {% include "@molecules/text/yds-text-field.twig" with {
+              text_field__content: '<ul><li>Lorem ipsum dolor sit amet, consectetur adipiscing elit</li><li>Feugiat in ante metus dictum</li><li>Massa eget egestas purus viverra accumsan in nisl nisi</li><li>Sed tempus urna et pharetra</li></ul>',
+            } %}
+          {% endblock %}
+        {% endembed %}
+
       {% endblock %}
     {% endembed %}
 

--- a/components/05-page-examples/profiles/profiles.stories.js
+++ b/components/05-page-examples/profiles/profiles.stories.js
@@ -67,7 +67,7 @@ export const ProfilePage = ({
     utility_nav__link__url: '#',
     utility_nav__search: utilityNavSearch,
     breadcrumbs__items: breadcrumbData.items,
-    ...imageData.responsive_images['16x9'],
+    ...imageData.responsive_images['3x2'],
     ...textWithImageData,
     ...referenceCardData,
     ...socialLinksData,

--- a/components/05-page-examples/profiles/profiles.stories.js
+++ b/components/05-page-examples/profiles/profiles.stories.js
@@ -1,0 +1,77 @@
+// Shared Storybook args.
+import argTypes from '../../04-page-layouts/cl-page-args';
+
+// Twig files.
+import profilePageTwig from './profile.twig';
+
+// Data files.
+import utilityNavData from '../../03-organisms/menu/utility-nav/utility-nav.yml';
+import primaryNavData from '../../03-organisms/menu/primary-nav/primary-nav.yml';
+import breadcrumbData from '../../03-organisms/menu/breadcrumbs/breadcrumbs.yml';
+import imageData from '../../01-atoms/images/image/image.yml';
+import textWithImageData from '../../02-molecules/text-with-image/text-with-image.yml';
+import referenceCardData from '../../02-molecules/cards/reference-card/examples/post-card.yml';
+import socialLinksData from '../../02-molecules/social-links/social-links.yml';
+import videoData from '../../02-molecules/video/video.yml';
+import accordionData from '../../02-molecules/accordion/accordion.yml';
+import tabData from '../../02-molecules/tabs/tabs.yml';
+
+// JavaScript.
+import '../../00-tokens/layout/yds-layout';
+import '../../01-atoms/controls/text-link/yds-text-link';
+
+/**
+ * Storybook Definition.
+ */
+export default {
+  title: 'Page Examples/Profiles',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    ...argTypes,
+  },
+};
+
+export const ProfilePage = ({
+  siteName,
+  pageTitle,
+  globalTheme = localStorage.getItem('yds-cl-twig-global-theme'),
+  menuVariation = localStorage.getItem('yds-cl-twig-menu-variation'),
+  headerBorderThickness = localStorage.getItem(
+    'yds-cl-twig-header-border-thickness',
+  ),
+  primaryNavPosition = localStorage.getItem('yds-cl-twig-primary-nav-position'),
+  siteHeaderTheme = localStorage.getItem('yds-cl-twig-site-header-theme'),
+  utilityNavLinkContent,
+  utilityNavSearch,
+  siteFooterTheme = localStorage.getItem('yds-cl-twig-site-footer-theme'),
+  footerBorderThickness = localStorage.getItem(
+    'yds-cl-twig-footer-border-thickness',
+  ),
+}) =>
+  profilePageTwig({
+    site_name: siteName,
+    page_title__heading: pageTitle,
+    page_title__meta: null,
+    site_global__theme: globalTheme,
+    site_header__border_thickness: headerBorderThickness,
+    site_header__nav_position: primaryNavPosition,
+    site_header__theme: siteHeaderTheme,
+    site_footer__border_thickness: footerBorderThickness,
+    site_footer__theme: siteFooterTheme,
+    utility_nav__items: utilityNavData.items,
+    primary_nav__items: primaryNavData.items,
+    menu__variation: menuVariation,
+    utility_nav__link__content: utilityNavLinkContent,
+    utility_nav__link__url: '#',
+    utility_nav__search: utilityNavSearch,
+    breadcrumbs__items: breadcrumbData.items,
+    ...imageData.responsive_images['16x9'],
+    ...textWithImageData,
+    ...referenceCardData,
+    ...socialLinksData,
+    ...videoData,
+    ...accordionData,
+    ...tabData,
+  });

--- a/components/05-page-examples/profiles/profiles.stories.js
+++ b/components/05-page-examples/profiles/profiles.stories.js
@@ -33,7 +33,6 @@ export default {
 
 export const ProfilePage = ({
   siteName,
-  pageTitle,
   globalTheme = localStorage.getItem('yds-cl-twig-global-theme'),
   menuVariation = localStorage.getItem('yds-cl-twig-menu-variation'),
   headerBorderThickness = localStorage.getItem(
@@ -50,8 +49,6 @@ export const ProfilePage = ({
 }) =>
   profilePageTwig({
     site_name: siteName,
-    page_title__heading: pageTitle,
-    page_title__meta: null,
     site_global__theme: globalTheme,
     site_header__border_thickness: headerBorderThickness,
     site_header__nav_position: primaryNavPosition,

--- a/components/05-page-examples/profiles/profiles.stories.js
+++ b/components/05-page-examples/profiles/profiles.stories.js
@@ -28,9 +28,7 @@ export default {
   parameters: {
     layout: 'fullscreen',
   },
-  argTypes: {
-    ...argTypes,
-  },
+  argTypes,
 };
 
 export const ProfilePage = ({


### PR DESCRIPTION
## [YALB-1440: Create and theme profile-meta component (FE)](https://yaleits.atlassian.net/browse/YALB-1440) | [YALB-1436: Create new display modes (FE)](https://yaleits.atlassian.net/browse/YALB-1436) 

### Description of work
- Adds new meta component for profiles
- Adds new display mode: `condensed` for `news`, `events`, `profiles`
- Adds new `directory-listing` display mode for `profiles`

### Testing Link(s)
- [ ] New component content type: [Profile Card Component Story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card)
- [ ] New component content type display:  [Profile Card Directory Component Story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card-directory-listing)
- [ ] New display: [Post Card Condensed](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--post-card&args=collectionType:condensed)
- [ ] New display: [Event Card Condensed](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--event-card&args=collectionType:condensed)
- [ ] New display: [Profile Card Condensed](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card&args=collectionType:condensed)
- [ ] New display: [Profile Card List](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card&args=collectionType:list)
- [ ] New display: [Profile Card Grid](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card)
- [ ] New display: [Profile Card Collection Grid, List and Condensed ](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--profile-card-collection)
- [ ] New display: [Profile Directory Card Collection Grid - non-featured](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--directory-listing-card-collection&args=featured:false)
- [ ] New display: [Profile Directory Card Collection Grid - featured](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--directory-listing-card-collection)

### Functional Review Steps
#### Testing YALB-1440: Create and theme profile-meta component (FE)

- [x] Navigate to https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-meta--profile
  - [x] Verify there is a new page example for `Profile`: https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/page-examples-profiles--profile-page
  - [x] Verify it matches the [designs](https://www.figma.com/proto/G4sJ0BLu4jCJpGzW82JHE8/YaleSites-Components?type=design&node-id=8239-26166&t=tPPrKP3gmj8tU8EI-0&scaling=min-zoom&page-id=8239%3A26166) 


https://github.com/yalesites-org/component-library-twig/assets/366413/efa0a81e-5c63-4016-a16f-a27f252ab974



---

#### Testing YALB-1436: Create new display modes (FE)

##### Cards
- [x] Navigate to the [Profile Directory Card Component Story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card-directory-listing)
  - [x] Verify the card resembles this type of data structure: https://fas.yale.edu/fas-governance/fas-deans-office

- [x] Navigate to the [Profile Card Component Story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card)
  - [x] Verify the card has Storybook control options and you can switch between `grid`, `list`, and `condensed` (see examples in video below)
  - [x] Verify the `list` and `condensed` displays resemble the designs: https://www.figma.com/proto/G4sJ0BLu4jCJpGzW82JHE8/YaleSites-Components?type=design&node-id=8416-27552&scaling=min-zoom&page-id=8239%3A26166
  - [x] Note: to make the images smaller than other `reference` cards, I had to add an optional and contextual `data-collection-source` attribute. In Storybook, this gets picked up because we define the variable in each collection page example. In Drupal, we simply need to pass this variable to any profile list component - `card_example_type: 'profile'`

- [x] Navigate to the [Post Card Component Story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--post-card&args=collectionType:condensed)
  - [x] Verify the card has Storybook control options and you can switch between `grid`, `list`, and `condensed` (see examples in video below)
  - [x]  Verify `condensed` resembles the design in Notion - https://www.notion.so/fourkitchens/News-Cards-Grids-Lists-827e9260ec3647fba279783c3e3b8649?pvs=4#7c29011257dc4cec9b3fe63bc12f874e

- [x] Navigate to the [Event Card Component Story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--event-card&args=collectionType:condensed)
  - [x] Verify the card has Storybook control options and you can switch between `grid`, `list`, and `condensed` (see examples in video below)
  - [x] Verify `condensed` resembles the design in Notion - https://www.notion.so/fourkitchens/Event-Lists-Cards-and-Grid-c185951ddf6842b38dba40da8efc2cff?pvs=4#bb151d3331d8476cae0d61ce972e2e8f


##### Card Collections
- [x] Navigate to the [Post Card Collection component Story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--post-card-collection&args=collectionType:condensed)
  - [x] Verify the new `condensed` display mode renders

- [x] Navigate to the [Event Card Collection component Story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--event-card-collection&args=collectionType:condensed)
  - [x] Verify the new `condensed` display mode renders
 
- [x] Navigate to the [Profile Card Collection component Story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--profile-card-collection&args=collectionType:condensed)
  - [x] Verify the new `condensed` display mode renders

- [x] Navigate to the [Profile Directory Card Collection component story](https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--directory-listing-card-collection&args=featured:false;heading:Person+Namerton)
  - [x] Verify the card resembles this type of data structure: https://fas.yale.edu/fas-governance/fas-deans-office
  - [x] Verify toggling between `featured` and non, the grid changes between 4-columns and 6-columns https://deploy-preview-263--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--directory-listing-card-collection

### Video example | cards and card collections: 

https://github.com/yalesites-org/component-library-twig/assets/366413/15a66438-3d4a-435b-9673-bf2d9cb31eee




### Design Review
- [x] Verify the designs match the [Figma Designs](https://www.figma.com/proto/G4sJ0BLu4jCJpGzW82JHE8/YaleSites-Components?type=design&node-id=8239-26166&t=tPPrKP3gmj8tU8EI-0&scaling=min-zoom&page-id=8239%3A26166) and here: https://www.figma.com/proto/G4sJ0BLu4jCJpGzW82JHE8/YaleSites-Components?type=design&node-id=8416-27552&scaling=min-zoom&page-id=8239%3A26166 and Notion designs for `condensed` [event](https://www.notion.so/fourkitchens/Event-Lists-Cards-and-Grid-c185951ddf6842b38dba40da8efc2cff?pvs=4#bb151d3331d8476cae0d61ce972e2e8f), [post](https://www.notion.so/fourkitchens/News-Cards-Grids-Lists-827e9260ec3647fba279783c3e3b8649#fa2d4c3c3aec4a0ca357924da2795ddc)


### Accessibility Review
- [x] Verify the component meets Accessibility requirements
