### PR TITLE
YSP-275: Long email breaks Profile card grid: update email address to linked mailto

### DIFF
--- a/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
+++ b/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
@@ -1,5 +1,6 @@
 @use '../../../00-tokens/tokens';
 @use '../../../01-atoms/atoms';
+@use '../../../01-atoms/controls/text-link/yds-text-link' as link;
 
 $break-directory-card-collection-max: tokens.$break-m - 0.05;
 $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
@@ -125,6 +126,10 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
     & {
     @include tokens.body-s-condensed;
   }
+}
+
+.directory-listing-card__link {
+  @include link.plain-link;
 }
 
 .directory-listing-card__email {

--- a/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
+++ b/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
@@ -46,11 +46,6 @@
         } %}
       {% endif %}
       {% if directory_listing_card__email %}
-        {# {% include "@atoms/typography/text/yds-text.twig" with {
-          text__base_class: 'email',
-          text__blockname: directory_listing_card__base_class,
-          text__content: directory_listing_card__email,
-        } %} #}
         {% include "@atoms/controls/text-link/yds-text-link.twig" with {
           link__url: directory_listing_card_link__url|default('mailto:' ~ directory_listing_card__email),
           link__content: directory_listing_card_link__content|default('Email'),

--- a/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
+++ b/components/02-molecules/cards/directory-listing-card/yds-directory-listing-card.twig
@@ -46,11 +46,16 @@
         } %}
       {% endif %}
       {% if directory_listing_card__email %}
-        {% include "@atoms/typography/text/yds-text.twig" with {
+        {# {% include "@atoms/typography/text/yds-text.twig" with {
           text__base_class: 'email',
           text__blockname: directory_listing_card__base_class,
           text__content: directory_listing_card__email,
-        } %}
+        } %} #}
+        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+          link__url: directory_listing_card_link__url|default('mailto:' ~ directory_listing_card__email),
+          link__content: directory_listing_card_link__content|default('Email'),
+          link__blockname: directory_listing_card__base_class,
+        }%}
       {% endif %}
       {% if directory_listing_card__phone %}
         {% include "@atoms/typography/text/yds-text.twig" with {


### PR DESCRIPTION
## [YSP-275: Long email breaks Profile card grid](https://yaleits.atlassian.net/browse/YSP-275)

### Description of work
- Replaces the text-based email address with a `mailto: link value` link with `Email` text
- Atomic PR: https://github.com/yalesites-org/atomic/pull/203

### Testing Link(s)
- [ ] Navigate to the [Directory Card Component Story](https://deploy-preview-335--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--directory-listing-card-collection)

### Functional Review Steps
- [ ] Navigate to https://deploy-preview-335--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--directory-listing-card-collection
- [ ] Verify the email address plain text has been replaced with a `mailto:` link
- [ ] Test in Drupal here (scroll to the bottom of the page): https://pr-566-yalesites-platform.pantheonsite.io/testing-all-of-the-things
- [ ] You should see something like this: 

https://github.com/yalesites-org/component-library-twig/assets/366413/7b379634-ccce-4439-b6c8-ee4df5a3d647


### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
