### PR TITLE
YALB-363: Design: Serif text in right column gets cut off | YALB-365: Design: Grand Hero Banner overlay header spacing | YALB-424: Removing primary-nav and grand hero results in missing fontawesome

### DIFF
--- a/components/00-tokens/layout/yds-layout.js
+++ b/components/00-tokens/layout/yds-layout.js
@@ -10,6 +10,9 @@ Drupal.behaviors.layout = {
     // Selectors.
     const bodyCopyComponents = context.querySelectorAll(bodyCopyClasses);
 
+    // tables
+    const tableElement = context.querySelectorAll('table');
+
     bodyCopyComponents.forEach((component) => {
       const nextElement = component.nextElementSibling;
 
@@ -24,6 +27,14 @@ Drupal.behaviors.layout = {
         // Add the `no-page-spacing` class to the component.
         component.classList.add('no-page-spacing');
       }
+    });
+
+    // Wrap table elements in a wrapping div to control overflow
+    tableElement.forEach((table) => {
+      const wrapper = document.createElement('div');
+      wrapper.classList.add('table-wrapper');
+      table.parentNode.insertBefore(wrapper, table);
+      wrapper.appendChild(table);
     });
   },
 };

--- a/components/01-atoms/images/fa-icons/_yds-fa-icon.twig
+++ b/components/01-atoms/images/fa-icons/_yds-fa-icon.twig
@@ -39,5 +39,5 @@
   {% endif %}
 </i>
 {%- if fa_icon__sr_title %}
-  <span class="sr-only">{{fa_icon__sr_title}}</span>
+  <span class="visually-hidden">{{fa_icon__sr_title}}</span>
 {% endif %}

--- a/components/01-atoms/tables/_table.scss
+++ b/components/01-atoms/tables/_table.scss
@@ -9,6 +9,10 @@ table {
   width: 100%;
 }
 
+.table-wrapper {
+  overflow-x: auto;
+}
+
 table caption {
   text-align: left;
   margin-top: var(--size-spacing-4);

--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -193,8 +193,7 @@ $break-grand-hero-banner: tokens.$break-m;
 
 .grand-hero-banner__content {
   position: relative;
-  padding: var(--size-spacing-6) var(--size-spacing-site-gutter)
-    var(--size-spacing-7);
+  padding: var(--size-spacing-6) var(--size-spacing-site-gutter);
   background: transparent;
   color: var(--color-text);
 

--- a/components/02-molecules/text/_yds-text-field.scss
+++ b/components/02-molecules/text/_yds-text-field.scss
@@ -7,10 +7,6 @@
   // used by a element for animated hover underline
   --color-text-shadow: var(--color-basic-white);
 
-  .text {
-    overflow-x: auto;
-  }
-
   &[data-component-alignment='left'] {
     .text {
       max-width: var(--size-component-layout-width-content);

--- a/lib/ys_link/builders/sr_only_creator.js
+++ b/lib/ys_link/builders/sr_only_creator.js
@@ -9,7 +9,7 @@
   ysLinks.createSrOnlySpan = (options = {}) => {
     const {
       content = '(unknown link--please let us know so we can add one)',
-      classes = ['sr-only'],
+      classes = ['visually-hidden'],
       elementType = 'span',
     } = options;
     const span = document.createElement(elementType);


### PR DESCRIPTION
## [YALB-363: Design: Serif text in right column gets cut off](https://yaleits.atlassian.net/browse/YSP-363)
## [YALB-365: Design: Grand Hero Banner overlay header spacing](https://yaleits.atlassian.net/browse/YSP-365)
## [YALB-424: Removing primary-nav and grand hero results in missing fontawesome](https://yaleits.atlassian.net/browse/YSP-424)

### Description of work
- YSP-363: Adds `overflow` override to text component in second column so the serif along the left side doesn't get cut off. 
- YSP-365: Adds conditional check for grand hero content so the markup for grand hero content doesn't render, causing the `gap` flex spacing to add more space when only the heading is present
- YSP-424: Adds fontawesome library in atomic.yml file and removes the attach statements from block templates

### Testing Link(s)
- [ ] https://pr-601-yalesites-platform.pantheonsite.io/profile

### Functional Review Steps
#### Testing: [YALB-363: Design: Serif text in right column gets cut off](https://yaleits.atlassian.net/browse/YSP-363)

- [x] Navigate to: https://pr-601-yalesites-platform.pantheonsite.io/profile
- [x] Scroll to the bottom of the content on the page to the two-column layout
- [x] Verify that the 'Y' serifs in `Yale` fully render and are not cut off by their parent `text` div
- [x] Note: this issue was caused by `overflow-x: auto` on the `text` element. This was added to allow `table` elements to scroll when users are on smaller screen.

https://github.com/yalesites-org/component-library-twig/assets/366413/00181bb4-d37f-4b36-a71f-07c153d2d1b8

- [x] Navigate to this page: https://pr-601-yalesites-platform.pantheonsite.io/table-page-test
- [x] If you view the page at mobile/smaller resolutions, verify the table still allows you to scroll. 
- [x] I added some JS to wrap any `table` element in a wrapper div, which has the `overflow-x: auto` property so we don't have to set it on the `text` element and cause other issues. 


https://github.com/yalesites-org/component-library-twig/assets/366413/7a8cc75d-2b26-41f4-8b08-550a7325fbbb



---

#### Testing: [YALB-365: Design: Grand Hero Banner overlay header spacing](https://yaleits.atlassian.net/browse/YSP-365)

- [x] Navigate to: https://pr-601-yalesites-platform.pantheonsite.io/profile
- [x] Verify that the hero heading is the only content in the hero content area
- [x] Note: This issue was caused by the content div element (`grand-hero-banner__snippet`) printing to the DOM even if no content was entered **and** the `grand-hero-banner__content-inner` element has a `gap` property set which added extra space in between the heading and the empty content div. I changed the wiring in Atomic to conditionally display the value if a value actually exists. With the empty content markup no longer printing, the heading does not have extra space. I also adjusted the bottom padding to match the top padding. Previously, the bottom padding was using a larger padding variable than the top. 
- [x] Inspect the heading and verify there is equal space around the heading and the content appears vertically centered within its background

https://github.com/yalesites-org/component-library-twig/assets/366413/ef05d5a6-d2ed-4f9b-82bb-91708abe88a3


---

#### Testing: [YALB-424: Removing primary-nav and grand hero results in missing fontawesome](https://yaleits.atlassian.net/browse/YSP-424)

- [x] Navigate to: https://pr-601-yalesites-platform.pantheonsite.io
- [x] Verify that fontawesome still loads on the page
- [x] Note the code changes in Atomic: https://github.com/yalesites-org/atomic/pull/211/files
- [x] The library is now loaded by default as part of the theme instead of loading in components based on use since we're using fontawesome globally.


https://github.com/yalesites-org/component-library-twig/assets/366413/bdef43cf-22e3-413a-8563-25281adbec62



---

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
