### PR TITLE
YSP-277: Spotlight without header shows an empty h tag

### DIFF
--- a/components/02-molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig
+++ b/components/02-molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig
@@ -41,11 +41,13 @@
         } %}
       {% endif %}
       {# Heading #}
-      {% include "@atoms/typography/headings/yds-heading.twig" with {
-        heading: content_spotlight_portrait__heading,
-        heading__level: '2',
-        heading__blockname: content_spotlight_portrait__base_class,
-      } %}
+      {% if content_spotlight_portrait__heading %}
+        {% include "@atoms/typography/headings/yds-heading.twig" with {
+          heading: content_spotlight_portrait__heading,
+          heading__level: '2',
+          heading__blockname: content_spotlight_portrait__base_class,
+        } %}
+      {% endif %}
       {# Subheading #}
       {% if content_spotlight_portrait__subheading %}
         {% include "@atoms/typography/text/yds-text.twig" with {

--- a/components/02-molecules/text-with-image/yds-text-with-image.twig
+++ b/components/02-molecules/text-with-image/yds-text-with-image.twig
@@ -41,11 +41,13 @@
         } %}
       {% endif %}
       {# Heading #}
-      {% include "@atoms/typography/headings/yds-heading.twig" with {
-        heading: text_with_image__heading,
-        heading__level: '2',
-        heading__blockname: text_with_image__base_class,
-      } %}
+      {% if text_with_image__heading %}
+        {% include "@atoms/typography/headings/yds-heading.twig" with {
+          heading: text_with_image__heading,
+          heading__level: '2',
+          heading__blockname: text_with_image__base_class,
+        } %}
+      {% endif %}
       {# Subheading #}
       {% if text_with_image__subheading %}
         {% include "@atoms/typography/text/yds-text.twig" with {


### PR DESCRIPTION
## [YSP-277: Spotlight without header shows an empty h tag](https://yaleits.atlassian.net/browse/YSP-277)

### Description of work
- Wraps headings in conditional

### Functional Review Steps
- [ ] Navigate to https://pr-564-yalesites-platform.pantheonsite.io/spotlights-no-heading-no-empty-markup
- [ ] Inspect the first two content spotlights
- [ ] Note that neither have headings or subheadings
- [ ] Verify that markup does not appear for empty html tags (`h2`, `div.content-spotlight-portrait__subheading`)
- [ ] Now inspect the bottom two, the two after the divider
- [ ] Note that both have Headings and Subheadings

https://github.com/yalesites-org/component-library-twig/assets/366413/d58de1d5-dfe8-463c-9afa-4c104dc6a85f
