### PR TITLE
YSP-583: Event date display a range

### DIFF
--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -21,20 +21,10 @@
 {% set format__iso = 'c' %} {# 2022-04-01T08:34:42+00:00 #}
 {% set format__html_date = 'Y-m-d' %} {# 2022-04-01 #}
 {% set format__date = 'F j, Y' %} {# April 1, 2022 #}
-{% set format__day__full__start = 'l, F j' %} {# Friday, April 1 #}
-{% set format__day__full = 'l, F j, Y' %} {# Friday, April 1, 2022 #}
-{# If minutes == ":00" don't show them #}
-{% if date_time__start|date('i') == '00' %}
-  {% set format__time__start = 'g-' %} {# 8- #}
-{% else %}
-  {% set format__time__start = 'g:i-' %} {# 8:30- #}
-{% endif %}
-{% if date_time__end|date('i') == '00' %}
-  {% set format__time = 'g a T' %} {# 11 pm ET #}
-{% else %}
-  {% set format__time = 'g:i a T' %} {# 11:30 pm ET #}
-{% endif %}
-
+{% set format__day__full__start = 'D M j' %} {# Fri Apr 1 #}
+{% set format__day__full = 'D M j, Y' %} {# Fri Apr, 1 2022 #}
+{% set format__time__start = 'g:ia - ' %} {# 8:30pm - #}
+{% set format__time = 'g:ia' %} {# 11:30pm #}
 
 {% if date_time__all_day == true %}
   All Day

--- a/components/02-molecules/meta/event-meta/event-localist.yml
+++ b/components/02-molecules/meta/event-meta/event-localist.yml
@@ -1,16 +1,16 @@
 event_dates:
-  - formatted_start_date: Friday May 3rd 2024
+  - formatted_start_date: Friday, May 3rd, 2024
     formatted_end_date: Friday, May 3rd, 2024
-    formatted_start_time: 8:30am 
-    formatted_end_time: 9:30am
-  - formatted_start_date: Saturday May 4th 2024
+    formatted_start_time: 8:30 am EDT
+    formatted_end_time: 9:30 am EDT
+  - formatted_start_date: Saturday, May 4th, 2024
     formatted_end_date: Saturday, May 4th, 2024
-    formatted_start_time: 8:30am
-    formatted_end_time: 9:30am
-  - formatted_start_date: Sunday May 5th 2024
+    formatted_start_time: 8:30 am EDT
+    formatted_end_time: 9:30 am EDT
+  - formatted_start_date: Sunday, May 5th, 2024
     formatted_end_date: Sunday, May 5th, 2024
-    formatted_start_time: 8:30am
-    formatted_end_time: 9:30am
+    formatted_start_time: 8:30 am EDT
+    formatted_end_time: 9:30 am EDT
 ticket_cost: $40 pre registration, $60 at the door
 ticket_url: https://www.yale.edu
 event_meta__cta_primary__content: Event Name Website

--- a/components/02-molecules/meta/event-meta/event-localist.yml
+++ b/components/02-molecules/meta/event-meta/event-localist.yml
@@ -1,16 +1,16 @@
 event_dates:
-  - formatted_start_date: Friday, May 3rd, 2024
+  - formatted_start_date: Friday May 3rd 2024
     formatted_end_date: Friday, May 3rd, 2024
-    formatted_start_time: 8:30 am EDT
-    formatted_end_time: 9:30 am EDT
-  - formatted_start_date: Saturday, May 4th, 2024
+    formatted_start_time: 8:30am 
+    formatted_end_time: 9:30am
+  - formatted_start_date: Saturday May 4th 2024
     formatted_end_date: Saturday, May 4th, 2024
-    formatted_start_time: 8:30 am EDT
-    formatted_end_time: 9:30 am EDT
-  - formatted_start_date: Sunday, May 5th, 2024
+    formatted_start_time: 8:30am
+    formatted_end_time: 9:30am
+  - formatted_start_date: Sunday May 5th 2024
     formatted_end_date: Sunday, May 5th, 2024
-    formatted_start_time: 8:30 am EDT
-    formatted_end_time: 9:30 am EDT
+    formatted_start_time: 8:30am
+    formatted_end_time: 9:30am
 ticket_cost: $40 pre registration, $60 at the door
 ticket_url: https://www.yale.edu
 event_meta__cta_primary__content: Event Name Website

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -180,6 +180,8 @@
             <ul {{ bem('multiple-dates', [], event_meta__base_class) }} aria-expanded="false">
               {% for event_date in event_dates %}
                 <li {{ bem('multiple-dates__date', [], event_meta__base_class) }}>
+                {{ event_date.formatted_start_date }} {{ event_date.formatted_start_time }} to {{ event_date.formatted_end_date }} {{ event_date.formatted_end_time }}
+                </li>
               {% endfor %}
             </ul>
           </div>

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -138,9 +138,9 @@
         <div {{ bem('date', [], event_meta__base_class) }}>
 					{% if event_dates.0.formatted_start_date == event_dates.0.formatted_end_date %}
 						{{event_dates.0.formatted_start_date| date('D M j, Y')}}
-						{{ event_dates.0.formatted_start_time| date('g:i a') }}
+						{{ event_dates.0.formatted_start_time| date('g:ia') }}
 						-
-						{{ event_dates.0.formatted_end_time| date('g:i a') }}
+						{{ event_dates.0.formatted_end_time| date('g:ia') }}
 					{% else %}
           	{{ event_dates.0.formatted_start_date }}
 						{{ event_dates.0.formatted_start_time }}
@@ -180,8 +180,20 @@
             <ul {{ bem('multiple-dates', [], event_meta__base_class) }} aria-expanded="false">
               {% for event_date in event_dates %}
                 <li {{ bem('multiple-dates__date', [], event_meta__base_class) }}>
-                {{ event_date.formatted_start_date }} {{ event_date.formatted_start_time }} to {{ event_date.formatted_end_date }} {{ event_date.formatted_end_time }}
+                  {% if event_date.formatted_start_date == event_date.formatted_end_date %}
+                    {{event_date.formatted_start_date| date('D M j, Y')}}
+                    {{ event_date.formatted_start_time| date('g:ia') }}
+                    -
+                    {{ event_date.formatted_end_time| date('g:ia') }}
+                  {% else %}
+                    {{ event_date.formatted_start_date }}
+                    {{ event_date.formatted_start_time }}
+                    -
+                    {{ event_date.formatted_end_date }}
+                    {{ event_date.formatted_end_time }}
+                  {% endif %}
                 </li>
+
               {% endfor %}
             </ul>
           </div>

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -135,9 +135,21 @@
     {% block page_title__extra %}
       {# Date #}
       {% if event_dates %}
-            {#Friday July 13th 1:00pm - 2:00pm#}
         <div {{ bem('date', [], event_meta__base_class) }}>
-          {{ event_dates.0.formatted_start_date }} {{ event_dates.0.formatted_start_time }} - {{ event_dates.0.formatted_end_time }}
+					{% if event_dates.0.formatted_start_date == event_dates.0.formatted_end_date %}
+						{{event_dates.0.formatted_start_date| date('l, F j, Y')}}
+						{{ event_dates.0.formatted_start_time| date('h:i a') }}
+						-
+						{{ event_dates.0.formatted_end_time| date('h:i a') }}
+						{# {{ event_dates.0.formatted_start_date }} {{ event_dates.0.formatted_start_time }} - {{ event_dates.0.formatted_end_time }} #}
+					{% else %}
+          	{{ event_dates.0.formatted_start_date }}
+						{{ event_dates.0.formatted_start_time }}
+						-
+						{{ event_dates.0.formatted_end_date }}
+						{{ event_dates.0.formatted_end_time }}
+					{% endif %}
+
         </div>
       {% endif %}
     {% endblock %}

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -136,18 +136,18 @@
       {# Date #}
       {% if event_dates %}
         <div {{ bem('date', [], event_meta__base_class) }}>
-					{% if event_dates.0.formatted_start_date == event_dates.0.formatted_end_date %}
-						{{event_dates.0.formatted_start_date| date('D M j, Y')}}
-						{{ event_dates.0.formatted_start_time| date('g:ia') }}
-						-
-						{{ event_dates.0.formatted_end_time| date('g:ia') }}
-					{% else %}
-          	{{ event_dates.0.formatted_start_date }}
-						{{ event_dates.0.formatted_start_time }}
-						-
-						{{ event_dates.0.formatted_end_date }}
-						{{ event_dates.0.formatted_end_time }}
-					{% endif %}
+          {% if event_dates.0.formatted_start_date == event_dates.0.formatted_end_date %}
+            {{event_dates.0.formatted_start_date| date('D M j, Y')}}
+            {{ event_dates.0.formatted_start_time| date('g:ia') }}
+            -
+            {{ event_dates.0.formatted_end_time| date('g:ia') }}
+          {% else %}
+            {{ event_dates.0.formatted_start_date }}
+            {{ event_dates.0.formatted_start_time }}
+            -
+            {{ event_dates.0.formatted_end_date }}
+            {{ event_dates.0.formatted_end_time }}
+          {% endif %}
 
         </div>
       {% endif %}

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -169,8 +169,7 @@
             <ul {{ bem('multiple-dates', [], event_meta__base_class) }} aria-expanded="false">
               {% for event_date in event_dates %}
                 <li {{ bem('multiple-dates__date', [], event_meta__base_class) }}>
-          {{ event_dates.0.formatted_start_date }} {{ event_dates.0.formatted_start_time }} - {{ event_dates.0.formatted_end_time }}
-git                 </li>
+          {{ event_dates.0.formatted_start_date }} {{ event_dates.0.formatted_start_time }} - {{ event_dates.0.formatted_end_time }}                 </li>
               {% endfor %}
             </ul>
           </div>

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -135,8 +135,9 @@
     {% block page_title__extra %}
       {# Date #}
       {% if event_dates %}
+            {#Friday July 13th 1:00pm - 2:00pm#}
         <div {{ bem('date', [], event_meta__base_class) }}>
-          {{ event_dates.0.formatted_start_date }} {{ event_dates.0.formatted_start_time }} to {{ event_dates.0.formatted_end_date }} {{ event_dates.0.formatted_end_time }}
+          {{ event_dates.0.formatted_start_date }} {{ event_dates.0.formatted_start_time }} - {{ event_dates.0.formatted_end_time }}
         </div>
       {% endif %}
     {% endblock %}
@@ -168,8 +169,8 @@
             <ul {{ bem('multiple-dates', [], event_meta__base_class) }} aria-expanded="false">
               {% for event_date in event_dates %}
                 <li {{ bem('multiple-dates__date', [], event_meta__base_class) }}>
-                  {{ event_date.formatted_start_date }} {{ event_date.formatted_start_time }} to {{ event_date.formatted_end_date }} {{ event_date.formatted_end_time }}
-                </li>
+          {{ event_dates.0.formatted_start_date }} {{ event_dates.0.formatted_start_time }} - {{ event_dates.0.formatted_end_time }}
+git                 </li>
               {% endfor %}
             </ul>
           </div>

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -137,11 +137,10 @@
       {% if event_dates %}
         <div {{ bem('date', [], event_meta__base_class) }}>
 					{% if event_dates.0.formatted_start_date == event_dates.0.formatted_end_date %}
-						{{event_dates.0.formatted_start_date| date('l, F j, Y')}}
-						{{ event_dates.0.formatted_start_time| date('h:i a') }}
+						{{event_dates.0.formatted_start_date| date('D M j, Y')}}
+						{{ event_dates.0.formatted_start_time| date('g:i a') }}
 						-
-						{{ event_dates.0.formatted_end_time| date('h:i a') }}
-						{# {{ event_dates.0.formatted_start_date }} {{ event_dates.0.formatted_start_time }} - {{ event_dates.0.formatted_end_time }} #}
+						{{ event_dates.0.formatted_end_time| date('g:i a') }}
 					{% else %}
           	{{ event_dates.0.formatted_start_date }}
 						{{ event_dates.0.formatted_start_time }}
@@ -181,7 +180,6 @@
             <ul {{ bem('multiple-dates', [], event_meta__base_class) }} aria-expanded="false">
               {% for event_date in event_dates %}
                 <li {{ bem('multiple-dates__date', [], event_meta__base_class) }}>
-          {{ event_dates.0.formatted_start_date }} {{ event_dates.0.formatted_start_time }} - {{ event_dates.0.formatted_end_time }}                 </li>
               {% endfor %}
             </ul>
           </div>


### PR DESCRIPTION
## [YSP-583: Event date display a range](https://yaleits.atlassian.net/browse/YSP-583)

### Description of work
- Updated start and end date formatted
- Updated start and end time formatted
- Delete comma and change "to" to "-" 

### Testing Link(s)
- [ ] Navigate to the [Localist Event](https://deploy-preview-393--dev-component-library-twig.netlify.app/?path=/story/molecules-meta--event-localist)
- [ ] Navigate to the [Event Page](https://deploy-preview-393--dev-component-library-twig.netlify.app/?path=/story/molecules-meta--event)

### Functional Review Steps
- [ ] Visit storybook Localist Event link
- [ ] Check the date field should look format example: Wed July, 31 2024 12:00pm-2:00pm
- [ ] Test to see the changes will work on different date and time.
- [ ] Test the above using the Event Page also
- [ ] Test this functionality inside of the [multidev](https://github.com/yalesites-org/yalesites-project/pull/717)

### UX
- [ ] Is the new format acceptable

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
