### PR TITLE
YALB-1478: Views: display modes and dynamic lists

### DIFF
--- a/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
+++ b/components/02-molecules/cards/directory-listing-card/directory-listing-card.stories.js
@@ -64,7 +64,7 @@ export const ProfileCardDirectoryListing = ({
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
       ${directoryCardTwig({
-        card_example_type: 'profile',
+        card_collection__source_type: 'profile',
         card_collection__type: collectionType,
         ...imageData.responsive_images['1x1'],
         directory_listing_card__overline: overline,

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -39,9 +39,13 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
   }
 
   [data-collection-type='condensed'] & {
-    padding-bottom: var(--size-spacing-5);
+    padding-bottom: var(--size-spacing-6);
     border-bottom: var(--border-thickness-1) solid var(--color-divider);
     margin-bottom: var(--size-spacing-5);
+
+    &:hover {
+      box-shadow: var(--drop-shadow-level-1-bottom-shadow-only);
+    }
   }
 }
 
@@ -192,7 +196,7 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
   }
 
   [data-collection-type='condensed'][data-collection-featured='true'] & {
-    @include tokens.h5-yale-new;
+    @include tokens.h4-yale-new;
 
     font-weight: var(--font-weights-yalenew-bold);
   }

--- a/components/02-molecules/cards/reference-card/examples/_card--examples.twig
+++ b/components/02-molecules/cards/reference-card/examples/_card--examples.twig
@@ -1,5 +1,5 @@
 {% set reference_card__date__formatted %}
-  {% set date_time__format = card_example_type == 'post' ? 'date' %}
+  {% set date_time__format = card_collection__source_type == 'post' ? 'date' %}
   {% include "@atoms/date-time/yds-date-time.twig" with {
     date_time__start: reference_card__date,
   } %}
@@ -13,7 +13,7 @@
 {% endset %}
 
 {# Post Card #}
-{% if card_example_type == 'post' %}
+{% if card_collection__source_type == 'post' %}
   {% set reference_card__overline = reference_card__date__formatted %}
   {# If post, list, and not freatured, hide snippet. #}
   {% if card_collection__type == 'list' and card_collection__featured == 'false' %}
@@ -27,7 +27,7 @@
   {% endif %}
 
 {# Profile Card #}
-{% elseif card_example_type == 'profile' %}
+{% elseif card_collection__source_type == 'profile' %}
   {# If post, list, and not freatured, hide snippet. #}
   {% if card_collection__type == 'list' and card_collection__featured == 'false' %}
     {% set reference_card__subheading = null %}
@@ -40,7 +40,7 @@
   {% endif %}
 
 {# Event Card #}
-{% elseif card_example_type == 'event' %}
+{% elseif card_collection__source_type == 'event' %}
   {# If a format is provided, put it in the overline #}
   {% if format %}
     {% set reference_card__overline %}
@@ -71,7 +71,7 @@
   {% endif %}
 {% endif %}
 
-{% if card_example_type == 'directory-listing' %}
+{% if card_collection__source_type == 'directory-listing' %}
   {% include "@molecules/cards/directory-listing-card/yds-directory-listing-card.twig" %}
 {% else %}
   {% include "@molecules/cards/reference-card/yds-reference-card.twig" %}

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -56,7 +56,7 @@ export const PostCard = ({
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
       ${referenceCardTwig({
-        card_example_type: 'post',
+        card_collection__source_type: 'post',
         card_collection__type: collectionType,
         ...imageData.responsive_images['3x2'],
         reference_card__date: date,
@@ -90,7 +90,7 @@ export const EventCard = ({
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
       ${referenceCardTwig({
-        card_example_type: 'event',
+        card_collection__source_type: 'event',
         card_collection__type: collectionType,
         ...imageData.responsive_images['3x2'],
         format,
@@ -118,7 +118,7 @@ export const ProfileCard = ({ collectionType, featured }) => `
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
       ${referenceCardTwig({
-        card_example_type: 'profile',
+        card_collection__source_type: 'profile',
         card_collection__type: collectionType,
         ...imageData.responsive_images['1x1'],
         reference_card__heading:

--- a/components/03-organisms/card-collection/_yds-card-collection.scss
+++ b/components/03-organisms/card-collection/_yds-card-collection.scss
@@ -31,6 +31,10 @@
     align-items: flex-start;
   }
 
+  [data-collection-type='profile-directory'] & {
+    align-items: flex-start;
+  }
+
   [data-collection-type='grid'][data-collection-featured='true'] & {
     @include grid.primary;
   }

--- a/components/03-organisms/card-collection/_yds-card-collection.scss
+++ b/components/03-organisms/card-collection/_yds-card-collection.scss
@@ -35,6 +35,11 @@
     align-items: flex-start;
   }
 
+  [data-collection-type='condensed'] & {
+    margin-block-start: 0;
+    padding-inline-start: 0;
+  }
+
   [data-collection-type='grid'][data-collection-featured='true'] & {
     @include grid.primary;
   }

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -38,7 +38,7 @@ export const PostCardCollection = ({
   const items = featured ? [1, 2, 3] : [1, 2, 3, 4];
 
   return cardCollectionTwig({
-    card_example_type: 'post',
+    card_collection__source_type: 'post',
     card_collection__type: collectionType,
     card_collection__heading: heading,
     card_collection__featured: featured ? 'true' : 'false',
@@ -70,7 +70,7 @@ export const EventCardCollection = ({
   const items = featured ? [1, 2, 3] : [1, 2, 3, 4];
 
   return cardCollectionTwig({
-    card_example_type: 'event',
+    card_collection__source_type: 'event',
     format: 'Online',
     card_collection__type: collectionType,
     card_collection__heading: heading,
@@ -103,7 +103,7 @@ export const ProfileCardCollection = ({
   const items = featured ? [1, 2, 3] : [1, 2, 3, 4];
 
   return cardCollectionTwig({
-    card_example_type: 'profile',
+    card_collection__source_type: 'profile',
     card_collection__type: collectionType,
     card_collection__heading: heading,
     card_collection__featured: featured ? 'true' : 'false',
@@ -130,7 +130,7 @@ export const DirectoryListingCardCollection = ({ featured, heading }) => {
   const items = featured ? [1, 2, 3, 4] : [1, 2, 3, 4, 5, 6];
 
   return cardCollectionTwig({
-    card_example_type: 'directory-listing',
+    card_collection__source_type: 'directory-listing',
     card_collection__type: 'profile-directory',
     card_collection__heading: 'Directory Listing',
     card_collection__featured: featured ? 'true' : 'false',

--- a/components/03-organisms/card-collection/yds-card-collection.twig
+++ b/components/03-organisms/card-collection/yds-card-collection.twig
@@ -21,9 +21,9 @@
   class: bem(card_collection__base_class, card_collection__modifiers),
 } %}
 
-{% if card_example_type %}
+{% if card_collection__source_type %}
   {% set card_collection__attributes = card_collection__attributes|merge({
-    'data-collection-source': card_example_type,
+    'data-collection-source': card_collection__source_type,
   }) %}
 {% endif %}
 

--- a/components/05-page-examples/_intro-content-examples.twig
+++ b/components/05-page-examples/_intro-content-examples.twig
@@ -38,7 +38,7 @@
   } %}
 {% elseif intro_content == 'collection-featured' %}
 	{% include "@organisms/card-collection/yds-card-collection.twig" with {
-        card_example_type: 'post',
+        card_collection__source_type: 'post',
         card_collection__type: 'grid',
         card_collection__featured: 'true',
         card_collection__with_images: 'true',
@@ -46,7 +46,7 @@
   } %}
 {% elseif intro_content == 'collection-secondary' %}
 	{% include "@organisms/card-collection/yds-card-collection.twig" with {
-        card_example_type: 'post',
+        card_collection__source_type: 'post',
         card_collection__type: 'grid',
         card_collection__featured: 'false',
         card_collection__with_images: 'true',

--- a/components/05-page-examples/events/_event-collection--example.twig
+++ b/components/05-page-examples/events/_event-collection--example.twig
@@ -1,6 +1,6 @@
 {% if variation == 'featured' %}
   {% include "@organisms/card-collection/yds-card-collection.twig" with {
-    card_example_type: 'event',
+    card_collection__source_type: 'event',
     card_collection__type: 'grid',
     card_collection__cards: [
       {},
@@ -13,7 +13,7 @@
   } %}
 {% elseif variation == 'secondary' %}
   {% include "@organisms/card-collection/yds-card-collection.twig" with {
-    card_example_type: 'event',
+    card_collection__source_type: 'event',
     card_collection__type: 'grid',
     card_collection__featured: 'false',
     card_collection__cards: [
@@ -25,7 +25,7 @@
   } %}
 {% elseif variation == 'list' %}
   {% include "@organisms/card-collection/yds-card-collection.twig" with {
-    card_example_type: 'event',
+    card_collection__source_type: 'event',
     card_collection__type: 'list',
     card_collection__cards: [
       {},

--- a/components/05-page-examples/post/post-article.twig
+++ b/components/05-page-examples/post/post-article.twig
@@ -58,7 +58,7 @@
     } %}
 
     {% include "@organisms/card-collection/yds-card-collection.twig" with {
-      card_example_type: 'events',
+      card_collection__source_type: 'events',
       card_collection__type: 'grid',
       card_collection__width: 'content',
       card_collection__cards:[

--- a/components/05-page-examples/standard-pages/standard-page-with-banner-left-align.twig
+++ b/components/05-page-examples/standard-pages/standard-page-with-banner-left-align.twig
@@ -103,7 +103,7 @@
 	{% include "@atoms/divider/yds-divider.twig" %}
 
 	{% include "@organisms/card-collection/yds-card-collection.twig" with {
-      card_example_type: 'post',
+      card_collection__source_type: 'post',
       card_collection__cards:[
         {
           reference_card__date: '2022-03-30 13:00',

--- a/components/05-page-examples/standard-pages/standard-page-with-banner.twig
+++ b/components/05-page-examples/standard-pages/standard-page-with-banner.twig
@@ -87,7 +87,7 @@
   }%}
 
 	{% include "@organisms/card-collection/yds-card-collection.twig" with {
-      card_example_type: 'post',
+      card_collection__source_type: 'post',
       card_collection__cards:[
         {
           reference_card__date: '2022-03-30 13:00',


### PR DESCRIPTION
## [YALB-1478: Views: display modes and dynamic lists](https://yaleits.atlassian.net/browse/YALB-1478)

### Description of work
- Updates card collection: `[data-collection-type='profile-directory'] flex-align: start`
- Renames `card_example_type` to `card_collection__source_type` 

### Testing Link(s)
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/371

### Functional Review Steps
- [ ] Verify directory-listings cards display as they should on `page` and `post`/`event` content. 
