### PR TITLE
fix(YALB-1622): fix aspect-ratio for profile card grid

### DIFF
--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -102,6 +102,25 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
     [data-collection-type='list'] & {
       flex: 0 0 33%;
     }
+
+    [data-collection-type='grid'][data-collection-source='profile'] & {
+      aspect-ratio: 1/1;
+
+      // Safari 14 fix for aspect-ratio
+      @supports not (aspect-ratio: 1 / 1) {
+        &::before {
+          float: left;
+          padding-top: 66.66%;
+          content: '';
+        }
+
+        &::after {
+          display: block;
+          content: '';
+          clear: both;
+        }
+      }
+    }
   }
 
   @media (min-width: tokens.$break-mobile) {

--- a/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
+++ b/components/02-molecules/meta/profile-meta/_yds-profile-meta.scss
@@ -104,6 +104,21 @@ $break-profile-banner-max: $break-profile-banner - 0.05;
   @media (min-width: $break-profile-banner) {
     max-width: 661px;
   }
+
+  // Safari 14 fix for aspect-ratio
+  @supports not (aspect-ratio: 3 / 2) {
+    &::before {
+      float: left;
+      padding-top: 66.66%;
+      content: '';
+    }
+
+    &::after {
+      display: block;
+      content: '';
+      clear: both;
+    }
+  }
 }
 
 .profile-meta__content {


### PR DESCRIPTION
## [YALB-1622: Bug: Safari: View of Profile card grid style](https://yaleits.atlassian.net/browse/YALB-1622)

### Description of work
- adds correct aspect-ratio for profile card grid - 1/1
- fixes safari rendering bug

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-307--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card)

### Functional Review Steps
- [x] Using Safari, verify the Profile Card Grid uses an aspect ratio of `1/1` instead of `3/2` which caused an overlap issue in Safari - https://deploy-preview-307--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card
- [x] Verify the Profile Card Collection also looks good https://deploy-preview-307--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--profile-card-collection

- [x] Compare with the dev site: https://dev-yalesites-mt927.pantheonsite.io/test-this-on-safari-please

#### Problem 


https://github.com/yalesites-org/component-library-twig/assets/366413/b878f783-ed84-49fa-b8f2-9320e850c404



---

#### Solution
https://github.com/yalesites-org/component-library-twig/assets/366413/46fd6c2d-ecf0-4949-8b96-d656807d1124


