### PR TITLE
YSP-375: TwigTweak errors when removing media used in gallery

### DIFF
--- a/components/01-atoms/images/image/_image.twig
+++ b/components/01-atoms/images/image/_image.twig
@@ -1,10 +1,14 @@
 {% set image__base_class = image__base_class|default('image') %}
 
-<img
-  {{ bem(image__base_class, image__modifiers, image__blockname) }}
-  {% if image__srcset %}srcset="{{ image__srcset }}"{% endif %}
-  {% if image__sizes %}sizes="{{ image__sizes }}"{% endif %}
-  {% if image__alt %}alt="{{ image__alt }}"{% endif %}
-  {% if image__title %}title="{{ image__title }}"{% endif %}
-  src="{{ image__src }}"
-/>
+{% if image__src is empty %}
+  Missing image
+{% else %}
+  <img
+    {{ bem(image__base_class, image__modifiers, image__blockname) }}
+    {% if image__srcset %}srcset="{{ image__srcset }}"{% endif %}
+    {% if image__sizes %}sizes="{{ image__sizes }}"{% endif %}
+    {% if image__alt %}alt="{{ image__alt }}"{% endif %}
+    {% if image__title %}title="{{ image__title }}"{% endif %}
+    src="{{ image__src }}"
+  />
+{% endif %}

--- a/components/03-organisms/galleries/media-grid/_yds-media-grid.scss
+++ b/components/03-organisms/galleries/media-grid/_yds-media-grid.scss
@@ -41,10 +41,6 @@
     }
   }
 
-  button& {
-    color: var(--color-basic-white);
-  }
-
   [data-media-grid-variation='interactive'] & {
     position: relative;
     background-color: var(--color-basic-black);
@@ -53,6 +49,15 @@
       cursor: pointer;
     }
   }
+}
+
+/*
+ * This is specific to a media grid item that would have no image.  In this
+ * case, we display text conveying this to the user, but it must be legible on
+ * the background.
+ */
+button.media-grid__image {
+  color: var(--color-basic-white);
 }
 
 .media-grid__image {

--- a/components/03-organisms/galleries/media-grid/_yds-media-grid.scss
+++ b/components/03-organisms/galleries/media-grid/_yds-media-grid.scss
@@ -41,6 +41,10 @@
     }
   }
 
+  button& {
+    color: var(--color-basic-white);
+  }
+
   [data-media-grid-variation='interactive'] & {
     position: relative;
     background-color: var(--color-basic-black);

--- a/components/03-organisms/galleries/media-grid/media-grid.yml
+++ b/components/03-organisms/galleries/media-grid/media-grid.yml
@@ -53,3 +53,10 @@ media_grid__items:
     image__sizes: '100vw'
     image__src: 'https://picsum.photos/320/512'
     image__alt: 'A 1 by 1.6 image'
+  - media_grid__modal__heading: 'Image that does not exist'
+    media_grid__modal__text: '<p>Optional nineth caption. Nibh nisl condimentum id venenatis a condimentum vitae sapien. Purus semper eget duis at tellus at. Magnis dis parturient montes nascetur ridiculus mus. Ipsum a arcu cursus vitae congue. Vel elit scelerisque mauris pellentesque pulvinar pellentesque. Massa tempor nec feugiat nisl. Consequat interdum varius sit amet mattis vulputate. Eget magna fermentum iaculis eu non. Maecenas sed enim ut sem.</p>'
+    output_image_tag: true
+    image__srcset: ''
+    image__sizes: '100vw'
+    image__src: ''
+    image__alt: 'No image'


### PR DESCRIPTION
## [YSP-375: TwigTweak errors when removing media used in gallery](https://yaleits.atlassian.net/browse/YSP-375)

### Description of work
- Adds "Missing image" for images with no src
- Ensure the text that is displayed has good contrast on the black background
- Create an instance in Storybook showing off a no-image gallery item

### Testing Link(s)
- [ ] Navigate to the [Gallery Story](https://deploy-preview-344--dev-component-library-twig.netlify.app/?path=/story/organisms-galleries--interactive-grid)

### Functional Review Steps
- [ ] Verify that you see the "Missing image" version as part of the gallery
- [ ] Visit [the atomic version](https://github.com/yalesites-org/atomic/pull/209) to test with Drupal