### PR TITLE
YALB-1527 - Bug: Update link styling "Skip to Main Content" | YALB-1560 - Blank space in toolbar on admin theme

### DIFF
--- a/components/01-atoms/controls/text-link/_yds-text-link.scss
+++ b/components/01-atoms/controls/text-link/_yds-text-link.scss
@@ -95,8 +95,6 @@ $global-link-themes: map.deep-get(tokens.$tokens, 'global-themes');
 // and directly referenced at the bottom of this file in:
 // &[data-link-style='no-underline-animation']
 @mixin plain-link {
-  @include tokens.animate;
-
   // Global themes: set color slots for each theme
   // This establishes `--color-slot-` variables name-spaced to the selector
   // in which it is used. We can map component-level variables to global-level

--- a/components/02-molecules/link-skip/_yds-link-skip.scss
+++ b/components/02-molecules/link-skip/_yds-link-skip.scss
@@ -1,0 +1,14 @@
+@use '../../00-tokens/tokens';
+@use '../../01-atoms/controls/text-link/yds-text-link' as link;
+
+.link-skip {
+  @include tokens.spacing-page-section;
+
+  width: 100%;
+}
+
+.link-skip__link {
+  @include link.link;
+
+  --color-text-shadow: var(--color-basic-white);
+}

--- a/components/02-molecules/link-skip/_yds-link-skip.scss
+++ b/components/02-molecules/link-skip/_yds-link-skip.scss
@@ -2,13 +2,18 @@
 @use '../../01-atoms/controls/text-link/yds-text-link' as link;
 
 .link-skip {
-  @include tokens.spacing-page-section;
-
-  width: 100%;
-}
-
-.link-skip__link {
-  @include link.link;
+  @include link.plain-link;
 
   --color-text-shadow: var(--color-basic-white);
+
+  margin-block-start: var(--size-spacing-4);
+  margin-block-end: var(--size-spacing-4);
+
+  &.visually-hidden.focusable:focus {
+    display: block;
+    width: 100%;
+    max-width: 1344px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }

--- a/components/02-molecules/link-skip/_yds-link-skip.scss
+++ b/components/02-molecules/link-skip/_yds-link-skip.scss
@@ -1,13 +1,14 @@
 @use '../../00-tokens/tokens';
 @use '../../01-atoms/controls/text-link/yds-text-link' as link;
 
-.link-skip {
+.link-skip__link {
   @include link.plain-link;
 
   --color-text-shadow: var(--color-basic-white);
 
   margin-block-start: var(--size-spacing-4);
   margin-block-end: var(--size-spacing-4);
+  padding-inline-start: 0;
 
   &.visually-hidden.focusable:focus {
     display: block;

--- a/components/02-molecules/link-skip/link-skip.stories.js
+++ b/components/02-molecules/link-skip/link-skip.stories.js
@@ -1,0 +1,15 @@
+import linkSkipTwig from './yds-link-skip.twig';
+
+import linkSkipData from './link-skip.yml';
+
+/**
+ * Storybook Definition.
+ */
+export default {
+  title: 'Molecules/Link skip',
+};
+
+export const linkSkip = () =>
+  linkSkipTwig({
+    ...linkSkipData,
+  });

--- a/components/02-molecules/link-skip/link-skip.yml
+++ b/components/02-molecules/link-skip/link-skip.yml
@@ -1,0 +1,2 @@
+link_skip__content: 'Skip to main content'
+link_skip__url: '#main-content'

--- a/components/02-molecules/link-skip/yds-link-skip.twig
+++ b/components/02-molecules/link-skip/yds-link-skip.twig
@@ -14,14 +14,11 @@
 {% set link_skip__attributes = link_skip__attributes|merge({
   'data-component-width': link_skip__width|default('site'),
   class: bem(link_skip__base_class, link_skip__modifiers, link_skip__blockname, link_skip__extra_class),
+  href: link_skip__url
 }) %}
 
-<div {{ add_attributes(link_skip__attributes) }}>
-  <div {{ bem('inner', [], link_skip__base_class ) }}>
-    <a href="{{link_skip__url}}" {{ bem('link', [], link_skip__base_class ) }}>
-      {% block link_skip__content %}
-        {{- link_skip__content -}}
-      {% endblock %}
-    </a>
-  </div>
-</div >
+<a {{ add_attributes(link_skip__attributes) }}>
+  {% block link_skip__content %}
+    {{- link_skip__content -}}
+  {% endblock %}
+</a>

--- a/components/02-molecules/link-skip/yds-link-skip.twig
+++ b/components/02-molecules/link-skip/yds-link-skip.twig
@@ -1,7 +1,6 @@
 {#
  # Available variables:
  # - link_skip__content - the content of the link (typically text)
- # - link_skip__attributes - array of attribute,value pairs
  #
  # Available blocks:
  # - link_skip__content - used to replace the content of the link
@@ -9,15 +8,9 @@
  #}
 
 {% set link_skip__base_class = link_skip__base_class|default('link-skip') %}
-{% set link_skip__attributes = link_skip__attributes|default({}) %}
+{% set link_skip__extra_class = link_skip__extra_class %}
 
-{% set link_skip__attributes = link_skip__attributes|merge({
-  'data-component-width': link_skip__width|default('site'),
-  class: bem(link_skip__base_class, link_skip__modifiers, link_skip__blockname, link_skip__extra_class),
-  href: link_skip__url
-}) %}
-
-<a {{ add_attributes(link_skip__attributes) }}>
+<a href={{link_skip__url}} {{ bem('link', [], link_skip__base_class, link_skip__extra_class) }}>
   {% block link_skip__content %}
     {{- link_skip__content -}}
   {% endblock %}

--- a/components/02-molecules/link-skip/yds-link-skip.twig
+++ b/components/02-molecules/link-skip/yds-link-skip.twig
@@ -1,0 +1,27 @@
+{#
+ # Available variables:
+ # - link_skip__content - the content of the link (typically text)
+ # - link_skip__attributes - array of attribute,value pairs
+ #
+ # Available blocks:
+ # - link_skip__content - used to replace the content of the link
+ #     Example: to insert the image component
+ #}
+
+{% set link_skip__base_class = link_skip__base_class|default('link-skip') %}
+{% set link_skip__attributes = link_skip__attributes|default({}) %}
+
+{% set link_skip__attributes = link_skip__attributes|merge({
+  'data-component-width': link_skip__width|default('site'),
+  class: bem(link_skip__base_class, link_skip__modifiers, link_skip__blockname, link_skip__extra_class),
+}) %}
+
+<div {{ add_attributes(link_skip__attributes) }}>
+  <div {{ bem('inner', [], link_skip__base_class ) }}>
+    <a href="{{link_skip__url}}" {{ bem('link', [], link_skip__base_class ) }}>
+      {% block link_skip__content %}
+        {{- link_skip__content -}}
+      {% endblock %}
+    </a>
+  </div>
+</div >

--- a/components/02-molecules/molecules.scss
+++ b/components/02-molecules/molecules.scss
@@ -8,6 +8,7 @@
 @forward './embed/yds-embed';
 @forward './image/yds-content-image';
 @forward './link-group/yds-link-group';
+@forward './link-skip/yds-link-skip';
 @forward './menu/yds-menu';
 @forward './menu/menu-toggle/yds-menu-toggle';
 @forward './meta/basic-meta/yds-basic-meta';


### PR DESCRIPTION
## [YALB-1527 - Bug: Update link styling "Skip to Main Content"](https://yaleits.atlassian.net/browse/YALB-1527)
## [YALB-1560 - Blank space in toolbar on admin theme](https://yaleits.atlassian.net/browse/YALB-1560)

### Description of work
- Adds a component for `link skip`: 
- Wires new link skip to `html.html` template.
- Fixes chosen input search colors on `admin/content` tags

### Testing Link(s)
- [ ] Navigate to the [Link Skip Component Story](https://deploy-preview-299--dev-component-library-twig.netlify.app/?path=/story/molecules-link-skip--link-skip)

### Functional Review Steps
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/438
