### PR TITLE
fix(yalb-mega-footer-2): remove two footer logos from mega footer, ch…

### DIFF
--- a/components/02-molecules/link-group/_yds-link-group.scss
+++ b/components/02-molecules/link-group/_yds-link-group.scss
@@ -99,18 +99,21 @@ $break-link-group-max: $break-link-group - 0.05;
   line-height: 1.2;
   font-weight: var(--font-weights-mallory-book);
 
-  [data-footer-theme='one'] &,
-  [data-footer-theme='two'] &,
-  [data-footer-theme='three'] & {
-    --color-link-group-hover: var(--color-slot-two);
-  }
+  // used in footer context, we need theme colors for hover
+  .site-footer__columns-inner & {
+    [data-footer-theme='one'] &,
+    [data-footer-theme='two'] &,
+    [data-footer-theme='three'] & {
+      --color-link-group-hover: var(--color-slot-two);
+    }
 
-  [data-footer-theme='four'] &,
-  [data-footer-theme='five'] & {
-    --color-link-group-hover: var(--color-slot-four);
-  }
+    [data-footer-theme='four'] &,
+    [data-footer-theme='five'] & {
+      --color-link-group-hover: var(--color-slot-four);
+    }
 
-  &:hover {
-    color: var(--color-link-group-hover);
+    &:hover {
+      color: var(--color-link-group-hover);
+    }
   }
 }

--- a/components/02-molecules/link-group/_yds-link-group.scss
+++ b/components/02-molecules/link-group/_yds-link-group.scss
@@ -72,11 +72,11 @@ $break-link-group-max: $break-link-group - 0.05;
 
   width: 100%;
   border-left: var(--thickness-divider) solid var(--color-link-group-border);
-  margin-bottom: var(--size-spacing-3);
 
   &--one {
     @media (max-width: $break-link-group-max) {
       grid-area: links-one;
+      margin-bottom: var(--size-spacing-8);
     }
   }
 
@@ -88,6 +88,7 @@ $break-link-group-max: $break-link-group - 0.05;
 
   @media (min-width: $break-link-group) {
     flex: 0 0 50%;
+    margin-bottom: var(--size-spacing-3);
   }
 }
 

--- a/components/02-molecules/link-group/_yds-link-group.scss
+++ b/components/02-molecules/link-group/_yds-link-group.scss
@@ -98,4 +98,19 @@ $break-link-group-max: $break-link-group - 0.05;
   text-align: left;
   line-height: 1.2;
   font-weight: var(--font-weights-mallory-book);
+
+  [data-footer-theme='one'] &,
+  [data-footer-theme='two'] &,
+  [data-footer-theme='three'] & {
+    --color-link-group-hover: var(--color-slot-two);
+  }
+
+  [data-footer-theme='four'] &,
+  [data-footer-theme='five'] & {
+    --color-link-group-hover: var(--color-slot-four);
+  }
+
+  &:hover {
+    color: var(--color-link-group-hover);
+  }
 }

--- a/components/02-molecules/link-group/_yds-link-group.scss
+++ b/components/02-molecules/link-group/_yds-link-group.scss
@@ -72,7 +72,7 @@ $break-link-group-max: $break-link-group - 0.05;
 
   width: 100%;
   border-left: var(--thickness-divider) solid var(--color-link-group-border);
-  margin-bottom: var(--size-spacing-7);
+  margin-bottom: var(--size-spacing-3);
 
   &--one {
     @media (max-width: $break-link-group-max) {

--- a/components/02-molecules/social-links/_yds-social-links.scss
+++ b/components/02-molecules/social-links/_yds-social-links.scss
@@ -26,6 +26,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--size-spacing-6);
+  justify-content: end;
 }
 
 .social-links__link {

--- a/components/02-molecules/social-links/_yds-social-links.scss
+++ b/components/02-molecules/social-links/_yds-social-links.scss
@@ -26,7 +26,10 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--size-spacing-6);
-  justify-content: end;
+
+  @media (min-width: sass-tokens.$break-l) {
+    justify-content: end;
+  }
 }
 
 .social-links__link {

--- a/components/02-molecules/social-links/_yds-social-links.scss
+++ b/components/02-molecules/social-links/_yds-social-links.scss
@@ -27,7 +27,7 @@
   flex-wrap: wrap;
   gap: var(--size-spacing-6);
 
-  @media (min-width: sass-tokens.$break-l) {
+  [data-footer-variation='mega'] & {
     justify-content: end;
   }
 }

--- a/components/03-organisms/site-footer/_site-footer-mega.twig
+++ b/components/03-organisms/site-footer/_site-footer-mega.twig
@@ -14,14 +14,6 @@
           placeholder: 'logo',
           placeholder__type: 'element',
         } %}
-        {% include "@page-layouts/placeholder/yds-placeholder.twig" with {
-          placeholder: 'logo',
-          placeholder__type: 'element',
-        } %}
-        {% include "@page-layouts/placeholder/yds-placeholder.twig" with {
-          placeholder: 'logo',
-          placeholder__type: 'element',
-        } %}
       {% endblock %}
     </div>
 

--- a/components/03-organisms/site-footer/_site-footer-mega.twig
+++ b/components/03-organisms/site-footer/_site-footer-mega.twig
@@ -46,16 +46,16 @@
         } %}
       {% endblock %}
     </div>
