### PR TITLE
YSP-323: breadcrumb overlayed into text block with heading when page title hidden

### DIFF
--- a/components/02-molecules/page-title/_yds-page-title.scss
+++ b/components/02-molecules/page-title/_yds-page-title.scss
@@ -26,7 +26,17 @@
 // Add margin to the following page-title display types:
 //   - visually-hidden
 //   - hidden (when no page-title div exists after the breadcrumbs__wrapper
+// Margins borrowed from
+// components/04-page-layouts/page-layouts.scss:page_layouts.scss:31-39
 div.page-title.visually-hidden + div,
 div.breadcrumbs__wrapper + :not(.page-title) {
-  margin-top: 1em;
+  margin-top: var(--size-spacing-10); // 4rem
+
+  @media (max-width: tokens.$break-l) {
+    margin-top: var(--size-spacing-8); // 2.5rem large breakpoints
+  }
+
+  @media (max-width: tokens.$break-s) {
+    margin-top: var(--size-spacing-7); // 2rem small breakpoints
+  }
 }

--- a/components/02-molecules/page-title/_yds-page-title.scss
+++ b/components/02-molecules/page-title/_yds-page-title.scss
@@ -22,3 +22,11 @@
 .prefix {
   margin-top: var(--size-spacing-7);
 }
+
+// Add margin to the following page-title display types:
+//   - visually-hidden
+//   - hidden (when no page-title div exists after the breadcrumbs__wrapper
+div.page-title.visually-hidden + div,
+div.breadcrumbs__wrapper + :not(.page-title) {
+  margin-top: 1em;
+}

--- a/components/05-page-examples/standard-pages/standard-page.stories.js
+++ b/components/05-page-examples/standard-pages/standard-page.stories.js
@@ -64,6 +64,12 @@ export default {
       options: ['one', 'two', 'three'],
       defaultValue: 'one',
     },
+    pageTitleDisplay: {
+      name: 'Page Title Display',
+      type: 'select',
+      options: ['display', 'hidden', 'visually-hidden'],
+      defaultValue: 'display',
+    },
   },
 };
 
