### PR TITLE
YSP-347: Tabs: Alignment dial + width

### DIFF
--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -26,6 +26,11 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
     margin: 0 auto;
   }
 
+  [data-component-alignment='center'][data-component-width='site'] & {
+    max-width: var(--size-component-layout-width-site);
+    margin: 0 auto;
+  }
+
   // Global themes: set color slots for each theme
   // This establishes `--color-slot-` variables name-spaced to the selector
   // in which it is used. We can map component-level variables to global-level

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -21,6 +21,11 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
     max-width: var(--size-component-layout-width-content);
   }
 
+  [data-component-width='site'] & {
+    max-width: var(--size-component-layout-width-site);
+    margin: 0 auto;
+  }
+
   // Global themes: set color slots for each theme
   // This establishes `--color-slot-` variables name-spaced to the selector
   // in which it is used. We can map component-level variables to global-level

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -17,18 +17,24 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   --color-tabs-accent: --color-gray-500;
   --size-tabs-control: 4rem;
 
-  [data-component-alignment='left'][data-component-width='site'] & {
+  // content width when left aligned
+  [data-component-alignment='left'] & {
     max-width: var(--size-component-layout-width-content);
   }
 
-  [data-component-alignment='center'][data-component-width='content'] & {
-    max-width: var(--size-component-layout-width-content);
+  // centered when center aligned
+  [data-component-alignment='center'] & {
     margin: 0 auto;
   }
 
-  [data-component-alignment='center'][data-component-width='site'] & {
+  // content-width
+  [data-component-width='content'] & {
+    max-width: var(--size-component-layout-width-content);
+  }
+
+  // center aligned and site width
+  [data-component-width='site'] & {
     max-width: var(--size-component-layout-width-site);
-    margin: 0 auto;
   }
 
   // Global themes: set color slots for each theme

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -17,12 +17,12 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   --color-tabs-accent: --color-gray-500;
   --size-tabs-control: 4rem;
 
-  [data-component-alignment='left'] & {
+  [data-component-alignment='left'][data-component-width='site'] & {
     max-width: var(--size-component-layout-width-content);
   }
 
-  [data-component-width='site'] & {
-    max-width: var(--size-component-layout-width-site);
+  [data-component-alignment='center'][data-component-width='content'] & {
+    max-width: var(--size-component-layout-width-content);
     margin: 0 auto;
   }
 

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -32,7 +32,12 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
     max-width: var(--size-component-layout-width-content);
   }
 
-  // center aligned and site width
+  // max width
+  [data-component-width='max'] & {
+    max-width: var(--size-component-layout-width-max);
+  }
+
+  // site width
   [data-component-width='site'] & {
     max-width: var(--size-component-layout-width-site);
   }

--- a/components/02-molecules/tabs/tabs.stories.js
+++ b/components/02-molecules/tabs/tabs.stories.js
@@ -12,7 +12,7 @@ export default {
   argTypes: {
     width: {
       name: 'Component width',
-      options: ['site', 'content'],
+      options: ['site', 'content', 'max'],
       type: 'select',
       defaultValue: 'site',
     },

--- a/components/02-molecules/tabs/tabs.stories.js
+++ b/components/02-molecules/tabs/tabs.stories.js
@@ -14,13 +14,13 @@ export default {
       name: 'Component width',
       options: ['site', 'content'],
       type: 'select',
-      defaultValue: 'site',
+      defaultValue: 'content',
     },
     alignment: {
       name: 'Component alignment',
       options: ['left', 'center'],
       type: 'select',
-      defaultValue: 'left',
+      defaultValue: 'center',
     },
   },
 };

--- a/components/02-molecules/tabs/tabs.stories.js
+++ b/components/02-molecules/tabs/tabs.stories.js
@@ -14,7 +14,7 @@ export default {
       name: 'Component width',
       options: ['site', 'content'],
       type: 'select',
-      defaultValue: 'content',
+      defaultValue: 'site',
     },
     alignment: {
       name: 'Component alignment',

--- a/components/02-molecules/tabs/tabs.stories.js
+++ b/components/02-molecules/tabs/tabs.stories.js
@@ -7,9 +7,27 @@ import './yds-tabs';
 /**
  * Storybook Definition.
  */
-export default { title: 'Molecules/Tabs' };
+export default {
+  title: 'Molecules/Tabs',
+  argTypes: {
+    width: {
+      name: 'Component width',
+      options: ['site', 'content'],
+      type: 'select',
+      defaultValue: 'site',
+    },
+    alignment: {
+      name: 'Component alignment',
+      options: ['left', 'center'],
+      type: 'select',
+      defaultValue: 'left',
+    },
+  },
+};
 
-export const Tabs = () => `
+export const Tabs = ({ width, alignment }) => `
+<div class="component-wrapper" data-component-width="${width}" data-component-alignment="${alignment}">
   ${tabs(tabData)}
   ${tabs({ ...tabData, tabs__id: '123' })}
+</div>
 `;


### PR DESCRIPTION
## [YSP-347: Tabs: Alignment dial + width](https://yaleits.atlassian.net/browse/YALB-347)

### Description of work
- Adds dial options to component wrapper around the tabs component

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Navigate to:https://deploy-preview-352--dev-component-library-twig.netlify.app/?path=/story/molecules-tabs--tabs
- [ ] Change the options to: 
  - [ ] Width: `site`  
  - [ ] Alignment: `center`

<img width="2553" alt="Screenshot 2024-04-10 at 1 17 22 PM" src="https://github.com/yalesites-org/component-library-twig/assets/366413/af82abbc-b057-4671-b51f-ebb105cb7206">

- [ ] And then
  - [ ] Width: `site`  
  - [ ] Alignment: `left`
  
<img width="2560" alt="Screenshot 2024-04-10 at 1 17 30 PM" src="https://github.com/yalesites-org/component-library-twig/assets/366413/b9a10917-67b1-4e89-ae82-7e8b40687ce5">


- [ ] And then
  - [ ] Width: `content`  
  - [ ] Alignment: `left`

<img width="2548" alt="Screenshot 2024-04-10 at 1 17 39 PM" src="https://github.com/yalesites-org/component-library-twig/assets/366413/01eaacd4-e940-4ba8-9328-4641837be307">


- [ ] Lastly
  - [ ] Width: `max`  
  - [ ] Alignment: `left`

<img width="2551" alt="Screenshot 2024-04-10 at 1 17 46 PM" src="https://github.com/yalesites-org/component-library-twig/assets/366413/9356cc3e-0633-4866-abec-9e1434a0cc51">


You can also play with `content` `center`, and `max`, `center` to see how the width might affect the layout. 

