### PR TITLE
YALB-1445: Accordion collapse and expand features; ARIA state addition

### DIFF
--- a/components/02-molecules/accordion/_yds-accordion.scss
+++ b/components/02-molecules/accordion/_yds-accordion.scss
@@ -31,6 +31,15 @@
   }
 }
 
+.accordion__icon {
+  height: 1em;
+  width: 1em;
+
+  .accordion__toggle-all--collapse & {
+    transform: rotate(180deg);
+  }
+}
+
 .accordion__toggle-all {
   @include tokens.body-s;
   @include atoms.button-reset;
@@ -42,13 +51,8 @@
   &:hover {
     color: var(--color-link-base);
   }
-}
 
-.accordion__icon {
-  height: 1em;
-  width: 1em;
-
-  .accordion__toggle-all--collapse & {
+  &[aria-expanded='true'] .accordion__icon {
     transform: rotate(180deg);
   }
 }

--- a/components/02-molecules/accordion/_yds-accordion.scss
+++ b/components/02-molecules/accordion/_yds-accordion.scss
@@ -34,10 +34,6 @@
 .accordion__icon {
   height: 1em;
   width: 1em;
-
-  .accordion__toggle-all--collapse & {
-    transform: rotate(180deg);
-  }
 }
 
 .accordion__toggle-all {

--- a/components/02-molecules/accordion/accordion.stories.js
+++ b/components/02-molecules/accordion/accordion.stories.js
@@ -23,20 +23,37 @@ export default {
   },
 };
 
-export const Accordion = ({ heading, content }) =>
-  accordionTwig({
-    accordion__items: [
-      {
-        accordion__item__heading: heading,
-        accordion__item__content: content,
-      },
-      {
-        accordion__item__heading: accordionData.accordion__item__heading,
-        accordion__item__content: accordionData.accordion__item__content,
-      },
-      {
-        accordion__item__heading: accordionData.accordion__item__heading,
-        accordion__item__content: accordionData.accordion__item__content,
-      },
-    ],
-  });
+export const Accordion = ({ heading, content }) => {
+  return `
+  <h2>With multiple items</h2>
+  <div>
+    ${accordionTwig({
+      accordion__items: [
+        {
+          accordion__item__heading: heading,
+          accordion__item__content: content,
+        },
+        {
+          accordion__item__heading: accordionData.accordion__item__heading,
+          accordion__item__content: accordionData.accordion__item__content,
+        },
+        {
+          accordion__item__heading: accordionData.accordion__item__heading,
+          accordion__item__content: accordionData.accordion__item__content,
+        },
+      ],
+    })}
+  </div>
+  <h2>With one item</h2>
+  <div>
+    ${accordionTwig({
+      accordion__items: [
+        {
+          accordion__item__heading: heading,
+          accordion__item__content: content,
+        },
+      ],
+    })}
+  </div>
+    `;
+};

--- a/components/02-molecules/accordion/yds-accordion.js
+++ b/components/02-molecules/accordion/yds-accordion.js
@@ -4,11 +4,11 @@ Drupal.behaviors.accordion = {
     const items = context.querySelectorAll('.accordion-item');
     const controls = context.querySelectorAll('.accordion__controls');
     // Classes
-    const itemToggle = '.accordion-item__toggle';
     const itemContent = '.accordion-item__content';
     const itemState = 'data-accordion-expanded';
+    const itemToggle = '.accordion-item__toggle';
+    // States
     const buttonState = 'aria-expanded';
-    const buttonPressed = 'aria-pressed';
 
     // Function to expand an accordion item.
     const expand = (item) => {
@@ -21,7 +21,6 @@ Drupal.behaviors.accordion = {
       );
       item.setAttribute(itemState, 'true');
       toggle.setAttribute(buttonState, 'true');
-      toggle.setAttribute(buttonPressed, 'true');
     };
 
     // Function to collapse an accordion item.
@@ -30,7 +29,36 @@ Drupal.behaviors.accordion = {
 
       item.setAttribute(itemState, 'false');
       toggle.setAttribute(buttonState, 'false');
-      toggle.setAttribute(buttonPressed, 'false');
+    };
+
+    // Tels if the expand/collapse button is expanded
+    const isButtonExpanded = (element) => {
+      const value = element.getAttribute(buttonState);
+
+      return value === 'true';
+    };
+
+    // Replaces the first word of a string with Collapse or Expand
+    // based on the state given (true or false)
+    const replaceCollapseOrExpand = (original, state) => {
+      const firstWordOptions = {
+        true: 'Collapse',
+        false: 'Expand',
+      };
+
+      // Capture the first word of a string
+      const firstWord = /^[^\s]+/;
+
+      return original.replace(firstWord, firstWordOptions[state]);
+    };
+
+    // Replaces text and aria for the toggle all button
+    const getNewToggleValue = (button) => {
+      const initialValue = isButtonExpanded(button);
+      const newValue = !initialValue;
+
+      // Return the new value so that other things can happen
+      return newValue;
     };
 
     // Hide all accordion content sections if JavaScript is enabled.
@@ -55,11 +83,16 @@ Drupal.behaviors.accordion = {
       const allItems = control.parentNode.querySelectorAll('.accordion-item');
       // Add click listener on the parent <ul>
       control.addEventListener('click', (e) => {
-        // Determine which control was activated. `action` will re turn a
-        // boolean. `true` if the expand control was clicked, otherwise false.
-        const action = e.target.classList.contains(
-          'accordion__toggle-all--expand',
+        const action = getNewToggleValue(e.target);
+        const targetButton = e.target;
+
+        // Replace first word with expand or collapse message
+        targetButton.innerHTML = replaceCollapseOrExpand(
+          targetButton.innerHTML,
+          action,
         );
+        // Set the button state so that arrows and actions take place
+        targetButton.setAttribute(buttonState, action);
 
         // Iterate over
         allItems.forEach((item) => {

--- a/components/02-molecules/accordion/yds-accordion.js
+++ b/components/02-molecules/accordion/yds-accordion.js
@@ -180,8 +180,8 @@ Drupal.behaviors.accordion = {
     const hideToggleIfOneItem = (parentUl, allItems) => {
       if (hasMoreThanOneItem(allItems)) return;
 
-      const button = parentUl.querySelector(accordionToggleAll);
-      button.style.display = 'none';
+      const ul = parentUl;
+      ul.style.display = 'none';
     };
 
     // Traverses each control to hide toggles with one item

--- a/components/02-molecules/accordion/yds-accordion.js
+++ b/components/02-molecules/accordion/yds-accordion.js
@@ -8,6 +8,7 @@ Drupal.behaviors.accordion = {
     const itemContent = '.accordion-item__content';
     const itemState = 'data-accordion-expanded';
     const buttonState = 'aria-expanded';
+    const buttonPressed = 'aria-pressed';
 
     // Function to expand an accordion item.
     const expand = (item) => {
@@ -20,6 +21,7 @@ Drupal.behaviors.accordion = {
       );
       item.setAttribute(itemState, 'true');
       toggle.setAttribute(buttonState, 'true');
+      toggle.setAttribute(buttonPressed, 'true');
     };
 
     // Function to collapse an accordion item.
@@ -28,6 +30,7 @@ Drupal.behaviors.accordion = {
 
       item.setAttribute(itemState, 'false');
       toggle.setAttribute(buttonState, 'false');
+      toggle.setAttribute(buttonPressed, 'false');
     };
 
     // Hide all accordion content sections if JavaScript is enabled.

--- a/components/02-molecules/accordion/yds-accordion.js
+++ b/components/02-molecules/accordion/yds-accordion.js
@@ -184,11 +184,27 @@ Drupal.behaviors.accordion = {
       ul.style.display = 'none';
     };
 
+    // Display the toggle button
+    const showToggleButton = (ul) => {
+      const control = ul;
+      control.style.display = '';
+    };
+
+    // Show accordion controls if JavaScript is enabled
+    const hideOrShowToggleButtons = (ul, allItems) => {
+      if (hasMoreThanOneItem(allItems)) {
+        showToggleButton(ul);
+      } else {
+        hideToggleIfOneItem(ul, allItems);
+      }
+    };
+
     // Traverses each control to hide toggles with one item
     const hideSingleItemToggles = (allControls) => {
       allControls.forEach((parentUl) => {
         const allItems = findAllItems(parentUl.parentNode);
-        hideToggleIfOneItem(parentUl, allItems);
+        // hideToggleIfOneItem(parentUl, allItems);
+        hideOrShowToggleButtons(parentUl, allItems);
       });
     };
 

--- a/components/02-molecules/accordion/yds-accordion.js
+++ b/components/02-molecules/accordion/yds-accordion.js
@@ -7,8 +7,14 @@ Drupal.behaviors.accordion = {
     const itemContent = '.accordion-item__content';
     const itemState = 'data-accordion-expanded';
     const itemToggle = '.accordion-item__toggle';
+    const accordion = '.accordion';
+    const accordionControls = '.accordion__controls';
+    const accordionToggleAll = '.accordion__toggle-all';
+    const accordionItem = '.accordion-item';
     // States
     const buttonState = 'aria-expanded';
+    const collapseText = 'Collapse';
+    const expandText = 'Expand';
 
     // Function to expand an accordion item.
     const expand = (item) => {
@@ -31,34 +37,121 @@ Drupal.behaviors.accordion = {
       toggle.setAttribute(buttonState, 'false');
     };
 
-    // Tels if the expand/collapse button is expanded
+    // Tests if a value starts with a set of text
+    const alreadyStartsWith = (value, startsWith) => {
+      return value.startsWith(startsWith);
+    };
+
+    // Replaces the first word of a string with Collapse or Expand
+    // based on the state given (true or false)
+    const replaceFirstWord = (original, revised) => {
+      // Capture the first word of a string
+      const firstWord = /^[^\s]+/;
+
+      return original.replace(firstWord, revised);
+    };
+
+    // Updates the button text and aria-exparnded state
+    const updateToggleButtonToCollapse = (element) => {
+      const button = element;
+
+      // Do not update if the beginning of the button's innerHTML
+      // starts with Collapse
+      if (alreadyStartsWith(button.innerHTML, collapseText)) return;
+
+      button.innerHTML = replaceFirstWord(button.innerHTML, collapseText);
+
+      // Set the button state so that arrows and actions take place
+      button.setAttribute(buttonState, true);
+    };
+
+    // Update the toggle button to expand text
+    const updateToggleButtonToExpand = (element) => {
+      const button = element;
+
+      // Do not update if the beginning of the button's innerHTML
+      // starts with Collapse
+      if (alreadyStartsWith(button.innerHTML, expandText)) return;
+
+      button.innerHTML = replaceFirstWord(button.innerHTML, expandText);
+
+      // Set the button state so that arrows and actions take place
+      button.setAttribute(buttonState, false);
+    };
+
+    // Returns the number of expanded items
+    const expandedItemCount = (allItems) => {
+      const itemsToEvaluate = allItems || [];
+
+      return Array.from(itemsToEvaluate).filter((item) => {
+        return item.getAttribute(itemState) === 'true';
+      }).length;
+    };
+
+    // Tests if all of the items have been expanded
+    const allItemsExpanded = (allItems) => {
+      const unevalutedItems = allItems || [];
+
+      return expandedItemCount(unevalutedItems) === unevalutedItems.length;
+    };
+
+    // Finds all items in a context
+    const findAllItems = (domContext) => {
+      return domContext.querySelectorAll(accordionItem);
+    };
+
+    // Finds the closest accordion from an item
+    const findClosestAccordion = (item) => item.closest(accordion);
+    // Finds the closest accordion controls from an item
+    const findClosestAccordionControls = (item) =>
+      findClosestAccordion(item).querySelector(accordionControls);
+    // Finds the closest toggle button from an item
+    const findClosestToggleButton = (item) =>
+      findClosestAccordionControls(item).querySelector(accordionToggleAll);
+
+    // Finds the toggler from an item
+    const findTogglerFromItem = (item) => {
+      return findClosestToggleButton(item);
+    };
+
+    // Tells if the expand/collapse button is expanded
     const isButtonExpanded = (element) => {
       const value = element.getAttribute(buttonState);
 
       return value === 'true';
     };
 
-    // Replaces the first word of a string with Collapse or Expand
-    // based on the state given (true or false)
-    const replaceCollapseOrExpand = (original, state) => {
-      const firstWordOptions = {
-        true: 'Collapse',
-        false: 'Expand',
-      };
-
-      // Capture the first word of a string
-      const firstWord = /^[^\s]+/;
-
-      return original.replace(firstWord, firstWordOptions[state]);
+    // Tests if a list of items is empty
+    const isEmpty = (itemsList) => {
+      return itemsList.length === 0;
     };
 
-    // Replaces text and aria for the toggle all button
-    const getNewToggleValue = (button) => {
-      const initialValue = isButtonExpanded(button);
-      const newValue = !initialValue;
+    // Tests if an item is expanded
+    const isExpanded = (item) => item.getAttribute(buttonState) === 'true';
 
-      // Return the new value so that other things can happen
-      return newValue;
+    // Given a list of items, run a state function on each item
+    // Currently, it's recommended to use one of the following:
+    //   collapse
+    //   expand
+    const setAllItemStates = (allItems, stateFn) => {
+      allItems.forEach((item) => stateFn(item));
+    };
+
+    // Toggles an item's state to match the toggler
+    const toggleItemState = (toggler, item) =>
+      isExpanded(toggler) ? collapse(item) : expand(item);
+
+    // Check if all of the items have been expanded or collapsed
+    const updateToggleButtonState = (allItems) => {
+      if (isEmpty(allItems)) return;
+
+      const toggler = findTogglerFromItem(allItems[0]);
+
+      if (allItemsExpanded(allItems)) {
+        updateToggleButtonToCollapse(toggler);
+      } else {
+        updateToggleButtonToExpand(toggler);
+      }
     };
 
     // Hide all accordion content sections if JavaScript is enabled.
@@ -69,39 +162,27 @@ Drupal.behaviors.accordion = {
     // Toggle accordion content when toggle is activated.
     items.forEach((item) => {
       const toggle = item.querySelector(itemToggle);
+      const otherAccordionItems =
+        findClosestAccordion(item).querySelectorAll(accordionItem);
 
       toggle.addEventListener('click', () => {
-        // Toggle the item's state.
-        return toggle.getAttribute(buttonState) === 'true'
-          ? collapse(item)
-          : expand(item);
+        toggleItemState(toggle, item);
+        updateToggleButtonState(otherAccordionItems);
       });
     });
 
-    controls.forEach((control) => {
+    controls.forEach((parentUl) => {
       // Get all items relevant to the control.
-      const allItems = control.parentNode.querySelectorAll('.accordion-item');
+      const allItems = findAllItems(parentUl.parentNode);
       // Add click listener on the parent <ul>
-      control.addEventListener('click', (e) => {
-        const action = getNewToggleValue(e.target);
-        const targetButton = e.target;
-
-        // Replace first word with expand or collapse message
-        targetButton.innerHTML = replaceCollapseOrExpand(
-          targetButton.innerHTML,
-          action,
-        );
-        // Set the button state so that arrows and actions take place
-        targetButton.setAttribute(buttonState, action);
-
-        // Iterate over
-        allItems.forEach((item) => {
-          if (action === false) {
-            collapse(item);
-          } else {
-            expand(item);
-          }
-        });
+      parentUl.addEventListener('click', (e) => {
+        if (isButtonExpanded(e.target)) {
+          updateToggleButtonToExpand(e.target);
+          setAllItemStates(allItems, collapse);
+        } else {
+          updateToggleButtonToCollapse(e.target);
+          setAllItemStates(allItems, expand);
+        }
       });
     });
   },

--- a/components/02-molecules/accordion/yds-accordion.twig
+++ b/components/02-molecules/accordion/yds-accordion.twig
@@ -8,7 +8,7 @@
 
 {% set accordion__base_class = 'accordion' %}
 
-{% set expand_all__content -%}
+{% set toggle_all__content -%}
   Expand All
   {% include "@atoms/images/icons/_yds-icon.twig" with {
     icon__name: 'angle-down',
@@ -16,13 +16,9 @@
   } %}
 {% endset %}
 
-{% set collapse_all__content -%}
-  Collapse All
-  {% include "@atoms/images/icons/_yds-icon.twig" with {
-    icon__name: 'angle-down',
-    icon__blockname: accordion__base_class,
-  } %}
-{% endset %}
+{% set control__attributes = {
+  'aria-expanded': 'false'
+} %}
 
 {% set accordion__attibutes = {
   'data-component-width': accordion__width|default('content'),
@@ -50,20 +46,10 @@
         {% embed "@atoms/lists/_yds-list-item.twig" %}
           {% block list__item__content %}
             {% include "@atoms/controls/base/yds-control.twig" with {
-              control__content: expand_all__content,
+              control__content: toggle_all__content,
               control__base_class: 'toggle-all',
-              control__modifiers: ['expand'],
               control__blockname: accordion__base_class,
-            } %}
-          {% endblock %}
-        {% endembed %}
-        {% embed "@atoms/lists/_yds-list-item.twig" %}
-          {% block list__item__content %}
-            {% include "@atoms/controls/base/yds-control.twig" with {
-              control__content: collapse_all__content,
-              control__base_class: 'toggle-all',
-              control__modifiers: ['collapse'],
-              control__blockname: accordion__base_class,
+              control__attributes: control__attributes,
             } %}
           {% endblock %}
         {% endembed %}

--- a/components/02-molecules/accordion/yds-accordion.twig
+++ b/components/02-molecules/accordion/yds-accordion.twig
@@ -26,6 +26,11 @@
   class: bem(accordion__base_class, accordion__modifiers),
 } %}
 
+{% set section_controls__attributes = {
+  'style': 'display: none',
+  'aria-label': 'Section controls'
+} %}
+
 <div {{ add_attributes(accordion__attibutes) }} data-embedded-components>
   {% block prefix_suffix %}
   {% endblock %}
@@ -40,7 +45,7 @@
     {% embed "@atoms/lists/yds-list.twig" with {
       list__base_class: 'controls',
       list__blockname: accordion__base_class,
-      list__attributes: {'aria-label': 'Section controls'},
+      list__attributes: section_controls__attributes,
     } %}
       {% block list__content %}
         {% embed "@atoms/lists/_yds-list-item.twig" %}


### PR DESCRIPTION
## [YALB-1445: Accordion collapse and expand features](https://yaleits.atlassian.net/browse/YALB-1445)
## [YALB-1395: Bug: Accessibility (FE)- Accordion controls need ARIA state added](https://yaleits.atlassian.net/browse/YALB-1395)

### Description of work
- Add aria-expanded to toggleAll buttons
- Set initial aria-expanded state on toggleAll button
- Transform the "Expand all" and "Collapse all" to one toggle button
  - Replace the first word to Expand or Collapse depending on the current state
  - Add css to rotate the icon for visual toggle
  - Change "Expand All" to "Collapse All" when all items are manually expanded
    - If one or more are not expanded, it will default to "Expand all" unless ALL are expanded
    - If all are expanded manually, the toggle will change to "Collapse All"
- Refactor to hopefully better convey what it is doing through method names

### Testing Link(s)
- [ ] Navigate to the [Accordion Component Story](https://deploy-preview-271--dev-component-library-twig.netlify.app/?path=/story/molecules-accordion--accordion)

### Functional Review Steps

#### For accordion with multiple items
- [x] Verify that all items are collapsed
- [x] Verify that the initial toggle state is set to "Expand All"
- [x] Verify that the arrow/carrot next to "Expand All" is facing down (the same as the subitems)
- [x] Click "Expand All"
  - [x] Verify that all items expand
  - [x] Verify that all arrows/carrots are now facing up
  - [x] Verify that the toggle button that was "Expand All" has changed state to "Collapse All"
- [x] Click "Collapse All"
  - [x] Verify that all items collapse
  - [x] Verify that all arrows/carrots are now facing down
  - [x] Verify that the toggle button that was "Collapse All" has changed state to "Expand All"
- [x] Click "Expand All"
  - [ ] Verify that toggle button that was "Expand All" now says "Collapse All"
- [x] Click any one of the subitems of that group to expand it
  - [x] Verify that the toggle button that was "Collapse All" now says "Expand All" since not all are expanded
  - [x] Verify that the arrow/carrot next to "Expand All" is pointing down
- [x] Click "Collapse All"
- [x] Click each collapsed subitem to expand all items
  - [x] Verify that the toggle button that was "Expand All" now says "Collapse All" after the last item is expanded
- [x] Click "Collapse All"
  - [x] Verify that all items collapse
  - [x] Verify that toggle button that was "Collapse All" now says "Expand All"

#### For accordion with one item
- [x] Verify that there is no toggle button
- [x] Verify that you can expand/collapse the item

### Accessibility Review
- [x] Verify that aria-expanded is properly represented in different states for each item, and for the toggle button.
- [x] Verify that when not all items are expanded, that it is acceptable that the aria-expanded on the toggle is false (since they're not all expanded)
