### PR TITLE
YSP-649: EDT vs EST from Localist causing incorrect time render

### DIFF
--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -138,9 +138,9 @@
         <div {{ bem('date', [], event_meta__base_class) }}>
           {% if event_dates.0.formatted_start_date == event_dates.0.formatted_end_date %}
             {{event_dates.0.formatted_start_date| date('D M j, Y')}}
-            {{ event_dates.0.formatted_start_time| date('g:ia') }}
+            {{ event_dates.0.formatted_start_time| date('g:ia T', false) }}
             -
-            {{ event_dates.0.formatted_end_time| date('g:ia') }}
+            {{ event_dates.0.formatted_end_time| date('g:ia T', false) }}
           {% else %}
             {{ event_dates.0.formatted_start_date }}
             {{ event_dates.0.formatted_start_time }}


### PR DESCRIPTION
## [YSP-649: EDT vs EST from Localist causing incorrect time render](https://yaleits.atlassian.net/browse/YSP-649)

Modeling after the "Manage Events" time display, they are dropping the time zone completely, and instead just showing the time.  We can mirror this, which does seem to fix the issues we're seeing currently.  My worry is will there ever be a legitimate time zoned event that needs to go up?  (i.e. One occurring at 6pm PDT)

### Description of work
- Drops evaluation of the time zone adjustment

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
