### PR TITLE
YALB-1297: Media: Verify images are using optimized styles

### DIFF
--- a/components/03-organisms/galleries/media-grid/_yds-media-grid.scss
+++ b/components/03-organisms/galleries/media-grid/_yds-media-grid.scss
@@ -57,14 +57,7 @@
 
   overflow: hidden;
   opacity: 1;
-
-  [data-component-width='content'] & {
-    width: 100%;
-
-    img {
-      width: 100%;
-    }
-  }
+  width: 100%;
 
   [data-media-grid-variation='interactive'] &:focus-visible,
   [data-media-grid-variation='interactive'] .media-grid__item:hover & {


### PR DESCRIPTION
## [YALB-1297: Media: Verify images are using optimized styles](https://yaleits.atlassian.net/browse/YALB-1297)

### Description of work
- Adds `width:100%` to `media-grid__image` so that the image fills its parent's width at in-between responsive image sizes

### Testing Link(s)
- [ ] Test in main repository here: https://github.com/yalesites-org/yalesites-project/pull/351

### Functional Review Steps
- [ ] Test in main repository here: https://github.com/yalesites-org/yalesites-project/pull/351
 

