### PR TITLE
YSP-366: Card display mode spacing between heading, content, and image

### DIFF
--- a/components/02-molecules/cards/custom-card/_yds-custom-card.scss
+++ b/components/02-molecules/cards/custom-card/_yds-custom-card.scss
@@ -133,6 +133,7 @@ $global-card-themes: map.deep-get(tokens.$tokens, 'global-themes');
 
     @media (min-width: tokens.$break-m) {
       min-height: 0.375rem;
+      margin-bottom: tokens.$size-spacing-5;
     }
   }
 

--- a/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
+++ b/components/02-molecules/cards/directory-listing-card/_yds-directory-listing-card.scss
@@ -24,6 +24,8 @@ $break-directory-card-collection-list-image-max: tokens.$break-s - 0.05;
 
 .directory-listing-card__image {
   @media (max-width: $break-directory-card-collection-list-image-max) {
+    margin-bottom: tokens.$size-spacing-5;
+
     [data-collection-type='directory-listing'] & {
       max-width: 50%;
     }

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -70,6 +70,8 @@ $break-card-collection-list-image-max: tokens.$break-s - 0.05;
   }
 
   @media (min-width: tokens.$break-m) {
+    margin-bottom: tokens.$size-spacing-5;
+
     [data-collection-type='list'][data-collection-featured='false'] & {
       flex: 0 1 40%;
     }


### PR DESCRIPTION
## [YSP-366: Card display mode spacing between heading, content, and image](https://yaleits.atlassian.net/browse/YSP-366)

### Description of work
- Adds conditional logic to `reference__card__overline` in Atomic template: 
- Adds `bottom-margin` to `__image` s in card grid to create more space between the image and the heading
- The ticket issue highlighted `page` grid items, specifically, but this fix applies to all card grid type items. 

### Testing Link(s)
- [ ] Navigate to the [Multidev](https://pr-603-yalesites-platform.pantheonsite.io/all-the-cards)
- [ ] Atomic pr is here: https://github.com/yalesites-org/atomic/pull/212

### Functional Review Steps
- [x] Navigate to: https://pr-603-yalesites-platform.pantheonsite.io/all-the-cards
- [x] Review the card grids on the page
- [x] Inspect a card item in each grid, verify there is equal spacing between the card image and the card title. Rather, verify that bottom margin has been added to the `__image` element in each card grid item.

https://github.com/yalesites-org/component-library-twig/assets/366413/3e9af43b-6b8b-48b6-9d7f-869db358255c



