### PR TITLE
YALB-1388 - Feedback: Embed Block | YALB-1390 - Remove transparency from banner overlay | YALB-1417 - Bug: Block picker in Posts and Events only have 2 columns compared to 3 on Pages | YALB-1463 - Bug: Content Spotlight Border severely impacts use/placement of Block | YALB-858 - Feedback: Site Name looks too small on mobile

### DIFF
--- a/components/02-molecules/banner/action/_yds-action-banner.scss
+++ b/components/02-molecules/banner/action/_yds-action-banner.scss
@@ -186,7 +186,10 @@ $break-cta-banner-max: $break-cta-banner - 0.05;
     width: 100%;
     content: '';
     background-color: var(--color-banner-background);
-    opacity: 0.85;
+
+    @media (min-width: $break-cta-banner) {
+      opacity: 0.85;
+    }
 
     [data-banner-content-layout='left'] &,
     [data-banner-content-layout='right'] & {

--- a/components/02-molecules/text-with-image/_yds-text-with-image.scss
+++ b/components/02-molecules/text-with-image/_yds-text-with-image.scss
@@ -32,17 +32,6 @@
       grid-template-columns: 5fr 3fr;
     }
   }
-
-  // add bottom border and bottom padding if text with image isn't the last element
-  // on the page.
-  .text-with-image:not(:last-of-type) & {
-    padding-bottom: var(--size-spacing-5);
-    border-bottom: var(--thickness-divider) solid var(--color-divider);
-
-    @media (min-width: tokens.$break-mobile) {
-      padding-bottom: var(--size-spacing-10);
-    }
-  }
 }
 
 .text-with-image__image {

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -16,6 +16,12 @@ $global-site-themes: map.deep-get(tokens.$tokens, 'global-themes');
   color: var(--color-site-header-yale-branding);
 }
 
+// Department/site name on mobile
+@mixin branding-small-mobile {
+  font: var(--font-style-branding-site-mobile);
+  color: var(--color-site-header-yale-branding);
+}
+
 .site-header {
   // prettier-ignore
   --site-header-border-bottom: var(--site-header-border-thickness) solid var(--color-site-header-border-color);
@@ -258,13 +264,17 @@ $global-site-themes: map.deep-get(tokens.$tokens, 'global-themes');
     }
   }
 
