### PR TITLE
YALB-1290: Bug: Grand Hero Text alignment

### DIFF
--- a/components/02-molecules/pull-quote/_yds-pull-quote.scss
+++ b/components/02-molecules/pull-quote/_yds-pull-quote.scss
@@ -112,4 +112,12 @@ blockquote {
   font: var(--font-style-body-default);
   color: var(--color-pull-quote-attribution);
   margin-top: 0.4em;
+
+  // if the attribution has a <p> element we need to make the `-` character
+  // and the attribution text in line, and remove bottom-margin from the <p>
+  display: flex;
+
+  p {
+    margin-bottom: 0;
+  }
 }


### PR DESCRIPTION
## [YALB-1290: Bug: Grand Hero Text alignment](https://yaleits.atlassian.net/browse/YALB-1290)

### Description of work
- Adds functionality bullet item
- Fixes this or that bullet item

### Testing Link(s)
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/335

### Functional Review Steps
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/335
- [ ] Verify that if you have a quote on a page, if the attribution element has a `<p>` element within it, it renders inline with the `-` character and does not have bottom-margin. 
- [ ] https://pr-335-yalesites-platform.pantheonsite.io/components