@@ -71,6 +77,7 @@ export default {
 export const Basic = ({
   siteName,
   pageTitle,
+  pageTitleDisplay,
   allowAnimatedItems = localStorage.getItem('yds-cl-twig-animate-items'),
   globalTheme = localStorage.getItem('yds-cl-twig-global-theme'),
   menuVariation = localStorage.getItem('yds-cl-twig-menu-variation'),
@@ -97,6 +104,8 @@ export const Basic = ({
     site_name: siteName,
     page_title__heading: pageTitle,
     page_title__meta: null,
+    page_title__display: pageTitleDisplay,
+    page_title__additional_classes: [pageTitleDisplay],
     site_animate_components: allowAnimatedItems,
     site_global__theme: globalTheme,
     site_header__border_thickness: headerBorderThickness,

--- a/components/05-page-examples/standard-pages/standard-page.twig
+++ b/components/05-page-examples/standard-pages/standard-page.twig
@@ -1,7 +1,10 @@
 {% extends "@page-layouts/yds-full-width.twig" %}
   {% block page__content %}
     {% include "@organisms/menu/breadcrumbs/yds-breadcrumbs.twig" %}
-    {% include "@molecules/page-title/yds-page-title.twig" %}
+    {% include "@molecules/page-title/yds-page-title.twig" with {
+        page_title__display: page_title__display,
+        page_title__additional_classes: page_title__additional_classes,
+    } %}
 
     {% include "@molecules/text/yds-text-field.twig" with {
       text_field__alignment: 'left',
@@ -21,7 +24,7 @@
       text_field__content: '<h2>New Text Block</h2>
         <p>People will want to chunk out text content by sections, often kicking off with a heading, to make it easier to maintain. E.g. rearranging sections of the page, dropping in CTAs, etc. The spacing isn’t the same using this approach, though.</p>
         '
-    }%}
+    } %}
 
     {% include "@molecules/wrapped-image/yds-wrapped-image.twig" with {
       wrapped_image__width: 'site',
@@ -35,15 +38,14 @@
     } %}
 
     {% include "@page-examples/_intro-content-examples.twig" %}
-    {% include "@molecules/text/yds-text-field.twig" with { 
-      text_field__alignment: 'left', 
+    {% include "@molecules/text/yds-text-field.twig" with {
+      text_field__alignment: 'left',
       text_field__content: '<p>Chemistry has been responsible for some of the most significant improvements in our quality of life over the last century.</p><p>The discovery of antibiotics and other pharmaceuticals, the advent of computers, and the development of industrial methods to produce fertilizer, all have required fundamental advances in chemistry. Chemistry is increasingly playing a central role in the development of alternative-energy vectors to replace fossil fuels, the realization of practical quantum computers, the discovery of new methods to treat and prevent diseases, and the adoption of more sustainable industrial processes.</p>',
     } %}
     {% include "@molecules/image/yds-content-image.twig" with {
       content_image__alignment: 'left',
       content_image__width: 'site',
-    }
-    %}
+    } %}
     {% include "@molecules/text/yds-text-field.twig" with {
       text_field__alignment: 'left',
       text_field__content: '<p>The undergraduate program in Chemistry at Yale reflects the position of chemistry as the foundation of all the molecular sciences. Students are equipped with the technical skills to appreciate the scientific basis for previous discoveries and develop the fundamental expertise required to make future breakthroughs. Under the tutelage of world-leading researchers, students are exposed to a broad range of topics in chemistry. The development of technical skills through lecture classes is complemented with hands-on experience in state-of-the-art chemistry laboratories.</p><h2>Heading 2</h2><p>Many students also perform independent laboratory research under the guidance of a faculty mentor. This rigorous training prepares students for professional careers in a diverse array of fields by teaching them how to apply the scientific method, providing them with skills in quantitative reasoning, and exposing them to scientific research.</p><h3>Heading 3</h3><p>After graduation, students with a B.A. or B.S. degree often pursue work or further studies in chemistry, biochemistry, or health-related disciplines, but also find their broad scientific training beneficial in energy research, policy, environment, business management, and law. As the problems of contemporary society involve ever more complex scientific issues, degree programs in the sciences become increasingly appropriate for students wishing to pursue careers in public policy, government, or public service.</p><p><strong>The following headings are here only on this page to showcase them inside a text block</strong>.</p><h4>Heading 4</h4><p>After graduation, students with a B.A. or B.S. degree often pursue work or further studies in chemistry, biochemistry, or health-related disciplines, but also find their broad scientific training beneficial in energy research, policy, environment, business management, and law. As the problems of contemporary society involve ever more complex scientific issues, degree programs in the sciences become increasingly appropriate for students wishing to pursue careers in public policy, government, or public service.</p><h5>Heading 5</h5><p>After graduation, students with a B.A. or B.S. degree often pursue work or further studies in chemistry, biochemistry, or health-related disciplines, but also find their broad scientific training beneficial in energy research, policy, environment, business management, and law. As the problems of contemporary society involve ever more complex scientific issues, degree programs in the sciences become increasingly appropriate for students wishing to pursue careers in public policy, government, or public service.</p><h6>Heading 6</h6><p>After graduation, students with a B.A. or B.S. degree often pursue work or further studies in chemistry, biochemistry, or health-related disciplines, but also find their broad scientific training beneficial in energy research, policy, environment, business management, and law. As the problems of contemporary society involve ever more complex scientific issues, degree programs in the sciences become increasingly appropriate for students wishing to pursue careers in public policy, government, or public service.</p>',
@@ -55,7 +57,7 @@
     } %}
 
     {% include "@molecules/text/yds-text-field.twig" with {
-      text_field__alignment: 'left', 
+      text_field__alignment: 'left',
       text_field__content: '<h2>Program Information</h2><h3>The Undergraduate Handbook</h3><p>A comprehensive guide for prospective and current Chemistry Majors, with a complete description of requirements and opportunities.</p><p><a href="#">View the handbook online</a></p><h3>Course List</h3><p>A list of courses and a description of the Chemistry undergraduate program, including information on placement exams, laboratory registration, premedical students, and major requirements</p><p><a href="#">Yale College programs of study</a></p>',
     } %}
 


### PR DESCRIPTION
## [YSP-323: breadcrumb overlayed into text block with heading when page title hidden](https://yaleits.atlassian.net/browse/YSP-323)

The issue was when hiding the page title, yet creating a block that contained a header for its first element, it would cause the header item to bleed into the breadcrumbs.  This was due to the visually hidden happening on the whole div.  In normal cases, the heading has a margin-top of 1em due to text-field-header-spacing on the h1.  We emulate this by targeting the div that still is present containing the visually hidden page title so that we still have the same spacing.

### Description of work
- Add margin-tops to both visually-hidden page titles and hidden page titles
- Add a storybook variable to display these in a standard page

### Testing Link(s)
- [ ] [Storybook](https://deploy-preview-339--dev-component-library-twig.netlify.app/?path=/story/page-examples-standard-pages--basic)

### Functional Review Steps
- [ ] Change the new `Page Title Display` select between each option and ensure that breadcrumbs don't bleed into the heading below it.
- [ ] Visit temporarily created multidev in [Yalesites PR](https://github.com/yalesites-org/yalesites-project/pull/584) and follow the steps there

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
