### PR TITLE
fix(YSP-527): V1.3.0: Reference Card link color contrast

### DIFF
--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -42,15 +42,6 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     --color-heading: var(--color-card-single-text);
 
     margin-block-start: var(--size-spacing-11);
-
-    // Overload the color to be the single text color to fix contrast issues.
-    & a.reference-card__heading-link {
-      color: var(--color-card-single-text);
-
-      &:visited {
-        color: var(--color-card-single-text);
-      }
-    }
   }
 
   // Condensed card collection
@@ -361,6 +352,12 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     @include tokens.h3-yale-new;
 
     font-weight: var(--font-weights-yalenew-bold);
+
+    // Override hover link color since slot 2 could cause contrast issues
+    // with the darker background.
+    & .reference-card__heading-link {
+      --color-link-hover: var(--color-link-hover);
+    }
   }
 
   [data-collection-type='grid'][data-collection-featured='true'] & {

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -42,6 +42,15 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     --color-heading: var(--color-card-single-text);
 
     margin-block-start: var(--size-spacing-11);
+
+    // Overload the color to be the single text color to fix contrast issues.
+    & a.reference-card__heading-link {
+      color: var(--color-card-single-text);
+
+      &:visited {
+        color: var(--color-card-single-text);
+      }
+    }
   }
 
   // Condensed card collection


### PR DESCRIPTION
## [YSP-527: V1.3.0: Reference Card link color contrast](https://yaleits.atlassian.net/browse/YSP-527)

In single card types like reference cards, the hover link and link would change color, which does not match Storybook, which keeps the text white, even when visited.  This attempts to get us closer to a consistent look with Storybook.

### Description of work
- Modifies what `--color-link-hover` is in the case of the heading link on a reference card to match color-link-hover
  - This mimics what grand hero is doing in a similar case

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-365--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--profile-card&args=collectionType:single)

### Functional Review Steps
- Verify these in Safari, Firefox, and a Chromium-based browser as they had different behaviors
  - [ ] Verify the link text is using an overloaded `--color-link-hover` of `var(--color-link-hover)`
  - [ ] Visit the [Drupal Multidev](https://github.com/yalesites-org/yalesites-project/pull/651) to test this in Drupal as well
  - [ ] Ensure behavior is consistent cross browser

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
