### PR TITLE
YSP-352: Mobile menu hide animation on resize

### DIFF
--- a/components/02-molecules/menu/menu-toggle/yds-menu-toggle.js
+++ b/components/02-molecules/menu/menu-toggle/yds-menu-toggle.js
@@ -64,11 +64,22 @@ Drupal.behaviors.menuToggle = {
       }
     }
 
+    // Retrieve the current menu state of the menu
+    function getMenuState(target, attribute) {
+      return target.getAttribute(attribute);
+    }
+
     // Show/Hide menu on toggle click.
     if (menuToggle) {
       menuToggle.addEventListener('click', () => {
         toggleMenuState(header, mainMenuState);
         trapKeyboard(header);
+      });
+
+      window.addEventListener('resize', () => {
+        if (getMenuState(header, mainMenuState) === 'closed') {
+          header.setAttribute(mainMenuState, 'loaded');
+        }
       });
     }
 

--- a/components/02-molecules/menu/menu-toggle/yds-menu-toggle.js
+++ b/components/02-molecules/menu/menu-toggle/yds-menu-toggle.js
@@ -39,7 +39,7 @@ Drupal.behaviors.menuToggle = {
     // Function to toggle the open/closed state of the main menu.
     function toggleMenuState(target, attribute) {
       const newMenuState =
-        target.getAttribute(attribute) === 'closed' ? 'open' : 'closed';
+        target.getAttribute(attribute) === 'open' ? 'closed' : 'open';
       const ariaButtonState =
         target.getAttribute(attribute) === 'closed' ? 'true' : 'false';
 

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -254,6 +254,10 @@ $background-image-max-width: 100rem;
     [data-main-menu-state='loaded'] & {
       visibility: hidden;
       transform: translateY(-100%);
+
+      & svg.primary-nav__toggle-icon {
+        display: none;
+      }
     }
 
     [data-main-menu-state='closed'] & {

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -249,12 +249,21 @@ $background-image-max-width: 100rem;
     max-width: 100%;
     overflow: auto;
     border-bottom: var(--site-header-mobile-border-bottom);
-    transform: translateY(0%);
+    transform: translateY(-100%);
+
+    [data-main-menu-state='loaded'] & {
+      visibility: hidden;
+      transform: translateY(-100%);
+    }
 
     [data-main-menu-state='closed'] & {
       @include tokens.animate-hidden(var(--site-header-animation-speed));
 
       transform: translateY(-100%);
+    }
+
+    [data-main-menu-state='open'] & {
+      transform: translateY(0%);
     }
 
     // when it's a simple menu with an image we need to set a min-height

--- a/components/03-organisms/site-header/yds-site-header.twig
+++ b/components/03-organisms/site-header/yds-site-header.twig
@@ -14,7 +14,7 @@
 {% set site_header__base_class = 'site-header' %}
 
 {% set site_header__attributes = {
-  'data-main-menu-state': 'closed',
+  'data-main-menu-state': 'loaded',
   'data-component-width': 'site',
   'data-site-header-nav-position': site_header__nav_position|default('right'),
   'data-site-header-border-thickness': site_header__border_thickness|default('8'),


### PR DESCRIPTION
## [YSP-352: Mobile menu hide animation on resize](https://yaleits.atlassian.net/browse/YSP-352)

When resizing the window to a mobile size, the closed menu actually shows temporarily and then animates up to hide itself.

A loaded menu state is one where the page has been loaded, but no toggles have been made.  This lets us take that into account and not display the visual rollup on a resize.

### Description of work
- Add `loaded` initial menu state so that we can properly hide the menu on initial resize
- On window resize, set the state to `loaded` if it was `closed`

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-340--dev-component-library-twig.netlify.app/?path=/story/page-examples-standard-pages--basic)

### Functional Review Steps
- [x] Resize the loaded page to a mobile menu size
- [x] Verify you don't see the mobile menu roll up after resizing
- [x] Click the expand button
- [x] Click the collapse button
- [x] Resize outside of mobile menu size
- [x] Resize back to mobile menu size
- [x] Verify that you do not see the mobile menu roll up after resizing
- [x] Expand the menu button
- [x] Resize and make sure the open state still works when going mobile

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
