### PR TITLE
YSP-581: Mobile hamburger menu not showing up

### DIFF
--- a/components/03-organisms/site-header/yds-site-header.twig
+++ b/components/03-organisms/site-header/yds-site-header.twig
@@ -15,10 +15,11 @@
 
 {% set site_header__hamburger = 'no' %}
 
-{% if utility_nav__items or primary_nav__items %}
+{% if utility_nav__items is not empty or primary_nav__items is not empty %}
   {% set site_header__hamburger = 'yes' %}
 {% endif %}
 
+{# Set the site_header__attributes variable with the default attributes #}  
 {% set site_header__attributes = {
   'data-main-menu-state': 'loaded',
   'data-component-width': 'site',


### PR DESCRIPTION
### [YSP-581: Mobile hamburger menu not showing up](https://yaleits.atlassian.net/browse/YSP-581)

### Description of work
- Updates checks to account for `is not empty` to return `true` or `false`

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Test with https://github.com/yalesites-org/atomic/pull/251
