### PR TITLE
YALB-1410: Bug: Accessibility (FE)- Color Contrast issues in automatic testing tools

### DIFF
--- a/components/02-molecules/banner/action/_yds-action-banner.scss
+++ b/components/02-molecules/banner/action/_yds-action-banner.scss
@@ -15,16 +15,95 @@ $break-cta-banner-max: $break-cta-banner - 0.05;
     $banner-spacing: true
   );
 
+  // Component themes defaults: iterate over each component theme to establish
+  // default variables.
+  @each $theme, $value in $component-banner-themes {
+    &[data-component-theme='#{$theme}'] {
+      --color-text: var(--color-banner-text);
+      --color-backgound: var(--color-banner-background);
+      --color-heading: var(--color-banner-heading);
+      --color-action: var(--color-banner-action);
+      --color-action-secondary: var(--color-banner-action-secondary);
+    }
+  }
+
+  // Global themes: set color slots for each theme
+  // This establishes `--color-slot-` variables name-spaced to the selector
+  // in which it is used. We can map component-level variables to global-level
+  // `--color-slot-` variables.
+  @each $globalTheme, $value in $global-banner-themes {
+    [data-global-theme='#{$globalTheme}'] & {
+      --color-slot-one: var(--global-themes-#{$globalTheme}-colors-slot-one);
+      --color-slot-two: var(--global-themes-#{$globalTheme}-colors-slot-two);
+      --color-slot-three: var(
+        --global-themes-#{$globalTheme}-colors-slot-three
+      );
+      --color-slot-four: var(--global-themes-#{$globalTheme}-colors-slot-four);
+      --color-slot-five: var(--global-themes-#{$globalTheme}-colors-slot-five);
+    }
+  }
+
+  max-width: tokens.$break-max-width;
+  margin-inline-start: auto;
+  margin-inline-end: auto;
   padding: 0;
+  background-color: var(--color-banner-background);
 
   --banner-content-max-width: 37rem;
+
+  // Component theme overrides: set specific component themes overrides
+  /// define component name spaced variables and map them to global theme slots.
+  &[data-component-theme='one'] {
+    --color-banner-background: var(--color-slot-one);
+    --color-banner-text: var(--color-basic-white);
+    --color-banner-heading: var(--color-basic-white);
+    --color-banner-action: var(--color-basic-white);
+    --color-banner-action-secondary: var(--color-slot-one);
+    --color-link-base: var(--color-banner-heading);
+    --color-link-hover: var(--color-banner-heading);
+  }
+
+  &[data-component-theme='two'] {
+    --color-banner-background: var(--color-slot-four);
+    --color-banner-text: var(--color-gray-800);
+    --color-banner-heading: var(--color-gray-800);
+    --color-banner-action: var(--color-gray-800);
+    --color-banner-action-secondary: var(--color-basic-white);
+    --color-link-base: var(--color-banner-heading);
+    --color-link-hover: var(--color-banner-heading);
+
+    // component theme two has a white background when in global theme one, four, and five.
+    // add border between the bottom of the banner and any content after it.
+    [data-global-theme='one'] &,
+    [data-global-theme='four'] &,
+    [data-global-theme='five'] & {
+      @media (max-width: $break-cta-banner-max) {
+        &::after {
+          content: '';
+          position: absolute;
+          bottom: 0;
+          left: var(--size-spacing-site-gutter);
+          right: var(--size-spacing-site-gutter);
+          height: var(--border-thickness-1);
+          background-color: var(--color-gray-300);
+        }
+      }
+    }
+  }
+
+  &[data-component-theme='three'] {
+    --color-banner-background: var(--color-slot-five);
+    --color-banner-text: var(--color-basic-white);
+    --color-banner-heading: var(--color-basic-white);
+    --color-banner-action: var(--color-basic-white);
+    --color-banner-action-secondary: var(--color-slot-one);
+    --color-link-base: var(--color-banner-heading);
+    --color-link-hover: var(--color-banner-heading);
+  }
 }
 
 .cta-banner__content-wrapper {
   position: relative;
-  max-width: tokens.$break-max-width;
-  margin-inline-start: auto;
-  margin-inline-end: auto;
 
   @media (min-width: $break-cta-banner) {
     aspect-ratio: 16 / 5;
@@ -98,34 +177,6 @@ $break-cta-banner-max: $break-cta-banner - 0.05;
   // the `::before` element below.
   background-color: transparent;
 
-  // Component themes defaults: iterate over each component theme to establish
-  // default variables.
-  @each $theme, $value in $component-banner-themes {
-    &[data-component-theme='#{$theme}'] {
-      --color-text: var(--color-banner-text);
-      --color-backgound: var(--color-banner-background);
-      --color-heading: var(--color-banner-heading);
-      --color-action: var(--color-banner-action);
-      --color-action-secondary: var(--color-banner-action-secondary);
-    }
-  }
-
-  // Global themes: set color slots for each theme
-  // This establishes `--color-slot-` variables name-spaced to the selector
-  // in which it is used. We can map component-level variables to global-level
-  // `--color-slot-` variables.
-  @each $globalTheme, $value in $global-banner-themes {
-    [data-global-theme='#{$globalTheme}'] & {
-      --color-slot-one: var(--global-themes-#{$globalTheme}-colors-slot-one);
-      --color-slot-two: var(--global-themes-#{$globalTheme}-colors-slot-two);
-      --color-slot-three: var(
-        --global-themes-#{$globalTheme}-colors-slot-three
-      );
-      --color-slot-four: var(--global-themes-#{$globalTheme}-colors-slot-four);
-      --color-slot-five: var(--global-themes-#{$globalTheme}-colors-slot-five);
-    }
-  }
-
   > * {
     position: relative;
   }
@@ -197,56 +248,6 @@ $break-cta-banner-max: $break-cta-banner - 0.05;
         max-width: var(--banner-content-max-width);
       }
     }
-  }
-
-  // Component theme overrides: set specific component themes overrides
-  /// define component name spaced variables and map them to global theme slots.
-  &[data-component-theme='one'] {
-    --color-banner-background: var(--color-slot-one);
-    --color-banner-text: var(--color-basic-white);
-    --color-banner-heading: var(--color-basic-white);
-    --color-banner-action: var(--color-basic-white);
-    --color-banner-action-secondary: var(--color-slot-one);
-    --color-link-base: var(--color-banner-heading);
-    --color-link-hover: var(--color-banner-heading);
-  }
-
-  &[data-component-theme='two'] {
-    --color-banner-background: var(--color-slot-four);
-    --color-banner-text: var(--color-gray-800);
-    --color-banner-heading: var(--color-gray-800);
-    --color-banner-action: var(--color-gray-800);
-    --color-banner-action-secondary: var(--color-basic-white);
-    --color-link-base: var(--color-banner-heading);
-    --color-link-hover: var(--color-banner-heading);
-
-    // component theme two has a white background when in global theme one, four, and five.
-    // add border between the bottom of the banner and any content after it.
-    [data-global-theme='one'] &,
-    [data-global-theme='four'] &,
-    [data-global-theme='five'] & {
-      @media (max-width: $break-cta-banner-max) {
-        &::after {
-          content: '';
-          position: absolute;
-          bottom: 0;
-          left: var(--size-spacing-site-gutter);
-          right: var(--size-spacing-site-gutter);
-          height: var(--border-thickness-1);
-          background-color: var(--color-gray-300);
-        }
-      }
-    }
-  }
-
-  &[data-component-theme='three'] {
-    --color-banner-background: var(--color-slot-five);
-    --color-banner-text: var(--color-basic-white);
-    --color-banner-heading: var(--color-basic-white);
-    --color-banner-action: var(--color-basic-white);
-    --color-banner-action-secondary: var(--color-slot-one);
-    --color-link-base: var(--color-banner-heading);
-    --color-link-hover: var(--color-banner-heading);
   }
 }
 

--- a/components/02-molecules/banner/action/yds-action-banner.twig
+++ b/components/02-molecules/banner/action/yds-action-banner.twig
@@ -17,6 +17,7 @@
 
 {% set banner__attributes = {
   'data-banner-content-layout': banner__content__layout|default('bottom'),
+  'data-component-theme': banner__content__background,
   class: bem(banner__base_class),
 } %}
 
@@ -35,7 +36,7 @@
         {% include "@atoms/images/image/_responsive-image.twig" %}
       {% endblock %}
     </div>
-    <div {{ bem('content', [], banner__base_class) }} data-component-theme={{ banner__content__background }}>
+    <div {{ bem('content', [], banner__base_class) }}>
       <div {{ bem('outer-wrap', [], banner__base_class) }}>
         <div {{ bem('wrap', [], banner__base_class) }}>
           <div {{ bem('text', [], banner__base_class) }}>

--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -20,6 +20,7 @@ $break-grand-hero-banner: tokens.$break-m;
   width: 100%;
   max-width: tokens.$break-max-width;
   margin: 0 auto;
+  background-color: var(--color-grand-hero-background);
 
   @media (min-width: $break-grand-hero-banner) {
     align-items: center;
@@ -31,6 +32,70 @@ $break-grand-hero-banner: tokens.$break-m;
 
   &[data-grand-hero-size='full'] {
     min-height: calc(95vh - var(--site-header-height));
+  }
+
+  // Component themes defaults: iterate over each component theme to establish
+  // default variables.
+  @each $theme, $value in $component-grand-hero-themes {
+    &[data-component-theme='#{$theme}'] {
+      --color-text: var(--color-grand-hero-text);
+      --color-backgound: var(--color-grand-hero-background);
+      --color-heading: var(--color-grand-hero-heading);
+      --color-action: var(--color-grand-hero-action);
+      --color-action-secondary: var(--color-grand-hero-action-secondary);
+    }
+  }
+
+  // Global themes: set color slots for each theme
+  // This establishes `--color-slot-` variables name-spaced to the selector
+  // in which it is used. We can map component-level variables to global-level
+  // `--color-slot-` variables.
+  @each $globalTheme, $value in $global-grand-hero-themes {
+    [data-global-theme='#{$globalTheme}'] & {
+      --color-slot-one: var(--global-themes-#{$globalTheme}-colors-slot-one);
+      --color-slot-two: var(--global-themes-#{$globalTheme}-colors-slot-two);
+      --color-slot-three: var(
+        --global-themes-#{$globalTheme}-colors-slot-three
+      );
+      --color-slot-four: var(--global-themes-#{$globalTheme}-colors-slot-four);
+      --color-slot-five: var(--global-themes-#{$globalTheme}-colors-slot-five);
+    }
+  }
+
+  // Component theme overrides: set specific component themes overrides
+  /// define component name spaced variables and map them to global theme slots.
+  &[data-component-theme='one'] {
+    --color-grand-hero-background: var(--color-slot-one);
+    --color-grand-hero-text: var(--color-basic-white);
+    --color-grand-hero-heading: var(--color-basic-white);
+    --color-grand-hero-action: var(--color-basic-white);
+    --color-grand-hero-action-secondary: var(--color-slot-one);
+    --color-link-base: var(--color-grand-hero-text);
+    --color-link-hover: var(--color-grand-hero-text);
+  }
+
+  &[data-component-theme='two'] {
+    --color-grand-hero-background: var(--color-slot-four);
+    --color-grand-hero-text: var(--color-gray-800);
+    --color-grand-hero-heading: var(--color-gray-800);
+    --color-grand-hero-action: var(--color-gray-800);
+    --color-grand-hero-action-secondary: var(--color-basic-white);
+    --color-link-base: var(--color-grand-hero-text);
+    --color-link-hover: var(--color-grand-hero-text);
+
+    a {
+      color: var(--color-gray-800);
+    }
+  }
+
+  &[data-component-theme='three'] {
+    --color-grand-hero-background: var(--color-slot-five);
+    --color-grand-hero-text: var(--color-basic-white);
+    --color-grand-hero-heading: var(--color-basic-white);
+    --color-grand-hero-action: var(--color-basic-white);
+    --color-grand-hero-action-secondary: var(--color-slot-one);
+    --color-link-base: var(--color-grand-hero-text);
+    --color-link-hover: var(--color-grand-hero-text);
   }
 }
 
@@ -114,34 +179,6 @@ $break-grand-hero-banner: tokens.$break-m;
   background: transparent;
   color: var(--color-text);
 
-  // Component themes defaults: iterate over each component theme to establish
-  // default variables.
-  @each $theme, $value in $component-grand-hero-themes {
-    &[data-component-theme='#{$theme}'] {
-      --color-text: var(--color-grand-hero-text);
-      --color-backgound: var(--color-grand-hero-background);
-      --color-heading: var(--color-grand-hero-heading);
-      --color-action: var(--color-grand-hero-action);
-      --color-action-secondary: var(--color-grand-hero-action-secondary);
-    }
-  }
-
-  // Global themes: set color slots for each theme
-  // This establishes `--color-slot-` variables name-spaced to the selector
-  // in which it is used. We can map component-level variables to global-level
-  // `--color-slot-` variables.
-  @each $globalTheme, $value in $global-grand-hero-themes {
-    [data-global-theme='#{$globalTheme}'] & {
-      --color-slot-one: var(--global-themes-#{$globalTheme}-colors-slot-one);
-      --color-slot-two: var(--global-themes-#{$globalTheme}-colors-slot-two);
-      --color-slot-three: var(
-        --global-themes-#{$globalTheme}-colors-slot-three
-      );
-      --color-slot-four: var(--global-themes-#{$globalTheme}-colors-slot-four);
-      --color-slot-five: var(--global-themes-#{$globalTheme}-colors-slot-five);
-    }
-  }
-
   [data-grand-hero-overlay-variation='contained'] & {
     margin-bottom: var(--size-spacing-6);
     width: 100%;
@@ -168,42 +205,6 @@ $break-grand-hero-banner: tokens.$break-m;
     width: 100%;
     background-color: var(--color-grand-hero-background);
     opacity: 0.85;
-  }
-
-  // Component theme overrides: set specific component themes overrides
-  /// define component name spaced variables and map them to global theme slots.
-  &[data-component-theme='one'] {
-    --color-grand-hero-background: var(--color-slot-one);
-    --color-grand-hero-text: var(--color-basic-white);
-    --color-grand-hero-heading: var(--color-basic-white);
-    --color-grand-hero-action: var(--color-basic-white);
-    --color-grand-hero-action-secondary: var(--color-slot-one);
-    --color-link-base: var(--color-grand-hero-text);
-    --color-link-hover: var(--color-grand-hero-text);
-  }
-
-  &[data-component-theme='two'] {
-    --color-grand-hero-background: var(--color-slot-four);
-    --color-grand-hero-text: var(--color-gray-800);
-    --color-grand-hero-heading: var(--color-gray-800);
-    --color-grand-hero-action: var(--color-gray-800);
-    --color-grand-hero-action-secondary: var(--color-basic-white);
-    --color-link-base: var(--color-grand-hero-text);
-    --color-link-hover: var(--color-grand-hero-text);
-
-    a {
-      color: var(--color-gray-800);
-    }
-  }
-
-  &[data-component-theme='three'] {
-    --color-grand-hero-background: var(--color-slot-five);
-    --color-grand-hero-text: var(--color-basic-white);
-    --color-grand-hero-heading: var(--color-basic-white);
-    --color-grand-hero-action: var(--color-basic-white);
-    --color-grand-hero-action-secondary: var(--color-slot-one);
-    --color-link-base: var(--color-grand-hero-text);
-    --color-link-hover: var(--color-grand-hero-text);
   }
 }
 

--- a/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
+++ b/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
@@ -22,6 +22,7 @@
 {% set grand_hero__attributes = {
   'data-grand-hero-overlay-variation': grand_hero__overlay_variation,
   'data-grand-hero-size' : grand_hero__size,
+  'data-component-theme' : grand_hero__content__background,
   class: bem(grand_hero__base_class),
 } %}
 
@@ -53,7 +54,7 @@
   {% if grand_hero__heading is not empty or grand_hero__snippet is not empty or grand_hero__link__content is not empty and grand_hero__link__url is not empty %}
     <div {{ bem('outer-wrap', [], grand_hero__base_class) }}>
       <div {{ bem('wrap', [], grand_hero__base_class) }}>
-        <div {{ bem('content', [], grand_hero__base_class) }} data-component-theme={{ grand_hero__content__background }}>
+        <div {{ bem('content', [], grand_hero__base_class) }}>
           <div {{ bem('content-inner', [], grand_hero__base_class) }}>
             {% if grand_hero__heading is not empty %}
               {% include "@atoms/typography/headings/yds-heading.twig" with {


### PR DESCRIPTION
## [YALB-1410: Bug: Accessibility (FE)- Color Contrast issues in automatic testing tools](https://yaleits.atlassian.net/browse/YALB-1410)

### Description of work
- Moves component theme to root div of the following components:
  - Grand Hero
  - Action Banner

### Testing Link(s)
- [x] Navigate to the [Action Banner Component Story](https://deploy-preview-300--dev-component-library-twig.netlify.app/iframe.html?args=&id=molecules-banners--action-banner)
- [x] Navigate to the [Grand Hero Component Story](https://deploy-preview-300--dev-component-library-twig.netlify.app/iframe.html?args=&id=molecules-banners--grand-hero-banner&viewMode=story)
- [x] Navigate to the [Global Theme Color Pairings](https://deploy-preview-300--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--global-theme-color-pairings)
- [x] Deployed Versions
  - [x] [Grand Hero](https://yalesites-org.github.io/component-library-twig/iframe.html?args=&id=molecules-banners--grand-hero-banner)
  - [x] [Action Banner](https://yalesites-org.github.io/component-library-twig/iframe.html?args=&id=molecules-banners--action-banner)

### Functional Review Steps
- [x] Verify the action banner and grand hero still look and feel like the deployed versions.
- [x] Verify that the global theme levers for the banner matches the currently deployed versions.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify that WAVE, Axe, and any other checkers are now happy with the H2 background color for both components
