### PR TITLE
YSP-426: Placement for the external link icon on footer logo

### DIFF
--- a/lib/ys_link/config.js
+++ b/lib/ys_link/config.js
@@ -13,6 +13,7 @@ ysLinkSettings = {
     '.node-page-layout-builder-form a',
     '.layout-builder__link',
     '.toolbar-menu a',
+    'a:has(img)'
   ],
   debug: false,
 };


### PR DESCRIPTION
## [YSP-426: Placement for the external link icon on footer logo](https://yaleits.atlassian.net/browse/YSP-426)

The mega footer allows images to be linked, which could be external, causing the external link to occur in some cases, which looks odd.  This skips those and any that would contain an image inside of the link since it would look odd in most cases I can think of.

### Description of work
- Excludes link treatment for links containing an image tag

### Testing Link(s)
- [ ] Navigate to [multidev](https://pr-602-yalesites-platform.pantheonsite.io)

### Functional Review Steps
- [x] Change footer to use mega footer
- [x] Add external links to a footer logo image
- [x] Ensure the image is not decorated when visiting pages
- [x] Ensure other blocks look ok