### PR TITLE
rel-100-spotlight-margin-start-fix: Fix padding in between spotlight padding

### DIFF
--- a/components/02-molecules/content-spotlight-portrait/_yds-content-spotlight-portrait.scss
+++ b/components/02-molecules/content-spotlight-portrait/_yds-content-spotlight-portrait.scss
@@ -214,3 +214,8 @@ $component-content-spotlight-port-themes: map.deep-get(
     margin-bottom: 0;
   }
 }
+
+.content-spotlight-portrait:not([data-component-theme='default'])
+  + .content-spotlight-portrait__test:not([data-component-theme='default']) {
+  margin-block-start: 0;
+}

--- a/components/02-molecules/text-with-image/_yds-text-with-image.scss
+++ b/components/02-molecules/text-with-image/_yds-text-with-image.scss
@@ -199,3 +199,8 @@ $component-content-spotlight-themes: map.deep-get(
     margin-bottom: 0;
   }
 }
+
+.content-spotlight-portrait:not([data-component-theme='default'])
+  + .text-with-image:not([data-component-theme='default']) {
+  margin-block-start: 0;
+}


### PR DESCRIPTION
## rel-100-spotlight-margin-start-fix: Fix padding in between spotlight padding

In the original, I believe we were attempting to target the block so that we can make margin-block-start 0, but in the case we were using, it was not selecting it.  I beleve this is correclty targeting now.

Mike T found that there was a gap between the two spotlights.

![Screenshot 2024-01-18 at 11 59 07 AM](https://github.com/yalesites-org/component-library-twig/assets/128765777/83b30763-2616-4522-99a4-050f9d1bb6ef)

### Description of work
- Specifically target the element so we can apply a margin-block-start to 0
- Mirror this in both spotlight places just in case

### Testing Link(s)
- [ ] Navigate to the [Basic Spotlights](https://deploy-preview-326--dev-component-library-twig.netlify.app/?path=/story/page-examples-standard-pages--basic-spotlights)