### PR TITLE
YALB 1511 - Theming Primary Navigation Headings

### DIFF
--- a/components/01-atoms/lists/_yds-list-item.twig
+++ b/components/01-atoms/lists/_yds-list-item.twig
@@ -6,14 +6,29 @@
  # - list__item__content - used to replace the content of the list_item with something other than text
  #   for example: to insert the image and/or link components
  #}
+
 {% set list__item__base_class = list__item__base_class|default('item') %}
 {% set list__item__attributes = list__item__attributes|default({}) %}
 {% set list__item__attributes = list__item__attributes|merge({
   class: bem(list__item__base_class, list__item__modifiers, list__item__blockname),
 }) %}
 
+ {% if list__item__content__heading %}
+  {% set list__item__is_heading = true %}
+
+  {# li modifier#}
+  {% set list__item__content__heading %}
+    {% include "@atoms/typography/headings/yds-heading.twig" with {
+      heading__level: list__item__heading__level|default('4'),
+      heading__blockname: list__item__blockname,
+      heading: list__item__content__heading,
+    } %}
+  {% endset %}
+{% endif %}
+
 <li {{ add_attributes(list__item__attributes) }}>
   {% block list__item__content %}
+    {{ list__item__content__heading }}
     {{ list__item__content }}
   {% endblock %}
 </li>

--- a/components/01-atoms/lists/_yds-list-item.twig
+++ b/components/01-atoms/lists/_yds-list-item.twig
@@ -19,7 +19,7 @@
   {# li modifier#}
   {% set list__item__content__heading %}
     {% include "@atoms/typography/headings/yds-heading.twig" with {
-      heading__level: list__item__heading__level|default('4'),
+      heading__level: list__item__heading__level|default('2'),
       heading__blockname: list__item__blockname,
       heading: list__item__content__heading,
     } %}

--- a/components/01-atoms/lists/_yds-list-item.twig
+++ b/components/01-atoms/lists/_yds-list-item.twig
@@ -18,10 +18,10 @@
 
   {# li modifier#}
   {% set list__item__content__heading %}
-    {% include "@atoms/typography/headings/yds-heading.twig" with {
-      heading__level: list__item__heading__level|default('2'),
-      heading__blockname: list__item__blockname,
-      heading: list__item__content__heading,
+    {% include "@atoms/typography/text/yds-text.twig" with {
+      text__blockname: list__item__blockname,
+      text__content: list__item__content__heading,
+      text__base_class: 'heading',
     } %}
   {% endset %}
 {% endif %}

--- a/components/01-atoms/lists/list.yml
+++ b/components/01-atoms/lists/list.yml
@@ -4,5 +4,7 @@ unordered__list__items:
   - list__item__content: 'Elementum elit est, vitae feugiat enim odio cursus. Enim cum dictum gravida amet id eget.'
 ordered__list__items:
   - list__item__content: "This is a list of items that benefits from numbers.<ol><li>They may have sub-levels.<ol><li>Here's another level</li></ol></li></ol>"
+    list__item__is_heading: true
+    list__item__content__heading: 'Heading here'
   - list__item__content: 'Amet consectetur purus justo feugiat mattis sit ultricies odio. Pellentesque pellentesque sit sed porttitor duis interdum.'
   - list__item__content: 'Elementum elit est, vitae feugiat enim odio cursus. Enim cum dictum gravida amet id eget.'

--- a/components/01-atoms/lists/yds-list.twig
+++ b/components/01-atoms/lists/yds-list.twig
@@ -18,6 +18,9 @@
       {% include "@atoms/lists/_yds-list-item.twig" with {
         list__item__content: list__item.list__item__content,
         list__item__blockname: list__base_class,
+        list__item__modifiers: list__item__modifiers,
+        list__item__content__heading: list__item.list__item__content__heading,
+        list__item__is_heading: list__item.list__item__is_heading,
       } %}
     {% endfor %}
   {% endblock %}

--- a/components/02-molecules/menu/_yds-menu-item.twig
+++ b/components/02-molecules/menu/_yds-menu-item.twig
@@ -57,13 +57,14 @@
       'aria-current': 'page',
     }) %}
   {% endif %}
+
   {% if directory and not menu__contextual %}
     {% set link__url = item.url.toString %}
   {% else %}
     {% set link__url = item.url %}
   {% endif %}
 
-  {% if item.is_heading %}
+  {% if item.is_heading and menu__variation == 'mega' %}
     {% set link__type = 'with-chevron' %}
   {% endif %}
 
@@ -82,6 +83,7 @@
   list__item__blockname: item__blockname,
   list__item__attributes: item__attributes,
 } %}
