### PR TITLE
YALB-1135: Allow title to display as visually hidden

### DIFF
--- a/components/02-molecules/page-title/yds-page-title.twig
+++ b/components/02-molecules/page-title/yds-page-title.twig
@@ -3,6 +3,7 @@
  # - page_title__heading
  # - page_title__prefix
  # - page_title__meta (optional. Will fill in the `basic-meta` meta type.)
+ # - page_title__display (optional. 'display', 'hidden', or 'visually-hidden')
  #
  # Available Blocks
  # - page_title__meta
@@ -15,21 +16,23 @@
   class: bem(page_title__base_class, [], page_title__blockname, page_title__additional_classes),
 } %}
 
-<div {{ add_attributes(page_title__attributes) }}>
-  <div {{ bem('inner', [], page_title__base_class) }}>
-    {% include "@atoms/typography/headings/yds-heading.twig" with {
-      heading__level: '1',
-      heading: page_title__heading,
-      heading__blockname: page_title__base_class,
-      heading__prefix: page_title__prefix,
-      heading__prefix__base_class: page_title__base_class,
-    } %}
-    {% block page_title__meta %}
-      {% if page_title__meta %}
-        {% include "@molecules/meta/basic-meta/yds-basic-meta.twig" with {
-          basic_meta: page_title__meta,
-        } %}
-      {% endif %}
-    {% endblock %}
+{% if 'hidden' not in [page_title__display] %}
+  <div {{ add_attributes(page_title__attributes) }}>
+    <div {{ bem('inner', [], page_title__base_class) }}>
+      {% include "@atoms/typography/headings/yds-heading.twig" with {
+        heading__level: '1',
+        heading: page_title__heading,
+        heading__blockname: page_title__base_class,
+        heading__prefix: page_title__prefix,
+        heading__prefix__base_class: page_title__base_class,
+      } %}
+      {% block page_title__meta %}
+        {% if page_title__meta %}
+          {% include "@molecules/meta/basic-meta/yds-basic-meta.twig" with {
+            basic_meta: page_title__meta,
+          } %}
+        {% endif %}
+      {% endblock %}
+    </div>
   </div>
-</div>
+{% endif %}


### PR DESCRIPTION
## [YALB-1135: Allow title to display as visually hidden](https://yaleits.atlassian.net/browse/YALB-1135)

### Description of work
- Add a 'page_title__display' variable to the page title to switch the display between: 'display', 'hidden', or 'visually-hidden'.
  - Display: renders the same code as before without a perceivable change.
  - Hidden: No longer renders the page title block.
  - Visually Hidden: Adds the class to the block to visually hide using preexisting styles.

### Functional Review Steps
- This is tested in the cooresponding upstream PR.