### PR TITLE
rel-100-mailto-shadow-fix: set text-shadow to inherit for text-with-link__text links

### DIFF
--- a/components/02-molecules/text-with-image/_yds-text-with-image.scss
+++ b/components/02-molecules/text-with-image/_yds-text-with-image.scss
@@ -193,6 +193,8 @@ $component-content-spotlight-themes: map.deep-get(
 
   a {
     @include atoms.link;
+
+    text-shadow: inherit;
   }
 
   > *:last-child {


### PR DESCRIPTION
## [[YALB-XX: Title](https://yaleits.atlassian.net/browse/YALB-XX)](rel-100-mailto-shadow-fix: set text-shadow to inherit for text-with-link__text links)

For text-with-image__text a elements, override the atoms.link mixin to not put a text shadow on links.

### Description of work
- Changes `.text-with-image__text a` elements to inherit their text-shadow, removing the extra shadow from CKE elements linked without proper data attribute decoration.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
