### PR TITLE
YSP-335: New block: In-Line Message

### DIFF
--- a/components/02-molecules/alert/yds-alert.twig
+++ b/components/02-molecules/alert/yds-alert.twig
@@ -22,7 +22,7 @@
   {% set alert__icon = 'circle-info' %}
   {% set alert__toggle = 'xmark' %}
   {% set alert__toggle__text = 'Close alert' %}
-{# Set marketign icon #}
+{# Set marketing icon #}
 {% else %}
   {% set alert__toggle = 'xmark' %}
   {% set alert__toggle__text = 'Close alert' %}
@@ -49,11 +49,13 @@
     {% endif %}
     <div {{ bem('content', [], alert__base_class) }}>
       <div {{ bem('content-inner', [], alert__base_class) }}>
-        {% include "@atoms/typography/headings/yds-heading.twig" with {
-          heading__level: '2',
-          heading__blockname: alert__base_class,
-          heading: alert__heading,
-        } %}
+        {% if alert__heading %}
+          {% include "@atoms/typography/headings/yds-heading.twig" with {
+            heading__level: '2',
+            heading__blockname: alert__base_class,
+            heading: alert__heading,
+          } %}
+        {% endif %}
         {% if alert__content %}
           {% include "@atoms/typography/text/yds-text.twig" with {
             text__element: 'div',

--- a/components/02-molecules/inline-message/_yds-inline-message.scss
+++ b/components/02-molecules/inline-message/_yds-inline-message.scss
@@ -129,20 +129,3 @@ $component-inline-message-themes: map.deep-get(
     color: var(--color-slot-eight);
   }
 }
-
-.inline-message__link {
-  @include atoms.link;
-  @include tokens.body-s;
-
-  --position: 0 1.3em;
-
-  margin-bottom: var(--size-spacing-2);
-
-  &:visited {
-    color: var(--color-slot-six);
-  }
-
-  &:has(> i.fa-icon) {
-    padding-right: var(--size-spacing-3);
-  }
-}

--- a/components/02-molecules/inline-message/_yds-inline-message.scss
+++ b/components/02-molecules/inline-message/_yds-inline-message.scss
@@ -1,0 +1,127 @@
+@use '~@yalesites-org/tokens/build/scss/tokens' as sass-tokens;
+@use '../../00-tokens/functions/map';
+@use '../../00-tokens/tokens';
+@use '../../01-atoms/atoms';
+
+// get global themes
+$global-inline-message-themes: map.deep-get(tokens.$tokens, 'global-themes');
+$component-inline-message-themes: map.deep-get(
+  tokens.$tokens,
+  'component-themes'
+);
+
+.inline-message {
+  --size-icon: 1.5rem;
+
+  // Component themes defaults: iterate over each component theme to establish
+  // default variables.
+  @each $theme, $value in $component-inline-message-themes {
+    &[data-component-theme='#{$theme}'] {
+      // prettier-ignore
+      --color-slot-one: var(--component-themes-#{$theme}-slot-one);
+      --color-slot-two: var(--component-themes-#{$theme}-slot-two);
+      --color-slot-three: var(--component-themes-#{$theme}-slot-three);
+      --color-slot-four: var(--component-themes-#{$theme}-slot-four);
+      --color-slot-five: var(--component-themes-#{$theme}-slot-five);
+      --color-slot-six: var(--component-themes-#{$theme}-slot-six);
+      --color-slot-seven: var(--component-themes-#{$theme}-slot-seven);
+      --color-slot-eight: var(--component-themes-#{$theme}-slot-eight);
+
+      background-color: var(--color-slot-four);
+      color: var(--color-slot-six);
+    }
+  }
+
+  // Global themes: set color slots for each theme
+  // This establishes `--color-slot-` variables name-spaced to the selector
+  // in which it is used. We can map component-level variables to global-level
+  // `--color-slot-` variables.
+  @each $globalTheme, $value in $global-inline-message-themes {
+    [data-global-theme='#{$globalTheme}'] & {
+      --color-slot-one: var(--global-themes-#{$globalTheme}-colors-slot-one);
+      --color-slot-two: var(--global-themes-#{$globalTheme}-colors-slot-two);
+      --color-slot-three: var(
+        --global-themes-#{$globalTheme}-colors-slot-three
+      );
+      --color-slot-four: var(--global-themes-#{$globalTheme}-colors-slot-four);
+      --color-slot-five: var(--global-themes-#{$globalTheme}-colors-slot-five);
+      --color-slot-six: var(--global-themes-#{$globalTheme}-colors-slot-six);
+      --color-slot-seven: var(
+        --global-themes-#{$globalTheme}-colors-slot-seven
+      );
+      --color-slot-eight: var(
+        --global-themes-#{$globalTheme}-colors-slot-eight
+      );
+    }
+  }
+}
+
+.inline-message__inner {
+  display: flex;
+  align-items: flex-start;
+  padding-block-start: var(--size-spacing-5);
+  padding-block-end: var(--size-spacing-5);
+}
+
+.inline-message__icon {
+  display: flex;
+  margin-right: var(--size-spacing-3);
+  margin-top: var(--size-spacing-2);
+  flex: 0 0 var(--size-icon);
+
+  @media (max-width: tokens.$break-mobile-max) {
+    padding-top: var(--size-spacing-1);
+  }
+
+  @media (min-width: tokens.$break-mobile) {
+    margin-right: var(--size-spacing-5);
+  }
+
+  svg {
+    height: var(--size-icon);
+    width: var(--size-icon);
+  }
+}
+
+.inline-message__heading {
+  @include tokens.h5-mallory-compact-medium;
+
+  color: inherit;
+}
+
+.inline-message__content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: var(--size-spacing-1);
+  align-items: flex-start;
+}
+
+.inline-message__text {
+  @include tokens.body-s-condensed;
+
+  margin-top: var(--size-spacing-2);
+  max-width: var(--size-component-layout-width-content);
+  color: var(--color-gray-700);
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.inline-message__link {
+  @include atoms.link;
+  @include tokens.body-s;
+
+  --position: 0 1.3em;
+
+  margin-bottom: var(--size-spacing-2);
+
+  &:visited {
+    color: var(--color-slot-six);
+  }
+
+  &:has(> i.fa-icon) {
+    padding-right: var(--size-spacing-3);
+  }
+}

--- a/components/02-molecules/inline-message/_yds-inline-message.scss
+++ b/components/02-molecules/inline-message/_yds-inline-message.scss
@@ -119,6 +119,12 @@ $component-inline-message-themes: map.deep-get(
     margin-bottom: 0;
   }
 
+  // if there is 1 p element in the text element, remove the margin
+  // do not remove the margin if there are multiple p elements
+  > p:not(p + p) {
+    margin: 0;
+  }
+
   // if the component theme is dial two or three, change the color of the text to slot eight (white)
   [data-component-theme='two'] & {
     color: var(--color-slot-eight);

--- a/components/02-molecules/inline-message/_yds-inline-message.scss
+++ b/components/02-molecules/inline-message/_yds-inline-message.scss
@@ -102,17 +102,16 @@ $component-inline-message-themes: map.deep-get(
 }
 
 .inline-message__content {
-  flex: 1 1 auto;
   display: flex;
+  flex: 1 1 auto;
   flex-flow: column nowrap;
-  gap: var(--size-spacing-1);
+  gap: var(--size-spacing-2);
   align-items: flex-start;
 }
 
 .inline-message__text {
   @include tokens.body-s-condensed;
 
-  margin-top: var(--size-spacing-2);
   max-width: var(--size-component-layout-width-content);
   color: var(--color-gray-700);
 

--- a/components/02-molecules/inline-message/_yds-inline-message.scss
+++ b/components/02-molecules/inline-message/_yds-inline-message.scss
@@ -134,3 +134,30 @@ $component-inline-message-themes: map.deep-get(
     color: var(--color-slot-eight);
   }
 }
+
+.inline-message__link {
+  @include atoms.link;
+  @include tokens.body-s;
+
+  --position: 0 1.3em;
+
+  margin-bottom: var(--size-spacing-2);
+
+  [data-component-theme='two'] & {
+    --color-link-base: var(--color-slot-eight);
+    --color-link-hover: var(--color-slot-eight);
+  }
+
+  [data-component-theme='three'] & {
+    --color-link-base: var(--color-slot-eight);
+    --color-link-hover: var(--color-slot-eight);
+  }
+
+  &:visited {
+    color: var(--color-slot-six);
+  }
+
+  &:has(> i.fa-icon) {
+    padding-right: var(--size-spacing-3);
+  }
+}

--- a/components/02-molecules/inline-message/_yds-inline-message.scss
+++ b/components/02-molecules/inline-message/_yds-inline-message.scss
@@ -146,15 +146,23 @@ $component-inline-message-themes: map.deep-get(
   [data-component-theme='two'] & {
     --color-link-base: var(--color-slot-eight);
     --color-link-hover: var(--color-slot-eight);
+    --color-link-visited-base: var(--color-slot-eight);
+    --color-link-visited-hover: var(--color-slot-eight);
   }
 
   [data-component-theme='three'] & {
     --color-link-base: var(--color-slot-eight);
     --color-link-hover: var(--color-slot-eight);
+    --color-link-visited-base: var(--color-slot-eight);
+    --color-link-visited-hover: var(--color-slot-eight);
   }
 
   &:visited {
-    color: var(--color-slot-six);
+    color: var(--color-link-visited-base);
+
+    &:hover {
+      color: var(--color-link-visited-hover);
+    }
   }
 
   &:has(> i.fa-icon) {

--- a/components/02-molecules/inline-message/_yds-inline-message.scss
+++ b/components/02-molecules/inline-message/_yds-inline-message.scss
@@ -26,9 +26,11 @@ $component-inline-message-themes: map.deep-get(
       --color-slot-six: var(--component-themes-#{$theme}-slot-six);
       --color-slot-seven: var(--component-themes-#{$theme}-slot-seven);
       --color-slot-eight: var(--component-themes-#{$theme}-slot-eight);
+      --color-inline-message-background: var(--color-slot-four);
+      --color-inline-message-text: var(--color-slot-six);
 
-      background-color: var(--color-slot-four);
-      color: var(--color-slot-six);
+      background-color: var(--color-inline-message-background);
+      color: var(--color-inline-message-text);
     }
   }
 
@@ -54,13 +56,23 @@ $component-inline-message-themes: map.deep-get(
       );
     }
   }
+
+  &[data-component-theme='two'] {
+    --color-inline-message-background: var(--color-slot-one);
+    --color-inline-message-text: var(--color-slot-eight);
+  }
+
+  &[data-component-theme='three'] {
+    --color-inline-message-background: var(--color-slot-two);
+    --color-inline-message-text: var(--color-slot-eight);
+  }
 }
 
 .inline-message__inner {
   display: flex;
   align-items: flex-start;
-  padding-block-start: var(--size-spacing-5);
-  padding-block-end: var(--size-spacing-5);
+  padding-block-start: var(--size-spacing-6);
+  padding-block-end: var(--size-spacing-6);
 }
 
 .inline-message__icon {
@@ -106,6 +118,15 @@ $component-inline-message-themes: map.deep-get(
 
   > *:last-child {
     margin-bottom: 0;
+  }
+
+  // if the component theme is dial two or three, change the color of the text to slot eight (white)
+  [data-component-theme='two'] & {
+    color: var(--color-slot-eight);
+  }
+
+  [data-component-theme='three'] & {
+    color: var(--color-slot-eight);
   }
 }
 

--- a/components/02-molecules/inline-message/inline-message.stories.js
+++ b/components/02-molecules/inline-message/inline-message.stories.js
@@ -27,19 +27,38 @@ export default {
       options: ['one', 'two', 'three'],
       type: 'select',
     },
+    linkContent: {
+      name: 'Link Content',
+      type: 'string',
+    },
+    linkUrl: {
+      name: 'Link URL',
+      type: 'string',
+    },
   },
   args: {
     type: 'general',
     heading: 'This is a general message heading',
     content: 'This is a general message content',
     themeColor: 'one',
+    linkContent: 'This is a link',
+    linkUrl: '#',
   },
 };
 
-export const InlineMessage = ({ type, heading, content, themeColor }) =>
+export const InlineMessage = ({
+  type,
+  heading,
+  content,
+  themeColor,
+  linkContent,
+  linkUrl,
+}) =>
   inlineMessageTwig({
     inline_message__heading: heading,
     inline_message__content: content,
     inline_message__type: type,
     inline_message__theme: themeColor,
+    inline_message__link__content: linkContent,
+    inline_message__link__url: linkUrl,
   });

--- a/components/02-molecules/inline-message/inline-message.stories.js
+++ b/components/02-molecules/inline-message/inline-message.stories.js
@@ -1,0 +1,45 @@
+// Twig templates
+import inlineMessageTwig from './yds-inline-message.twig';
+
+// Data files
+
+/**
+ * Storybook Definition.
+ */
+export default {
+  title: 'Molecules/Inline Message',
+  argTypes: {
+    type: {
+      name: 'Type',
+      type: 'select',
+      options: ['general', 'alert'],
+    },
+    heading: {
+      name: 'Heading',
+      type: 'string',
+    },
+    content: {
+      name: 'Content',
+      type: 'string',
+    },
+    themeColor: {
+      name: 'Component Theme (dial)',
+      options: ['one', 'two', 'three'],
+      type: 'select',
+    },
+  },
+  args: {
+    type: 'general',
+    heading: 'This is a general message heading',
+    content: 'This is a general message content',
+    themeColor: 'one',
+  },
+};
+
+export const InlineMessage = ({ type, heading, content, themeColor }) =>
+  inlineMessageTwig({
+    inline_message__heading: heading,
+    inline_message__content: content,
+    inline_message__type: type,
+    inline_message__theme: themeColor,
+  });

--- a/components/02-molecules/inline-message/yds-inline-message.twig
+++ b/components/02-molecules/inline-message/yds-inline-message.twig
@@ -1,0 +1,65 @@
+{#
+ # Available Variables:
+ # - inline-message__id: unique id (must be unique to each site)
+ # - inline-message__type:  general (default), marketing
+ # - inline-message__heading
+ # - inline-message__content
+ # - inline-message__link__content
+ # - inline-message__link__url
+ #}
+
+{% set inline_message__base_class = 'inline-message' %}
+{% set inline_message__type = inline_message__type|default('general') %}
+
+{# Set emergency icons #}
+{% if inline_message__type == 'general' %}
+  {% set inline_message__icon = 'circle-info' %}
+{# Set marketign icon #}
+{% else %}
+  {% set inline_message__icon = 'circle-exclamation' %}
+{% endif %}
+
+{% set inline_message__attributes = {
+  'data-component-width': 'site',
+  'data-inline-message-id': 'ys-inline-message-id-' ~ inline_message__id,
+  'data-inline-message-type': inline_message__type,
+  'aria-label': 'information',
+  'data-component-theme': inline_message__theme|default('one'),
+  class: bem(inline_message__base_class),
+} %}
+
+<section {{ add_attributes(inline_message__attributes) }}>
+  <div {{ bem('inner', [], inline_message__base_class) }}>
+    {% if inline_message__icon %}
+      <div {{ bem('icon', ['type'], inline_message__base_class) }}>
+        {% include "@atoms/images/icons/_yds-icon.twig" with {
+          icon__name: inline_message__icon,
+          icon__decorative: true,
+        } %}
+      </div>
+    {% endif %}
+    <div {{ bem('content', [], inline_message__base_class) }}>
+      <div {{ bem('content-inner', [], inline_message__base_class) }}>
+        {% include "@atoms/typography/headings/yds-heading.twig" with {
+          heading__level: inline_message__heading_level|default('2'),
+          heading__blockname: inline_message__base_class,
+          heading: inline_message__heading,
+        } %}
+        {% if inline_message__content %}
+          {% include "@atoms/typography/text/yds-text.twig" with {
+            text__element: 'div',
+            text__content: inline_message__content,
+            text__blockname: inline_message__base_class,
+          } %}
+        {% endif %}
+      </div>
+      {% if inline_message__link__content and inline_message__link__url %}
+        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+          link__content: inline_message__link__content,
+          link__url: inline_message__link__url,
+          link__blockname: inline_message__base_class,
+        } %}
+      {% endif %}
+    </div>
+  </div>
+</section>

--- a/components/02-molecules/inline-message/yds-inline-message.twig
+++ b/components/02-molecules/inline-message/yds-inline-message.twig
@@ -14,7 +14,7 @@
 {# Set emergency icons #}
 {% if inline_message__type == 'general' %}
   {% set inline_message__icon = 'circle-info' %}
-{# Set marketign icon #}
+{# Set marketing icon #}
 {% else %}
   {% set inline_message__icon = 'circle-exclamation' %}
 {% endif %}
@@ -40,11 +40,13 @@
     {% endif %}
     <div {{ bem('content', [], inline_message__base_class) }}>
       <div {{ bem('content-inner', [], inline_message__base_class) }}>
-        {% include "@atoms/typography/headings/yds-heading.twig" with {
-          heading__level: inline_message__heading_level|default('2'),
-          heading__blockname: inline_message__base_class,
-          heading: inline_message__heading,
-        } %}
+        {% if inline_message__heading %}
+          {% include "@atoms/typography/headings/yds-heading.twig" with {
+            heading__level: inline_message__heading_level|default('2'),
+            heading__blockname: inline_message__base_class,
+            heading: inline_message__heading,
+          } %}
+        {% endif %}
         {% if inline_message__content %}
           {% include "@atoms/typography/text/yds-text.twig" with {
             text__element: 'div',
@@ -53,13 +55,6 @@
           } %}
         {% endif %}
       </div>
-      {% if inline_message__link__content and inline_message__link__url %}
-        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
-          link__content: inline_message__link__content,
-          link__url: inline_message__link__url,
-          link__blockname: inline_message__base_class,
-        } %}
-      {% endif %}
     </div>
   </div>
 </section>

--- a/components/02-molecules/inline-message/yds-inline-message.twig
+++ b/components/02-molecules/inline-message/yds-inline-message.twig
@@ -39,22 +39,20 @@
       </div>
     {% endif %}
     <div {{ bem('content', [], inline_message__base_class) }}>
-      <div {{ bem('content-inner', [], inline_message__base_class) }}>
-        {% if inline_message__heading %}
-          {% include "@atoms/typography/headings/yds-heading.twig" with {
-            heading__level: inline_message__heading_level|default('2'),
-            heading__blockname: inline_message__base_class,
-            heading: inline_message__heading,
-          } %}
-        {% endif %}
-        {% if inline_message__content %}
-          {% include "@atoms/typography/text/yds-text.twig" with {
-            text__element: 'div',
-            text__content: inline_message__content,
-            text__blockname: inline_message__base_class,
-          } %}
-        {% endif %}
-      </div>
+      {% if inline_message__heading %}
+        {% include "@atoms/typography/headings/yds-heading.twig" with {
+          heading__level: inline_message__heading_level|default('2'),
+          heading__blockname: inline_message__base_class,
+          heading: inline_message__heading,
+        } %}
+      {% endif %}
+      {% if inline_message__content %}
+        {% include "@atoms/typography/text/yds-text.twig" with {
+          text__element: 'div',
+          text__content: inline_message__content,
+          text__blockname: inline_message__base_class,
+        } %}
+      {% endif %}
     </div>
   </div>
 </section>

--- a/components/02-molecules/inline-message/yds-inline-message.twig
+++ b/components/02-molecules/inline-message/yds-inline-message.twig
@@ -1,6 +1,5 @@
 {#
  # Available Variables:
- # - inline-message__id: unique id (must be unique to each site)
  # - inline-message__type:  general (default), marketing
  # - inline-message__heading
  # - inline-message__content
@@ -21,7 +20,6 @@
 
 {% set inline_message__attributes = {
   'data-component-width': 'site',
-  'data-inline-message-id': 'ys-inline-message-id-' ~ inline_message__id,
   'data-inline-message-type': inline_message__type,
   'aria-label': 'information',
   'data-component-theme': inline_message__theme|default('one'),
@@ -51,6 +49,13 @@
           text__element: 'div',
           text__content: inline_message__content,
           text__blockname: inline_message__base_class,
+        } %}
+      {% endif %}
+      {% if inline_message__link__content and inline_message__link__url %}
+        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+          link__content: inline_message__link__content,
+          link__url: inline_message__link__url,
+          link__blockname: inline_message__base_class,
         } %}
       {% endif %}
     </div>

--- a/components/02-molecules/molecules.scss
+++ b/components/02-molecules/molecules.scss
@@ -31,3 +31,4 @@
 @forward './content-spotlight-portrait/yds-content-spotlight-portrait';
 @forward './facts-and-figures/yds-facts-and-figures';
 @forward './tile-item/yds-tile-item';
+@forward './inline-message/yds-inline-message';


### PR DESCRIPTION
## [YSP-335: New block: In-Line Message](https://yaleits.atlassian.net/browse/YSP-335)

### Description of work
- Adds new component for In-Line Message

### Testing Link(s)
- [ ] Navigate to the [In-Line Message Component Story](https://deploy-preview-379--dev-component-library-twig.netlify.app/?path=/story/molecules-inline-message--inline-message)

### Functional Review Steps
- [ ] Navigate to the In-Line Message component: https://deploy-preview-379--dev-component-library-twig.netlify.app/?path=/story/molecules-inline-message--inline-message
- [ ] Test the color theme variations
- [ ] Note: there are two `type` options - `general` and `alert`. Currently only `general` will be wired in Drupal. The `type` option is not exposed as a dial. We're going to wait until we have an icon selection process in place.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/proto/ad5VvIfKGdmKycWHIBTsK4/In-Line-Message?node-id=5-223&t=L5TVAMG7QuJnIfN7-0&scaling=scale-down&content-scaling=fixed&page-id=0%3A1)


### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
