### PR TITLE
YSP-353: Release Bug: Footer link style

### DIFF
--- a/components/01-atoms/controls/text-link/_yds-text-link.scss
+++ b/components/01-atoms/controls/text-link/_yds-text-link.scss
@@ -264,6 +264,12 @@ $global-link-themes: map.deep-get(tokens.$tokens, 'global-themes');
     align-items: center;
     width: fit-content;
     background-size: calc(100% - var(--size-spacing-3)) var(--thickness);
+
+    // Footer elements with a dark background can't have white shadows
+    // so this overrides it to match the current background color of the footer.
+    .site-footer__secondary & {
+      --color-text-shadow: var(--color-site-footer-background-color);
+    }
   }
 
   &[data-link-style='no-underline'] {


### PR DESCRIPTION
## [YSP-353: Release Bug: Footer link style](https://yaleits.atlassian.net/browse/YSP-353)

### Description of work
- Adds CSS to footer links to have shadow color matching background color

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-337--dev-component-library-twig.netlify.app/?path=/story/organisms-site-footer--footer-examples)
- [ ] [YaleSites Multidev](https://github.com/yalesites-org/yalesites-project/pull/579)

### Functional Review Steps
- [ ] Visit [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/organisms-site-footer--footer-examples) and verify that the links have a shadow color matching the background it's on
- [ ] Visit [multidev](https://github.com/yalesites-org/yalesites-project/pull/579) and verify that the footer looks right as well.