### PR TITLE
YALB-1562 themes previous old blues

### DIFF
--- a/components/00-tokens/spacing/spacing.twig
+++ b/components/00-tokens/spacing/spacing.twig
@@ -15,7 +15,7 @@
         <td>--{{ prefix }}-{{ key }}</td>
         <td>{{ value|trim('rem') }}</td>
         <td>{{ value * 16 }}</td>
-        <td><div style="background: var(--color-blue-horizon); height: var(--{{ prefix }}-{{key}}); width: var(--{{ prefix }}-{{key}});"></div></td>
+        <td><div style="background: var(--color-blue-medium); height: var(--{{ prefix }}-{{key}}); width: var(--{{ prefix }}-{{key}});"></div></td>
       </tr>
     {% endfor %}
   </tbody>

--- a/components/01-atoms/forms/select/_yds-select.scss
+++ b/components/01-atoms/forms/select/_yds-select.scss
@@ -4,9 +4,9 @@
 // SVG background-images encoded using https://yoksel.github.io/url-encoder/
 .form-item__dropdown {
   --color-dropdown-border: var(--color-gray-400);
-  --color-dropdown-border-hover: var(--color-blue-horizon);
+  --color-dropdown-border-hover: var(--color-blue-medium);
   --color-dropdown-icon: var(--color-gray-400);
-  --color-dropdown-icon-hover: var(--color-blue-horizon);
+  --color-dropdown-icon-hover: var(--color-blue-medium);
 
   border: var(--border-thickness-1) solid var(--color-dropdown-border);
   display: block;
@@ -43,10 +43,10 @@
 
 .form-item__select {
   --color-select-border: var(--color-gray-400);
-  --color-select-border-hover: var(--color-blue-horizon);
+  --color-select-border-hover: var(--color-blue-medium);
   --color-select-background: var(--color-gray-100);
   --color-select-icon: var(--color-gray-400);
-  --color-select-icon-hover: var(--color-blue-horizon);
+  --color-select-icon-hover: var(--color-blue-medium);
   --color-select-text-color: var(--color-gray-700);
 
   font-size: 100%;

--- a/components/02-molecules/cards/custom-card/_yds-custom-card.scss
+++ b/components/02-molecules/cards/custom-card/_yds-custom-card.scss
@@ -16,7 +16,7 @@ $global-card-themes: map.deep-get(tokens.$tokens, 'global-themes');
   --card-border: 1px solid var(--color-gray-200);
   --color-text-shadow: var(--color-basic-white);
   --color-card-bar-long: var(--color-blue-light);
-  --color-card-bar-short: var(--color-blue-horizon);
+  --color-card-bar-short: var(--color-blue-medium);
 
   display: grid;
   grid-template-columns: 1fr 2fr;

--- a/components/02-molecules/cards/custom-card/_yds-custom-card.scss
+++ b/components/02-molecules/cards/custom-card/_yds-custom-card.scss
@@ -15,7 +15,7 @@ $global-card-themes: map.deep-get(tokens.$tokens, 'global-themes');
 
   --card-border: 1px solid var(--color-gray-200);
   --color-text-shadow: var(--color-basic-white);
-  --color-card-bar-long: var(--color-blue-shale);
+  --color-card-bar-long: var(--color-blue-light);
   --color-card-bar-short: var(--color-blue-horizon);
 
   display: grid;

--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -6,7 +6,7 @@
   --color-muted: var(--color-gray-600);
   --color-navigation-border: var(--color-blue-yale);
   --color-navigation-expanded-item: var(--color-basic-brown-gray);
-  --color-navigation-active-item-link-background: var(--color-blue-shale);
+  --color-navigation-active-item-link-background: var(--color-blue-light);
   --color-navigation-active-item-link-opacity: 0.1;
 }
 
@@ -16,7 +16,7 @@ $menu-sub-max-width: 19rem;
   --color-muted: var(--color-gray-600);
   --color-navigation-border: var(--color-gray-600);
   --color-navigation-expanded-item: var(--color-gray-600);
-  --color-navigation-active-item-link-background: var(--color-blue-horizon);
+  --color-navigation-active-item-link-background: var(--color-blue-medium);
   --color-navigation-active-item-link-opacity: 0.13;
 }
 
@@ -24,7 +24,7 @@ $menu-sub-max-width: 19rem;
   --color-muted: var(--color-gray-600);
   --color-navigation-border: var(--color-gray-600);
   --color-navigation-expanded-item: var(--color-gray-600);
-  --color-navigation-active-item-link-background: var(--color-blue-horizon);
+  --color-navigation-active-item-link-background: var(--color-blue-medium);
   --color-navigation-active-item-link-opacity: 0.13;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6492,9 +6492,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.27.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.27.0/c9fe68223515753ea108a0813bee7889f149a34d",
-      "integrity": "sha512-8FYWs6hQMCHeCZ1RksJdDLRCUVLYqI9WxA1p0caiPbJ3vpNf+0bCtNkhSz43JElapFniMC6qPyfbQYzIP5pW3Q=="
+      "version": "1.28.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.28.0/98b124fb1639dd5e46d45c597bbff249f11ccba4",
+      "integrity": "sha512-w50fl+5UhRIN/6+gSQ+cjVcQoVIMpHvmJTgswN0So0aS58SI/o5T+OS8XDPhg0FmqZ/Ft+9jy3jbT1s/sq6Rww=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -36269,9 +36269,9 @@
       "requires": {}
     },
     "@yalesites-org/tokens": {
-      "version": "1.27.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.27.0/c9fe68223515753ea108a0813bee7889f149a34d",
-      "integrity": "sha512-8FYWs6hQMCHeCZ1RksJdDLRCUVLYqI9WxA1p0caiPbJ3vpNf+0bCtNkhSz43JElapFniMC6qPyfbQYzIP5pW3Q=="
+      "version": "1.28.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.28.0/98b124fb1639dd5e46d45c597bbff249f11ccba4",
+      "integrity": "sha512-w50fl+5UhRIN/6+gSQ+cjVcQoVIMpHvmJTgswN0So0aS58SI/o5T+OS8XDPhg0FmqZ/Ft+9jy3jbT1s/sq6Rww=="
     },
     "accepts": {
       "version": "1.3.8",


### PR DESCRIPTION
## [YALB-1562 - themes previous old blues](https://yaleits.atlassian.net/browse/YALB-1562)

### Description of work
- Reverts blue color values in the "Old Blues" theme and "One" theme in "Component Themes" back to original `medium` and `light` blues, and `gray 100` `gray 800`. 
 

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify the "Old Blues" theme is back to where it was previously. 
- [ ] Compare the old one: 
  - [ ] here: https://deploy-preview-299--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--colors 
  - [ ] and here: https://deploy-preview-299--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--color-global-themes
  - [ ] and here: https://deploy-preview-299--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--global-theme-color-pairings
- [ ] To the updated one in this branch: 
  - [ ] here: https://deploy-preview-304--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--colors
  - [ ] and here: https://deploy-preview-304--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--color-global-themes
  - [ ] and here: https://deploy-preview-304--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--global-theme-color-pairings
- [ ] Note: There are some minor differences due to how the updated themes need _all_ global slots mapped.


https://github.com/yalesites-org/component-library-twig/assets/366413/c8bf7b16-d4fd-41c0-95c2-2cb985f3da13


