### PR TITLE
YSP-519: Tech debt - remove subtle quicklinks from component library

### DIFF
--- a/components/02-molecules/quick-links/_yds-quick-links.scss
+++ b/components/02-molecules/quick-links/_yds-quick-links.scss
@@ -125,10 +125,6 @@ $component-quick-links-themes: map.deep-get(tokens.$tokens, 'component-themes');
   @media (min-width: tokens.$break-xl) {
     gap: var(--size-spacing-6);
   }
-
-  [data-quick-links-variation='subtle'][data-component-alignment='left'] & {
-    max-width: var(--size-component-layout-width-content);
-  }
 }
 
 .quick-links__heading {
@@ -163,15 +159,6 @@ $component-quick-links-themes: map.deep-get(tokens.$tokens, 'component-themes');
   row-gap: var(--size-spacing-6);
   column-gap: var(--size-spacing-7);
 
-  [data-quick-links-variation='subtle'] & {
-    grid-template-columns: 1fr 1fr;
-    justify-items: start;
-
-    @media (min-width: tokens.$break-s) {
-      grid-template-columns: 1fr 1fr 1fr;
-    }
-  }
-
   [data-quick-links-variation='promotional'] & {
     @media (min-width: tokens.$break-s) {
       grid-template-columns: 1fr 1fr;
@@ -203,10 +190,6 @@ $component-quick-links-themes: map.deep-get(tokens.$tokens, 'component-themes');
       grid-template-columns: 1fr 1fr 1fr;
     }
   }
-
-  [data-quick-links-variation='subtle'][data-component-alignment='left'] & {
-    max-width: var(--size-component-layout-width-content);
-  }
 }
 
 .quick-links__list-item {
@@ -219,10 +202,6 @@ $component-quick-links-themes: map.deep-get(tokens.$tokens, 'component-themes');
 
 .quick-links__link {
   @include atoms.link;
-
-  [data-quick-links-variation='subtle'] & {
-    --color-text-shadow: var(--color-basic-white);
-  }
 }
 
 .quick-links__cta {
@@ -231,12 +210,6 @@ $component-quick-links-themes: map.deep-get(tokens.$tokens, 'component-themes');
   display: flex;
   align-items: center;
   justify-content: center;
-
-  // in subtle variartion, inline-flex the links
-  [data-quick-links-variation='subtle'] & {
-    display: inline-flex;
-    text-align: left;
-  }
 }
 
 .quick-links__image {
@@ -255,9 +228,5 @@ $component-quick-links-themes: map.deep-get(tokens.$tokens, 'component-themes');
       width: 100%;
       object-fit: cover;
     }
-  }
-
-  [data-quick-links-variation='subtle'][data-component-alignment='left'] & {
-    max-width: var(--size-component-layout-width-content);
   }
 }

--- a/components/02-molecules/quick-links/quick-links.stories.js
+++ b/components/02-molecules/quick-links/quick-links.stories.js
@@ -23,12 +23,6 @@ export default {
       type: 'string',
       defaultValue: quickLinksData.quick_links__description,
     },
-    variation: {
-      name: 'Variation',
-      type: 'select',
-      options: ['promotional', 'subtle'],
-      defaultValue: 'promotional',
-    },
     image: {
       name: 'With image',
       type: 'boolean',

--- a/components/02-molecules/quick-links/yds-quick-links.twig
+++ b/components/02-molecules/quick-links/yds-quick-links.twig
@@ -26,20 +26,11 @@
   'class': bem(quick_links__base_class),
 } %}
 
-{% if quick_links__variation == 'promotional' %}
-  {% set quick_links__attributes = quick_links__attributes|merge({
-    'data-component-width': 'site',
-    'data-component-theme': quick_links__background_color|default('one'),
-    'data-quick-links-layout': quick_links__layout|default('stacked'),
-  }) %}
-{% endif %}
-
-{% if quick_links__variation == 'subtle' %}
-  {% set quick_links__attributes = quick_links__attributes|merge({
-    'data-component-width': quick_links__width|default('site'),
-    'data-component-alignment': quick_links__alignment|default('left'),
-  }) %}
-{% endif %}
+{% set quick_links__attributes = quick_links__attributes|merge({
+  'data-component-width': 'site',
+  'data-component-theme': quick_links__background_color|default('one'),
+  'data-quick-links-layout': quick_links__layout|default('stacked'),
+}) %}
 
 <div {{ add_attributes(quick_links__attributes) }}>
   {% block prefix_suffix %}


### PR DESCRIPTION
## [YSP-519: Tech debt - Remove subtle quicklinks from component library](https://fourkitchens.clickup.com/t/86a3d4c6j)

### Description of work
- Remove the entire 'variation' control, there are no variations now.
- Remove any styles related to 'subtle', variations were removed.
- Remove any custom code related to the 'subtle' variation.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-369--dev-component-library-twig.netlify.app/?path=/story/molecules-quick-links--quick-links)

### Functional Review Steps
- [ ] Verify that the "Quick Links" component has no "Variation" control.
- [ ] Verify that the "Quick Links" continue working fine.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
