### PR TITLE
YALB-1215: Dials: Banner heading levels

### DIFF
--- a/components/02-molecules/banner/action/yds-action-banner.twig
+++ b/components/02-molecules/banner/action/yds-action-banner.twig
@@ -40,7 +40,7 @@
         <div {{ bem('wrap', [], banner__base_class) }}>
           <div {{ bem('text', [], banner__base_class) }}>
             {% include "@atoms/typography/headings/yds-heading.twig" with {
-              heading__level: '2',
+              heading__level: banner__heading__level|default('2'),
               heading__blockname: banner__base_class,
               heading: banner__heading,
             } %}

--- a/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
+++ b/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
@@ -57,7 +57,7 @@
           <div {{ bem('content-inner', [], grand_hero__base_class) }}>
             {% if grand_hero__heading is not empty %}
               {% include "@atoms/typography/headings/yds-heading.twig" with {
-                heading__level: '2',
+                heading__level: grand_hero__heading__level|default('2'),
                 heading__blockname: grand_hero__base_class,
                 heading: grand_hero__heading,
               } %}


### PR DESCRIPTION
## [YALB-1215: Dials: Banner heading levels](https://yaleits.atlassian.net/browse/YALB-1215)


### Description of work
- Adds variables to wire heading__level to Drupal field
- Keeps default set to `2`

### Testing Link(s)
- [x] Test here: https://github.com/yalesites-org/yalesites-project/pull/407
