### PR TITLE
YSP-604: Grand Hero Video doesn't load on mobile

### DIFF
--- a/components/01-atoms/videos/video-background/yds-video-background.twig
+++ b/components/01-atoms/videos/video-background/yds-video-background.twig
@@ -14,7 +14,7 @@
 
 <div {{ bem(video_background__base_class, video_background__modifiers, video_background__blockname) }} data-component-theme={{ video_background__button__background_color }}>
   {% block video_background__content %}
-    <video muted>
+    <video muted playsinline>
       <source src="{{ video_background__content }}" type="video/mp4">
     </video>
   {% endblock %}


### PR DESCRIPTION
## [YSP-604: Grand Hero Video doesn't load on mobile](https://yaleits.atlassian.net/browse/YSP-604)

### Description of work
- Adds `playsinline` to video tag in adherence to Safari's newer policies

### Testing Link(s)
- [ ] Navigate to the [Grand Hero with video enabled](https://deploy-preview-394--dev-component-library-twig.netlify.app/?path=/story/molecules-banners--grand-hero-banner&args=withVideo:true)

### Functional Review Steps
- [ ] Verify that on mobile, the video autoplays
- [ ] Verify that on desktop Safari, the video autoplays
  - Keep in mind you must not be in low power mode for this to be successful
- [ ] Try in other browsers to ensure they still work
- [ ] [Test it in Drupal](https://pr-714-yalesites-platform.pantheonsite.io/)
  - Video should be on grand hero on front page