-    {# Social #}
-    <div {{ bem('social', [], site_footer__base_class) }}>
-      {% block site_footer__social_links %}
-        {% include "@molecules/social-links/yds-social-links.twig" %}
-      {% endblock %}
-    </div>
   </div>
 </div>
 {# Secondary #}
 <div {{ bem('secondary', [], site_footer__base_class) }}>
+  {# Social #}
+  <div {{ bem('social', [], site_footer__base_class) }}>
+    {% block site_footer__social_links %}
+      {% include "@molecules/social-links/yds-social-links.twig" %}
+    {% endblock %}
+  </div>
   {# YALE Logo #}
   <div {{ bem('logo', [], site_footer__base_class) }}>
     <a data-link-style="no-underline" class="site-footer__site-branding site-footer__site-branding--primary" href="https://yale.edu">&#XF2A2;</a>

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -289,14 +289,6 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     flex: 1 auto;
     flex-direction: column;
     gap: var(--size-spacing-3);
-
-    @media (min-width: tokens.$break-l) {
-      display: grid;
-      grid-template:
-        'top'
-        'bottom'
-        / 1fr;
-    }
   }
 }
 

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -159,7 +159,7 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
   [data-footer-variation='mega'] & {
     border-top: var(--thickness-divider) solid
       var(--color-site-footer-border-color);
-    padding-top: var(--size-spacing-6);
+    padding-top: var(--size-spacing-8);
 
     @media (min-width: $break-site-footer) {
       flex-direction: row;
@@ -218,6 +218,8 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
   }
 
   [data-footer-variation='mega'] & {
+    margin-bottom: var(--size-spacing-3);
+
     @media (min-width: tokens.$break-m) {
       margin-left: auto;
     }
@@ -298,9 +300,11 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
 // Social
 .site-footer__social {
   [data-footer-variation='mega'] & {
-    @media (min-width: tokens.$break-l) {
-      flex: 0 auto;
-      align-self: flex-end;
+    flex: 0 0 100%;
+    align-self: flex-end;
+
+    @media (max-width: $break-site-footer-max) {
+      order: 3;
     }
   }
 }

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -258,14 +258,14 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
 
     flex: 1 1 30%;
 
-    > p {
-      margin-top: 0;
-    }
-
     @media (min-width: tokens.$break-l) {
       grid-area: content;
       padding-inline-start: var(--size-spacing-8);
       padding-inline-end: var(--size-spacing-8);
+
+      > p {
+        margin-top: 0;
+      }
     }
   }
 }

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -175,7 +175,16 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
   gap: var(--size-spacing-3);
 
   [data-footer-variation='mega'] & {
-    flex: 1 1 30%;
+    @media (min-width: $break-site-footer) {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+
+    @media (min-width: tokens.$break-l) {
+      flex-direction: column;
+      justify-content: flex-start;
+      flex: 1 1 30%;
+    }
   }
 }
 
@@ -229,21 +238,14 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
 */
 .site-footer__logo-group {
   display: grid;
-  gap: var(--size-spacing-3);
   grid-template-columns: 1fr 1fr;
-
-  @media (min-width: $break-site-footer) {
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-  }
-
-  @media (min-width: tokens.$break-l) {
-    grid-template-columns: 1fr 1fr;
-  }
+  gap: var(--size-spacing-3);
 }
 
 // Yale school logo
 .site-footer__yale-logo {
   [data-footer-variation='mega'] & {
+    flex-basis: 50%;
     gap: var(--size-spacing-6);
   }
 }

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -141,7 +141,7 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     @media (min-width: tokens.$break-l) {
       display: grid;
       grid-template-areas: 'logos content columns';
-      grid-template-columns: 23.5rem 1fr 1fr;
+      grid-template-columns: 18rem 1fr 1fr;
     }
   }
 }

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -178,6 +178,7 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     @media (min-width: $break-site-footer) {
       flex-direction: row;
       justify-content: space-between;
+      gap: var(--size-spacing-5);
     }
 
     @media (min-width: tokens.$break-l) {
@@ -239,7 +240,7 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
 .site-footer__logo-group {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--size-spacing-3);
+  gap: var(--size-spacing-5);
 }
 
 // Yale school logo


### PR DESCRIPTION
## [YALB-1510: Mega Menu: Present Level One links as Headings - BE](https://yaleits.atlassian.net/browse/YALB-1510)
## [YALB-1487: Mega Footer Branding: FE ](https://yaleits.atlassian.net/browse/YALB-1487)

### Description of work
- Refines mega footer responsiveness
- Changes the logo group to 2 logos instead of 4
- Moves the placement of social links to render directly under the link group links instead of rendering in a grid row consisting of equal spacing properties (to the link group) which had more spacing, previously.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Test in main repo: https://github.com/yalesites-org/yalesites-project/pull/419
- [ ] You can also test here: https://deploy-preview-290--dev-component-library-twig.netlify.app/?path=/story/organisms-site-footer--footer&args=siteFooterVariation:mega
- [ ] Testing in Drupal is the best way to test the changes

https://github.com/yalesites-org/component-library-twig/assets/366413/214f5bf1-19a1-498b-89a0-300835952ab6