+
   {% block list__item__content %}
     {# This import needs to be inside the block for it to work in Drupal #}
     {% import "@molecules/menu/yds-menu.twig" as menus %}

--- a/components/02-molecules/menu/_yds-menu-item.twig
+++ b/components/02-molecules/menu/_yds-menu-item.twig
@@ -25,7 +25,12 @@
 {# Headings for main menu.
  # @see web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
 #}
-{% if menu__level == 1 and item|first and item.is_heading %}
+{%
+  if menu__level == 1
+  and item|first
+  and item.is_heading
+  and menu__variation == 'mega'
+%}
 
   {# Heading on left. #}
   {% set list__heading %}

--- a/components/02-molecules/menu/_yds-menu-item.twig
+++ b/components/02-molecules/menu/_yds-menu-item.twig
@@ -29,22 +29,16 @@
 {%
   if menu__level == 1
   and item|first
+  and item.list__item__is_heading
   and menu__variation == 'mega'
 %}
-
-  {# Heading on left. #}
-  {% set list__heading %}
-    {% include "@atoms/typography/headings/yds-heading.twig" with {
-      heading__level: item__heading__level|default('4'),
-      heading__blockname: item__blockname,
-      heading: item.title,
-    } %}
-  {% endset %}
+  {# Heading on left #}
+  {% set list__item__content__heading = item.title %}
 
   {# CTA on right #}
   {% set item = item|merge({'title': item.heading_cta }) %}
 
-  {# li modifier#}
+  {# li modifier #}
   {% set item__modifiers = item__modifiers|merge(['explore-bar', 'with-icon']) %}
 {% endif %}
 {# end headings for main menu #}
@@ -64,7 +58,7 @@
     {% set link__url = item.url %}
   {% endif %}
 
-  {% if item.is_heading and menu__variation == 'mega' %}
+  {% if item.list__item__is_heading and menu__variation == 'mega' %}
     {% set link__type = 'with-chevron' %}
   {% endif %}
 
@@ -89,7 +83,7 @@
     {% import "@molecules/menu/yds-menu.twig" as menus %}
     {% set levels = menu__variation == 'mega' ? 2 : 1 %}
 
-    {{ list__heading }}
+    {{ list__item__content__heading }}
 
     {{- list__item -}}
     {% if item.below and menu__level < levels %}

--- a/components/02-molecules/menu/_yds-menu-item.twig
+++ b/components/02-molecules/menu/_yds-menu-item.twig
@@ -25,10 +25,9 @@
 {# Headings for main menu.
  # @see web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
 #}
-
 {%
   if menu__level == 1
-  and item|first
+  and [item]|first
   and item.list__item__is_heading
   and menu__variation == 'mega'
 %}

--- a/components/02-molecules/menu/_yds-menu-item.twig
+++ b/components/02-molecules/menu/_yds-menu-item.twig
@@ -30,8 +30,8 @@
   {# Heading on left. #}
   {% set list__heading %}
     {% include "@atoms/typography/headings/yds-heading.twig" with {
-      heading__level: list__item__heading__level|default('4'),
-      heading__blockname: list__item__base_class,
+      heading__level: item__heading__level|default('4'),
+      heading__blockname: item__blockname,
       heading: item.title,
     } %}
   {% endset %}
@@ -40,31 +40,35 @@
   {% set item = item|merge({'title': item.heading_cta }) %}
 
   {# li modifier#}
-  {% set item__modifiers = item__modifiers|merge(['explore-bar']) %}
-
+  {% set item__modifiers = item__modifiers|merge(['explore-bar', 'with-icon']) %}
 {% endif %}
 {# end headings for main menu #}
 
 {# Set link component as default #}
 {% set list__item %}
-    {# Set aria-current if the link is the current page #}
-    {% if item.is_active %}
-      {% set link__attributes = link__attributes|merge({
-        'aria-current': 'page',
-      }) %}
-    {% endif %}
-    {% if directory and not menu__contextual %}
-      {% set link__url = item.url.toString %}
-    {% else %}
-      {% set link__url = item.url %}
-    {% endif %}
-    {% include "@atoms/controls/text-link/yds-text-link.twig" with {
-      link__content: item.title,
-      link__base_class: 'link',
-      link__blockname: menu__base_class,
-      link__modifiers: item__modifiers,
-      link__attributes: link__attributes,
-    } %}
+  {# Set aria-current if the link is the current page #}
+  {% if item.is_active %}
+    {% set link__attributes = link__attributes|merge({
+      'aria-current': 'page',
+    }) %}
+  {% endif %}
+  {% if directory and not menu__contextual %}
+    {% set link__url = item.url.toString %}
+  {% else %}
+    {% set link__url = item.url %}
+  {% endif %}
+
+  {% if item.is_heading %}
+    {% set link__type = 'with-chevron' %}
+  {% endif %}
+
+  {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+    link__content: item.title,
+    link__base_class: 'link',
+    link__blockname: menu__base_class,
+    link__modifiers: item__modifiers,
+    link__attributes: link__attributes,
+  } %}
 {% endset %}
 
 {% embed "@atoms/lists/_yds-list-item.twig" with {

--- a/components/02-molecules/menu/_yds-menu-item.twig
+++ b/components/02-molecules/menu/_yds-menu-item.twig
@@ -22,6 +22,29 @@
 {# Cta Modifiers #}
 {% set cta__modifiers = ['level-' ~ menu__level] %}
 
+{# Headings for main menu.
+ # @see web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+#}
+{% if menu__level == 1 and item|first and item.is_heading %}
+
+  {# Heading on left. #}
+  {% set list__heading %}
+    {% include "@atoms/typography/headings/yds-heading.twig" with {
+      heading__level: list__item__heading__level|default('4'),
+      heading__blockname: list__item__base_class,
+      heading: item.title,
+    } %}
+  {% endset %}
+
+  {# CTA on right #}
+  {% set item = item|merge({'title': item.heading_cta }) %}
+
+  {# li modifier#}
+  {% set item__modifiers = item__modifiers|merge(['explore-bar']) %}
+
+{% endif %}
+{# end headings for main menu #}
+
 {# Set link component as default #}
 {% set list__item %}
     {# Set aria-current if the link is the current page #}
@@ -54,6 +77,9 @@
     {# This import needs to be inside the block for it to work in Drupal #}
     {% import "@molecules/menu/yds-menu.twig" as menus %}
     {% set levels = menu__variation == 'mega' ? 2 : 1 %}
+
+    {{ list__heading }}
+
     {{- list__item -}}
     {% if item.below and menu__level < levels %}
       {% if menu__level == 0 and menu__level__toggle %}

--- a/components/02-molecules/menu/_yds-menu-item.twig
+++ b/components/02-molecules/menu/_yds-menu-item.twig
@@ -25,10 +25,10 @@
 {# Headings for main menu.
  # @see web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
 #}
+
 {%
   if menu__level == 1
   and item|first
-  and item.is_heading
   and menu__variation == 'mega'
 %}
 

--- a/components/02-molecules/menu/_yds-menu-list.twig
+++ b/components/02-molecules/menu/_yds-menu-list.twig
@@ -3,7 +3,11 @@
 {% set menu__item %}
   {% block menu__item__content %}
     {% for item in items %}
-      {% include "@molecules/menu/_yds-menu-item.twig" %}
+      {% include "@molecules/menu/_yds-menu-item.twig" with {
+        list__item__is_heading: item.list__item__is_heading, 
+        list__item__content__heading: item.list__item__content__heading,
+        list__item__modifiers: item.list__item__modifiers
+      }%}
     {% endfor %}
   {% endblock %}
 {% endset %}

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -286,8 +286,8 @@ $menu-sub-max-width: 19rem;
 
     padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
       calc(var(--size-spacing-2) + var(--size-spacing-1));
-    color: var(--color-gray-700);
     flex: 1 auto;
+    color: var(--color-heading);
   }
 }
 
@@ -365,9 +365,13 @@ $menu-sub-max-width: 19rem;
 
       flex: 0 1 auto;
       margin-bottom: 0;
-      color: inherit;
       padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
         calc(var(--size-spacing-2) + var(--size-spacing-1));
+      color: inherit;
+
+      &:hover {
+        color: var(--menu-link-color);
+      }
     }
   }
 }

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -256,6 +256,32 @@ $menu-sub-max-width: 19rem;
   &--level-2 {
     margin-bottom: var(--size-spacing-5);
   }
+
+  &--explore-bar {
+    [data-menu-variation='basic'] & {
+      visibility: hidden;
+    }
+
+    [data-menu-variation='mega'] & {
+      display: flex;
+      column-span: all;
+      justify-content: space-between;
+      position: relative;
+      z-index: 1;
+      margin-bottom: var(--size-spacing-6);
+      padding-bottom: var(--size-spacing-2);
+      border-bottom: var(--border-thickness-1) solid
+        var(--color-navigation-border);
+    }
+  }
+}
+
+.primary-nav__heading {
+  [data-menu-variation='mega'] & {
+    padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
+      calc(var(--size-spacing-2) + var(--size-spacing-1));
+    color: var(--color-gray-700);
+  }
 }
 
 .primary-nav__link {
@@ -325,6 +351,14 @@ $menu-sub-max-width: 19rem;
     padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
       calc(var(--size-spacing-2) + var(--size-spacing-1));
   }
+
+  &--explore-bar {
+    [data-menu-variation='mega'] & {
+      @include tokens.body-default;
+
+      margin-bottom: 0;
+    }
+  }
 }
 
 // Active trail styles.
@@ -332,7 +366,7 @@ $menu-sub-max-width: 19rem;
   color: var(--menu-link-color);
 }
 
-.primary-nav__link:not(.primary-nav__link--level-0).primary-nav__link--active {
+.primary-nav__link:not(.primary-nav__link--level-0):not(.primary-nav__link--explore-bar).primary-nav__link--active {
   position: relative;
   border-left: var(--border-thickness-4) solid var(--color-navigation-border);
 

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -259,21 +259,15 @@ $menu-sub-max-width: 19rem;
 
   &--explore-bar {
     [data-menu-variation='mega'] & {
-      display: flex;
-      flex-direction: column;
-      column-span: all;
-      justify-content: flex-start;
-      position: relative;
-      z-index: 1;
-      margin-bottom: var(--size-spacing-3);
-      padding-bottom: var(--size-spacing-2);
-      border-bottom: var(--border-thickness-1) solid
-        var(--color-navigation-border);
-
-      @media (min-width: tokens.$break-s) {
+      @media (min-width: tokens.$break-mobile) {
+        display: flex;
+        column-span: all;
         justify-content: space-between;
         align-items: center;
-        flex-direction: row;
+        position: relative;
+        padding-bottom: var(--size-spacing-2);
+        border-bottom: var(--border-thickness-1) solid
+          var(--color-navigation-border);
         margin-bottom: var(--size-spacing-6);
       }
     }
@@ -282,12 +276,18 @@ $menu-sub-max-width: 19rem;
 
 .primary-nav__heading {
   [data-menu-variation='mega'] & {
-    @include tokens.h4-mallory-compact-medium;
+    // hide heading on mobile
+    display: none;
 
-    padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
-      calc(var(--size-spacing-2) + var(--size-spacing-1));
-    flex: 1 auto;
-    color: var(--color-heading);
+    @media (min-width: tokens.$break-mobile) {
+      @include tokens.h5-mallory-compact-medium;
+
+      display: block;
+      padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
+        calc(var(--size-spacing-2) + var(--size-spacing-1));
+      flex: 1 auto;
+      color: var(--color-heading);
+    }
   }
 }
 
@@ -359,18 +359,26 @@ $menu-sub-max-width: 19rem;
       calc(var(--size-spacing-2) + var(--size-spacing-1));
   }
 
+  // this is used for the explore bar link
   &--with-icon {
     [data-menu-variation='mega'] & {
-      @include tokens.h5-mallory-compact-medium;
-
-      flex: 0 1 auto;
-      margin-bottom: 0;
+      font: var(--font-style-nav-primary-1);
+      color: var(--color-heading);
+      margin-bottom: var(--size-spacing-3);
       padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
         calc(var(--size-spacing-2) + var(--size-spacing-1));
-      color: inherit;
+      z-index: 1;
 
       &:hover {
         color: var(--menu-link-color);
+      }
+
+      @media (min-width: tokens.$break-mobile) {
+        @include tokens.h6-mallory-compact-medium;
+
+        flex: 0 1 auto;
+        margin-bottom: 0;
+        color: inherit;
       }
     }
   }

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -262,6 +262,7 @@ $menu-sub-max-width: 19rem;
       display: flex;
       column-span: all;
       justify-content: space-between;
+      align-items: center;
       position: relative;
       z-index: 1;
       margin-bottom: var(--size-spacing-6);
@@ -274,8 +275,9 @@ $menu-sub-max-width: 19rem;
 
 .primary-nav__heading {
   [data-menu-variation='mega'] & {
-    padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
-      calc(var(--size-spacing-2) + var(--size-spacing-1));
+    @include tokens.h4-mallory-compact-medium;
+
+    padding: var(--size-spacing-2) 0;
     color: var(--color-gray-700);
   }
 }

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -260,15 +260,22 @@ $menu-sub-max-width: 19rem;
   &--explore-bar {
     [data-menu-variation='mega'] & {
       display: flex;
+      flex-direction: column;
       column-span: all;
-      justify-content: space-between;
-      align-items: center;
+      justify-content: flex-start;
       position: relative;
       z-index: 1;
-      margin-bottom: var(--size-spacing-6);
+      margin-bottom: var(--size-spacing-3);
       padding-bottom: var(--size-spacing-2);
       border-bottom: var(--border-thickness-1) solid
         var(--color-navigation-border);
+
+      @media (min-width: tokens.$break-s) {
+        justify-content: space-between;
+        align-items: center;
+        flex-direction: row;
+        margin-bottom: var(--size-spacing-6);
+      }
     }
   }
 }
@@ -277,8 +284,10 @@ $menu-sub-max-width: 19rem;
   [data-menu-variation='mega'] & {
     @include tokens.h4-mallory-compact-medium;
 
-    padding: var(--size-spacing-2) 0;
+    padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
+      calc(var(--size-spacing-2) + var(--size-spacing-1));
     color: var(--color-gray-700);
+    flex: 1 auto;
   }
 }
 
@@ -354,8 +363,11 @@ $menu-sub-max-width: 19rem;
     [data-menu-variation='mega'] & {
       @include tokens.h5-mallory-compact-medium;
 
+      flex: 0 1 auto;
       margin-bottom: 0;
       color: inherit;
+      padding: var(--size-spacing-2) var(--size-spacing-5) var(--size-spacing-2)
+        calc(var(--size-spacing-2) + var(--size-spacing-1));
     }
   }
 }

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -258,10 +258,6 @@ $menu-sub-max-width: 19rem;
   }
 
   &--explore-bar {
-    [data-menu-variation='basic'] & {
-      visibility: hidden;
-    }
-
     [data-menu-variation='mega'] & {
       display: flex;
       column-span: all;
@@ -352,11 +348,12 @@ $menu-sub-max-width: 19rem;
       calc(var(--size-spacing-2) + var(--size-spacing-1));
   }
 
-  &--explore-bar {
+  &--with-icon {
     [data-menu-variation='mega'] & {
       @include tokens.body-default;
 
       margin-bottom: 0;
+      color: inherit;
     }
   }
 }

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -352,7 +352,7 @@ $menu-sub-max-width: 19rem;
 
   &--with-icon {
     [data-menu-variation='mega'] & {
-      @include tokens.body-default;
+      @include tokens.h5-mallory-compact-medium;
 
       margin-bottom: 0;
       color: inherit;

--- a/components/03-organisms/menu/primary-nav/primary-nav.yml
+++ b/components/03-organisms/menu/primary-nav/primary-nav.yml
@@ -2,6 +2,10 @@ items:
   - title: 'About YDS'
     url: '#'
     below:
+      - title: 'About YDS'
+        list__item__is_heading: true
+        heading_cta: 'Explore All'
+        url: '#'
       - title: "Dean's Office"
         url: '#'
       - title: 'Virtual Backgrounds with a lot more text entered to test max-width'
@@ -55,7 +59,7 @@ items:
     below:
       - title: 'Admission & Aid'
         list__item__is_heading: true
-        heading_cta: 'Explore More'
+        heading_cta: 'Explore All'
         url: '#'
       - title: 'Strategic Plan'
         url: '#'

--- a/components/03-organisms/menu/primary-nav/primary-nav.yml
+++ b/components/03-organisms/menu/primary-nav/primary-nav.yml
@@ -53,6 +53,10 @@ items:
   - title: 'Admission & Aid'
     url: '#'
     below:
+      - title: 'Admission & Aid'
+        list__item__is_heading: true
+        heading_cta: 'Explore More'
+        url: '#'
       - title: 'Strategic Plan'
         url: '#'
         below:


### PR DESCRIPTION
## [YALB-1511 - Mega Menu: Present Level One links as Headings - FE](https://yaleits.atlassian.net/browse/YALB-1511)

### Description of work
- Adds option list_heading to the main menu 

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-284--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-primary-nav--primary-nav&args=menuVariation:mega)

### Functional Review Steps
- [ ] You can also test this in the main PR here: https://github.com/yalesites-org/yalesites-project/pull/408 
  - or by navigating to: https://pr-408-yalesites-platform.pantheonsite.io/welcome and expanding any menu item. 

- [ ] @kara-franco For a11y review, could you please let me know if it's okay that the `primary-nav__heading` element is a `div`? Should it be a `<span>` or something else? 

![Screenshot-20230831181605-1859x1104](https://github.com/yalesites-org/component-library-twig/assets/366413/c3e2e15a-e779-4102-97ef-ef86afa1839e)



#### Otherwise, in Storybook
- [ ] Navigate to https://deploy-preview-284--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-primary-nav--primary-nav&args=menuVariation:mega
- [ ] Verify you're seeing the `mega` variant, if not select `mega`
- [ ] Expand the "Admissions & Aid" menu item
- [ ] Verify you see the following: 

#### Desktop
![Screenshot-20230831180827-1785x992](https://github.com/yalesites-org/component-library-twig/assets/366413/46e5448b-10e7-4928-8437-a82c53d9671c)


#### Mobile
![Screenshot-20230831180913-773x1041](https://github.com/yalesites-org/component-library-twig/assets/366413/df9edada-4ac1-452d-b21a-95a3bb9fedd3)