-  &--mobile {
-    @include branding-small;
+  // if right alignment, limit the branding width
+  @media (min-width: tokens.$break-mobile) {
+    [data-site-header-nav-position='right'] & {
+      max-width: 36.5%;
+    }
   }
 
-  // if right alignment, limit the branding width
-  [data-site-header-nav-position='right'] & {
-    max-width: 36.5%;
+  &--mobile {
+    @include branding-small-mobile;
+
+    max-width: 80%;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6491,9 +6491,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.21.6",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.21.6/77f1116b7115a2b24a3377b2bfb6a08406eab565",
-      "integrity": "sha512-iBtmynBLCh71OU+vX7VGx8LtcUf8TbjEGTvvv4vOdNYg8yG1fw9ivcigjILcAN9h7lSQdr6h3QAdVJRPsJYyOg=="
+      "version": "1.21.7",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.21.7/af1fdd09989d7979e4b49ba5df65edd5168d0d15",
+      "integrity": "sha512-WStxR6uZTt6h+959gxl+6lcn6Kkfct25kxz+ebss0AwSDdAo8xLV2W1y2j05iSMg5vSMcCd1/BnURrPkdK2XoA=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -35927,9 +35927,9 @@
       "requires": {}
     },
     "@yalesites-org/tokens": {
-      "version": "1.21.6",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.21.6/77f1116b7115a2b24a3377b2bfb6a08406eab565",
-      "integrity": "sha512-iBtmynBLCh71OU+vX7VGx8LtcUf8TbjEGTvvv4vOdNYg8yG1fw9ivcigjILcAN9h7lSQdr6h3QAdVJRPsJYyOg=="
+      "version": "1.21.7",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.21.7/af1fdd09989d7979e4b49ba5df65edd5168d0d15",
+      "integrity": "sha512-WStxR6uZTt6h+959gxl+6lcn6Kkfct25kxz+ebss0AwSDdAo8xLV2W1y2j05iSMg5vSMcCd1/BnURrPkdK2XoA=="
     },
     "accepts": {
       "version": "1.3.8",


### PR DESCRIPTION
## [YALB-1388 - Feedback: Embed Block](https://yaleits.atlassian.net/browse/YALB-1388) | [YALB-1390 - Remove transparency from banner overlay](https://yaleits.atlassian.net/browse/YALB-1390) |  [YALB-1417 - Bug: Block picker in Posts and Events only have 2 columns compared to 3 on Pages](https://yaleits.atlassian.net/browse/YALB-1417) | [YALB-1463 - Bug: Content Spotlight Border severely impacts use/placement of Block](https://yaleits.atlassian.net/browse/YALB-1463) | [YALB-858 - Feedback: Site Name looks too small on mobile](https://yaleits.atlassian.net/browse/YALB-858)

### Description of work
- yalb-1388 - Includes `embed__width` in the Embed layout-builder template (Atomic)
- yalb-1390 - Restricts opacity on content background to only when the background appears on top of the image.
- yalb-1417 - in progress
- yalb-1463 - removes bottom-border from Content Spotlight

### Testing Link(s)
- Storybook: https://deploy-preview-276--dev-component-library-twig.netlify.app/
- Drupal: 

### Functional Review Steps

#### Testing: [YALB-1388 - Feedback: Embed Block](https://yaleits.atlassian.net/browse/YALB-1388)
- [x] In Drupal, verify the Embed blocks on `post` and `event` content is limited to the narrower content region, in line with other content on the page
- [x] View the test page here: https://pr-365-yalesites-platform.pantheonsite.io/posts/2023-06-16-sdasdasdasdsdaasd
- [x] Verify each embed is "centered" / restricted to the content width boundaries. 

https://github.com/yalesites-org/component-library-twig/assets/366413/4fdfc608-a22a-4e71-b96f-21aa34b623fc


---

#### Testing: [YALB-1390 - Remove transparency from banner overlay](https://yaleits.atlassian.net/browse/YALB-1390) 
- [x] In Storybook, navigate to: https://deploy-preview-276--dev-component-library-twig.netlify.app/?path=/story/molecules-banners--action-banner
- [x] Verify at desktop sizes, the content background color renders with 85% opacity
- [x] Verify at smaller mobile sizes, the content background color renders with 100% opacity.


https://github.com/yalesites-org/component-library-twig/assets/366413/72019bd9-b8db-4f4a-ac52-8dd74b8c536c

---

#### Testing:  [YALB-1417 - Bug: Block picker in Posts and Events only have 2 columns compared to 3 on Pages](https://yaleits.atlassian.net/browse/YALB-1417)

- [x] Login to the multidev (https://pr-365-yalesites-platform.pantheonsite.io) and edit this Post (same as first node we tested above): https://pr-365-yalesites-platform.pantheonsite.io/node/76/layout
- [x] Add a block to one of the existing sections and verify it renders the grid of components in 3-columns
- [x] Edit an Event and make sure, it, too, renders 3-columns of components 

![Screenshot-20230727141030-1892x1330](https://github.com/yalesites-org/component-library-twig/assets/366413/8cdad79a-c99e-4dc0-abda-c9776d3d498a)


---

#### Testing: [YALB-1463 - Bug: Content Spotlight Border severely impacts use/placement of Block](https://yaleits.atlassian.net/browse/YALB-1463)

- [x] In Storybook, navigate to https://deploy-preview-276--dev-component-library-twig.netlify.app/?path=/story/page-examples-standard-pages--basic
- [x] You can test on the multidev, too : https://pr-365-yalesites-platform.pantheonsite.io/kitchen-sink/kitchen-sink-homepage (see  Content Spotlight Number Two" section)
- [x] Scroll to the section shown in the screenshare below, verify there is no longer a bottom border. Compare to production: https://yalesites-org.github.io/component-library-twig/?path=/story/page-examples-standard-pages--basic


https://github.com/yalesites-org/component-library-twig/assets/366413/ac855408-0ca3-402e-b566-488d978dcb1d


---
#### Testing:  [YALB-858 - Feedback: Site Name looks too small on mobile](https://yaleits.atlassian.net/browse/YALB-858)
- [x] In Storybook, navigate to: https://deploy-preview-276--dev-component-library-twig.netlify.app/?path=/story/page-examples-post--post-article
- [x] Compare this page to production: https://yalesites-org.github.io/component-library-twig/?path=/story/page-examples-post--post-article
- [x] Bring your browser window in to mobile sizes on both sites
- [x] Compare them, note that this branch increases the size of the site name

https://github.com/yalesites-org/component-library-twig/assets/366413/d4e4eadd-de73-495f-824d-f355daee117f


#### This branch:
![Screenshot-20230727142121-533x728](https://github.com/yalesites-org/component-library-twig/assets/366413/4e6d8fc3-e3a8-4caa-a956-5db341aff168)

#### Production: 

![Screenshot-20230727142157-534x791](https://github.com/yalesites-org/component-library-twig/assets/366413/ce4e320d-5da0-4d19-9c5f-f9e91a381802)
