### PR TITLE
 YALB-1423 - Feedback: Rename floated to inline | YALB-1425 - Bug: Firefox - GIF being uploaded to multiple blocks | YALB-1426 - Bug: Exposed taxonomy filter style on mobile

### DIFF
--- a/components/01-atoms/forms/_yds-form.scss
+++ b/components/01-atoms/forms/_yds-form.scss
@@ -42,8 +42,9 @@
 .ys-filter-form {
   align-items: flex-end;
   display: flex;
-  gap: 0 1rem;
+  gap: 1rem;
   margin-bottom: var(--size-spacing-8);
+  flex-flow: row wrap;
 
   .form-item {
     margin-bottom: 0;

--- a/components/01-atoms/forms/_yds-form.scss
+++ b/components/01-atoms/forms/_yds-form.scss
@@ -47,6 +47,7 @@
   flex-flow: row wrap;
 
   .form-item {
+    width: 100%;
     margin-bottom: 0;
   }
 
@@ -58,5 +59,7 @@
     @include button-submit;
 
     --border-radius-button: var(--radius-0);
+
+    min-height: var(--size-spacing-9);
   }
 }

--- a/components/03-organisms/galleries/media-grid/yds-media-grid-interactive.js
+++ b/components/03-organisms/galleries/media-grid/yds-media-grid-interactive.js
@@ -128,6 +128,16 @@ Drupal.behaviors.mediaGridInteractive = {
        * toggleCaptions
        * @description toggleCaptions truncates long captions visible in the modal.
        */
+
+      // Truncate caption function
+      // Take a string and a maxlength parameter
+      // slice the string starting at 0 and ending at maxLength.
+      function handleCaptionTruncation(captionContent, maxLength) {
+        return captionContent.length > maxLength
+          ? captionContent.slice(0, maxLength)
+          : captionContent;
+      }
+
       // Get all modal content.
       const imageCaptions = document.querySelectorAll(
         '.media-grid-modal__content',
@@ -154,7 +164,10 @@ Drupal.behaviors.mediaGridInteractive = {
 
           // Check the length of the caption and truncate if necessary
           if (toggleCaption && fullCaption.length > maxLength) {
-            const truncatedCaption = fullCaption.slice(0, maxLength);
+            const truncatedCaption = handleCaptionTruncation(
+              fullCaption,
+              maxLength,
+            );
 
             // set truncated content.
             captionContent.textContent = `${truncatedCaption}...`;
@@ -168,7 +181,7 @@ Drupal.behaviors.mediaGridInteractive = {
             toggleCaption.style.setProperty('display', 'inline');
 
             // Toggle the full caption when the "up arrow" toggle is clicked
-            toggleCaption.addEventListener('click', function (e) {
+            toggleCaption.addEventListener('click', function _(e) {
               e.preventDefault();
               if (captionContent.textContent === `${truncatedCaption}...`) {
                 toggleCaption.setAttribute('aria-expanded', 'true');


### PR DESCRIPTION
## [YALB-1423 - Feedback: Rename floated to inline](https://yaleits.atlassian.net/browse/YALB-1434)
## [YALB-1425 - Bug: Firefox - GIF being uploaded to multiple blocks](https://yaleits.atlassian.net/browse/YALB-1425)
## [YALB-1426 - Bug: Exposed taxonomy filter style on mobile](https://yaleits.atlassian.net/browse/YALB-1426)


### Description of work
- Adds functionality bullet item
- Fixes this or that bullet item

### Testing Link(s)
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/425

### Functional Review Steps
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/425

