### PR TITLE
YALB - safari fixes (YALB-1247, YALB-1320, YALB-1323, YALB-1345)

### DIFF
--- a/components/00-tokens/layout/_layout.scss
+++ b/components/00-tokens/layout/_layout.scss
@@ -108,7 +108,8 @@ $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
   $flush-top: false,
   $banner-spacing: false
 ) {
-  margin-block: var(--spacing-page-section);
+  margin-block-start: var(--spacing-page-section);
+  margin-block-end: var(--spacing-page-section);
 
   @if $flush-top == true {
     &:first-child {
@@ -125,7 +126,8 @@ $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
   }
 
   @if $banner-spacing == true {
-    margin-block: var(--spacing-component-banner);
+    margin-block-start: var(--spacing-component-banner);
+    margin-block-end: var(--spacing-component-banner);
 
     @if $flush-top == true {
       &:first-child {

--- a/components/00-tokens/layout/_layout.scss
+++ b/components/00-tokens/layout/_layout.scss
@@ -65,14 +65,16 @@ $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
 
 [data-component-width] {
   &:not([data-embedded-components] [data-component-width]) {
-    padding-inline: var(--size-spacing-site-gutter);
+    padding-inline-start: var(--size-spacing-site-gutter);
+    padding-inline-end: var(--size-spacing-site-gutter);
   }
 }
 
 [class*='__inner'] {
   width: var(--component-width);
   max-width: 100%;
-  margin-inline: auto;
+  margin-inline-start: auto;
+  margin-inline-end: auto;
 
   @each $width, $value in $layout-widths {
     [data-component-width='#{$width}'] & {

--- a/components/01-atoms/divider/cl-dividers.scss
+++ b/components/01-atoms/divider/cl-dividers.scss
@@ -1,4 +1,4 @@
 .divider__wrapper {
-  height: 100%;
-  min-height: 1rem;
+  min-height: 5rem;
+  margin-block: 2rem;
 }

--- a/components/01-atoms/divider/cl-dividers.scss
+++ b/components/01-atoms/divider/cl-dividers.scss
@@ -1,0 +1,4 @@
+.divider__wrapper {
+  height: 100%;
+  min-height: 1rem;
+}

--- a/components/01-atoms/divider/divider.stories.js
+++ b/components/01-atoms/divider/divider.stories.js
@@ -2,6 +2,8 @@ import tokens from '@yalesites-org/tokens/build/json/tokens.json';
 
 import dividerTwig from './yds-divider.twig';
 
+import './cl-dividers.scss';
+
 const layoutOptions = ['left', 'center'];
 const thicknessOptions = Object.keys(tokens.border.thickness);
 const widths = Object.keys(tokens.layout.width);

--- a/components/01-atoms/divider/divider.stories.js
+++ b/components/01-atoms/divider/divider.stories.js
@@ -58,7 +58,7 @@ export const Dividers = ({ position, thickness, dividerColor, width }) => {
   <div style="--thickness-divider: var(--size-thickness-4)">${dividerTwig()}</div>
   <div style="--thickness-divider: var(--size-thickness-6)">${dividerTwig()}</div>
   <div style="--thickness-divider: var(--size-thickness-8)">${dividerTwig()}</div>
-  <div style="
+  <div class="cl-divider-playground" style="
     --color-divider: var(--color-${dividerColor});
     --width-theme-divider: var(--layout-width-${width});
   ">

--- a/components/01-atoms/forms/textfields/_yds-textfields.scss
+++ b/components/01-atoms/forms/textfields/_yds-textfields.scss
@@ -85,7 +85,7 @@ $form-item-icon-size: 1.7rem;
   @include tokens.body-xs;
 
   color: var(--color-form-item-description);
-  padding-block: var(--size-spacing-2) 0;
+  padding-block-start: var(--size-spacing-2);
 }
 
 .form-fieldset {

--- a/components/01-atoms/forms/textfields/_yds-textfields.scss
+++ b/components/01-atoms/forms/textfields/_yds-textfields.scss
@@ -94,7 +94,8 @@ $form-item-icon-size: 1.7rem;
   padding: 0;
 
   .form-item {
-    margin-inline: var(--size-spacing-4);
+    margin-inline-start: var(--size-spacing-4);
+    margin-inline-end: var(--size-spacing-4);
     max-width: $form-item-max-width;
   }
 }

--- a/components/01-atoms/typography/headings/_yds-headings.scss
+++ b/components/01-atoms/typography/headings/_yds-headings.scss
@@ -12,7 +12,7 @@ h6 {
 }
 
 @mixin text-field-header-spacing {
-  margin-block: 0 0.6em;
+  margin-block-end: 0.6em;
 
   &:not(:first-child) {
     margin-top: 1.2em;

--- a/components/01-atoms/typography/text/_yds-text.scss
+++ b/components/01-atoms/typography/text/_yds-text.scss
@@ -1,5 +1,5 @@
 p {
-  margin-block: 0 var(--font-spacing-paragraph);
+  margin-block-end: var(--font-spacing-paragraph);
 }
 
 .text {

--- a/components/01-atoms/videos/video-background/yds-video-background.scss
+++ b/components/01-atoms/videos/video-background/yds-video-background.scss
@@ -97,7 +97,8 @@ $break-video-banner-max: $break-video-banner - 0.05;
       height: $video-background-icon-size;
 
       &.video-background__icon--play {
-        padding-inline: var(--size-spacing-3);
+        padding-inline-start: var(--size-spacing-3);
+        padding-inline-end: var(--size-spacing-3);
       }
     }
   }

--- a/components/01-atoms/videos/video-embed/_yds-video-embed.scss
+++ b/components/01-atoms/videos/video-embed/_yds-video-embed.scss
@@ -5,5 +5,27 @@
   iframe {
     height: 100%;
     width: 100%;
+
+    // Safari 14 fix for aspect-ratio
+    @supports not (aspect-ratio: 16 / 9) {
+      position: absolute;
+    }
+  }
+
+  // Safari 14 fix for aspect-ratio
+  @supports not (aspect-ratio: 16 / 9) {
+    position: relative;
+
+    &::before {
+      float: left;
+      padding-top: 56.25%;
+      content: '';
+    }
+
+    &::after {
+      display: block;
+      content: '';
+      clear: both;
+    }
   }
 }

--- a/components/02-molecules/accordion/_yds-accordion.scss
+++ b/components/02-molecules/accordion/_yds-accordion.scss
@@ -104,11 +104,13 @@
   overflow: hidden;
 
   @media (max-width: tokens.$break-mobile-max) {
-    padding-inline: var(--size-spacing-6);
+    padding-inline-start: var(--size-spacing-6);
+    padding-inline-end: var(--size-spacing-6);
   }
 
   @media (min-width: tokens.$break-mobile) {
-    padding-inline: var(--size-spacing-8);
+    padding-inline-start: var(--size-spacing-8);
+    padding-inline-end: var(--size-spacing-8);
   }
 
   [data-accordion-expanded='true'] & {

--- a/components/02-molecules/alert/_yds-alert.scss
+++ b/components/02-molecules/alert/_yds-alert.scss
@@ -42,7 +42,8 @@ $alert-fade-speed: var(--animation-speed-slow);
 .alert__inner {
   display: flex;
   align-items: flex-start;
-  padding-block: var(--size-spacing-5);
+  padding-block-start: var(--size-spacing-5);
+  padding-block-end: var(--size-spacing-5);
 
   @media (min-width: tokens.$break-mobile) {
     align-items: center;

--- a/components/02-molecules/banner/action/_yds-action-banner.scss
+++ b/components/02-molecules/banner/action/_yds-action-banner.scss
@@ -23,7 +23,8 @@ $break-cta-banner-max: $break-cta-banner - 0.05;
 .cta-banner__content-wrapper {
   position: relative;
   max-width: tokens.$break-max-width;
-  margin-inline: auto;
+  margin-inline-start: auto;
+  margin-inline-end: auto;
 
   @media (min-width: $break-cta-banner) {
     aspect-ratio: 16 / 5;

--- a/components/02-molecules/banner/action/_yds-action-banner.scss
+++ b/components/02-molecules/banner/action/_yds-action-banner.scss
@@ -27,6 +27,21 @@ $break-cta-banner-max: $break-cta-banner - 0.05;
 
   @media (min-width: $break-cta-banner) {
     aspect-ratio: 16 / 5;
+
+    // Safari 14 fix for aspect-ratio
+    @supports not (aspect-ratio: 16 / 5) {
+      &::before {
+        float: left;
+        padding-top: 26.25%;
+        content: '';
+      }
+
+      &::after {
+        display: block;
+        content: '';
+        clear: both;
+      }
+    }
   }
 
   [data-banner-content-layout='bottom'] & {
@@ -41,6 +56,21 @@ $break-cta-banner-max: $break-cta-banner - 0.05;
 .cta-banner__image {
   @media (max-width: $break-cta-banner - 0.05) {
     aspect-ratio: 16 / 5;
+
+    // Safari 14 fix for aspect-ratio
+    @supports not (aspect-ratio: 16 / 5) {
+      &::before {
+        float: left;
+        padding-top: 26.25%;
+        content: '';
+      }
+
+      &::after {
+        display: block;
+        content: '';
+        clear: both;
+      }
+    }
   }
 
   @media (min-width: $break-cta-banner) {
@@ -243,7 +273,8 @@ $break-cta-banner-max: $break-cta-banner - 0.05;
       flex-direction: row;
       justify-content: space-between;
       align-items: center;
-      padding-block: var(--size-spacing-5);
+      padding-block-start: var(--size-spacing-5);
+      padding-block-end: var(--size-spacing-5);
       min-height: auto;
       width: 100%;
       max-width: calc(1600px + 8rem);

--- a/components/02-molecules/callout/_yds-callout.scss
+++ b/components/02-molecules/callout/_yds-callout.scss
@@ -96,7 +96,8 @@ $global-callout-themes: map.deep-get(tokens.$tokens, 'global-themes');
   position: relative;
   padding-top: var(--size-spacing-8);
   padding-bottom: var(--size-spacing-9);
-  padding-inline: var(--size-spacing-7);
+  padding-inline-start: var(--size-spacing-7);
+  padding-inline-end: var(--size-spacing-7);
   flex: 1 1 50%;
   text-align: center;
 

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -66,6 +66,21 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
   @media (min-width: tokens.$break-mobile) {
     [data-collection-type='grid'] & {
       aspect-ratio: 3/2;
+
+      // Safari 14 fix for aspect-ratio
+      @supports not (aspect-ratio: 3 / 2) {
+        &::before {
+          float: left;
+          padding-top: 66.66%;
+          content: '';
+        }
+
+        &::after {
+          display: block;
+          content: '';
+          clear: both;
+        }
+      }
     }
 
     [data-collection-type='list'] & {

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -109,14 +109,16 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
   @media (min-width: tokens.$break-m) {
     [data-collection-type='list'][data-collection-featured='true'] & {
       flex: 1 0 50%;
-      margin-inline: auto;
+      margin-inline-start: auto;
+      margin-inline-end: auto;
     }
   }
 
   @media (min-width: tokens.$break-mobile) {
     [data-collection-type='list'][data-collection-featured='true'] & {
       flex: 0 1 71%;
-      margin-inline: auto;
+      margin-inline-start: auto;
+      margin-inline-end: auto;
     }
   }
 }

--- a/components/02-molecules/meta/event-meta/_yds-event-meta.scss
+++ b/components/02-molecules/meta/event-meta/_yds-event-meta.scss
@@ -3,7 +3,8 @@
 .event-meta__inner {
   > * {
     border-bottom: var(--border-thickness-1) solid var(--color-divider);
-    padding-block: var(--size-spacing-6);
+    padding-block-start: var(--size-spacing-6);
+    padding-block-end: var(--size-spacing-6);
   }
 }
 

--- a/components/02-molecules/quick-links/_yds-quick-links.scss
+++ b/components/02-molecules/quick-links/_yds-quick-links.scss
@@ -87,7 +87,8 @@ $component-quick-links-themes: map.deep-get(tokens.$tokens, 'component-themes');
   }
 
   [data-quick-links-variation='promotional'] & {
-    padding-block: var(--size-spacing-9);
+    padding-block-start: var(--size-spacing-9);
+    padding-block-end: var(--size-spacing-9);
   }
 
   [data-quick-links-layout='fluid'] & {

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -178,7 +178,8 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
 .tabs__container {
   position: absolute;
   width: 100%;
-  padding-block: var(--size-spacing-9);
+  padding-block-start: var(--size-spacing-9);
+  padding-block-end: var(--size-spacing-9);
 
   &:not(.is-active) {
     @include tokens.animate-hidden;

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -155,7 +155,8 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
 
   display: block;
   text-decoration: none;
-  padding-inline: var(--size-spacing-3);
+  padding-inline-start: var(--size-spacing-3);
+  padding-inline-end: var(--size-spacing-3);
   color: var(--color-gray-500);
 
   &:hover {

--- a/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
+++ b/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
@@ -19,7 +19,8 @@ $wrapped-image-offset-max: 1550px;
   }
 
   &[data-wrapped-image-style='offset'] {
-    padding-inline: 0;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
   }
 }
 

--- a/components/03-organisms/galleries/media-grid/_yds-media-grid-modal.scss
+++ b/components/03-organisms/galleries/media-grid/_yds-media-grid-modal.scss
@@ -58,7 +58,8 @@ $modal-speed: var(--animation-speed-slow);
 }
 
 .media-grid-modal__item {
-  padding-block: var(--size-spacing-site-gutter);
+  padding-block-start: var(--size-spacing-site-gutter);
+  padding-block-end: var(--size-spacing-site-gutter);
   width: 100%;
   height: 100%;
   overflow: auto;

--- a/components/03-organisms/galleries/media-grid/_yds-media-grid.scss
+++ b/components/03-organisms/galleries/media-grid/_yds-media-grid.scss
@@ -24,6 +24,23 @@
   display: flex;
   aspect-ratio: 3/2;
 
+  // Safari 14 fix for aspect-ratio
+  @supports not (aspect-ratio: 3 / 2) {
+    max-height: 200px;
+
+    &::before {
+      float: left;
+      padding-top: 66.66%;
+      content: '';
+    }
+
+    &::after {
+      display: block;
+      content: '';
+      clear: both;
+    }
+  }
+
   [data-media-grid-variation='interactive'] & {
     position: relative;
     background-color: var(--color-basic-black);
@@ -80,5 +97,39 @@
   svg {
     height: var(--size-icon);
     aspect-ratio: 1 / 1;
+
+    // Safari 14 fix for aspect-ratio
+    @supports not (aspect-ratio: 1 / 1) {
+      width: 1.5rem;
+      height: 1.5rem;
+      padding: var(--size-spacing-2);
+
+      &::before {
+        float: left;
+        padding-top: 100%;
+        content: '';
+      }
+
+      &::after {
+        display: block;
+        content: '';
+        clear: both;
+      }
+    }
+  }
+
+  // Safari 14 fix for aspect-ratio
+  @supports not (aspect-ratio: 1 / 1) {
+    &::before {
+      float: left;
+      padding-top: 100%;
+      content: '';
+    }
+
+    &::after {
+      display: block;
+      content: '';
+      clear: both;
+    }
   }
 }

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -32,7 +32,8 @@ $menu-sub-max-width: 19rem;
 
   @media (max-width: tokens.$break-mobile-max) {
     padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2);
-    margin-block: var(--size-spacing-3);
+    margin-block-start: var(--size-spacing-3);
+    margin-block-end: var(--size-spacing-3);
   }
 
   @media (min-width: tokens.$break-mobile) {

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -139,7 +139,8 @@ $global-site-themes: map.deep-get(tokens.$tokens, 'global-themes');
   padding: var(--size-spacing-4) var(--size-spacing-site-gutter);
   background-color: var(--color-background);
   border-bottom: var(--site-header-border-bottom);
-  margin-inline: calc(var(--size-spacing-site-gutter) * -1);
+  margin-inline-start: calc(var(--size-spacing-site-gutter) * -1);
+  margin-inline-end: calc(var(--size-spacing-site-gutter) * -1);
 
   @media (min-width: tokens.$break-mobile) {
     display: none;


### PR DESCRIPTION
## [YALB-1247: Bug: Safari hairline divider visibility issues](https://yaleits.atlassian.net/browse/YALB-1247) | [YALB-1320: Bug: Safari - Tab goes into banner](https://yaleits.atlassian.net/browse/YALB-1320) | [YALB-1323: Bug: Safari Gallery padding and expand button](https://yaleits.atlassian.net/browse/YALB-1323) | [YALB-1345: Bug: Padding for pagination (safari?) ](https://yaleits.atlassian.net/browse/YALB-1345)

### Description of work
- Fixes Safari 14.1 issues: 
  - `aspect-ratio` doesn't work in Safari 14.1 | https://caniuse.com/?search=aspect-ratio
    - Solution: apply conditional top-padding which equals the aspect-ratio 
  - `margin-block` is supposed to work in Safari 14.1, but it wasn't working | https://caniuse.com/?search=margin-block
    - Solution: use `margin-block-start` and `margin-block-end`
    - this simply replaces a less supported short-hand of the same properties with its long-hand version
  - `margin-inline` is supposed to work in Safari 14.1, but it wasn't working | https://caniuse.com/?search=margin-inline
    - Solution: use `margin-inline-start` and `margin-inline-end`
    - this simply replaces a less supported short-hand of the same properties with its long-hand version
  - `padding-block` doesn't work in Safari 14.1  | https://caniuse.com/?search=padding-block
    - Solution: use `padding-block-start` and `padding-block-end` 
      - this simply replaces a less supported short-hand of the same properties with its long-hand version
  - `padding-inline` doesn't work in Safari 14.1  | https://caniuse.com/?search=padding-inline
    - Solution: use `padding-inline-start` and `padding-inline-end` 
      - this simply replaces a less supported short-hand of the same properties with its long-hand version
      
### Testing Link(s)
Testing here, but only for the multidev: https://github.com/yalesites-org/yalesites-project/pull/339
- [ ] Using https://www.browserstack.com/users/sign_in
  - [ ] Select Mac OS: `Big Sur`
  - [ ] Safari 14.1 (the latest for that OS version)

![Screenshot-20230711132946-1709x1012](https://github.com/yalesites-org/component-library-twig/assets/366413/59a1ec79-f01f-4a35-85ad-3377f82f88e0)

- [ ] **NOTE**: The multidev does not have the most up-to-date `atomic` changes to the block templates. On the multidev, each component still has a wrapping `<div>` element, so the no top space and no bottom space rules aren't applying. This does work locally on `develop` of `atomic`. 

---
- [ ] Compare the following page URL in  browserstack with the same page outside of Browserstack (in your modern browser) 
- [ ] URL to test: https://pr-339-yalesites-platform.pantheonsite.io/components
- [ ] Verify there is spacing between components on the page (general spacing issue)
- [ ] Verify the media gallery renders similarly to modern browsers
- [ ] Verify the banner renders similarly to modern browsers
- [ ] Verify the tabs under the banner render properly 
- [ ] Verify the video component renders the full video embed 

https://github.com/yalesites-org/component-library-twig/assets/366413/cce88b44-9b71-45a5-9d03-925ba646ac19

---

- [ ] This ticket YALB-1345: Bug: Padding for pagination (safari?)  was a spacing issue caused by the `margin-block` fixes noted in the description above. Pagination doesn't seem to be working on the multidev, but works locally. Likely an `atomic` change that isn't included on the multidev (like my note above). 
  - This is my local
  
![Screenshot-20230711141318-1181x962](https://github.com/yalesites-org/component-library-twig/assets/366413/bf5e70a2-83a4-4b81-9084-f55cf4413d36)


---
### Storybook only fix for `divider` component
- [ ] Visit the divider component in Storybook. https://deploy-preview-265--dev-component-library-twig.netlify.app/?path=/story/atoms-divider--dividers
   - [ ] Verify that you can see `hairline` weights in the playground section. Note: this was a rendering issue in all browsers, not just Safari. The issue only affects Storybook and likely has something to do with browser resizing and its ability to render such a faint line. This is my best guess, anyway. If you add several divider components next to one another in Drupal, they render fine. 

![Screenshot-20230711135213-2555x1371](https://github.com/yalesites-org/component-library-twig/assets/366413/62c15e38-39cd-4bc1-97d3-526254582c44)


![Screenshot-20230711135312-2082x1280](https://github.com/yalesites-org/component-library-twig/assets/366413/7a2f9a80-116c-491b-9c1c-ff95f08006ea)

