### PR TITLE
YSP-649: EDT vs EST from Localist causing incorrect time render

### DIFF
--- a/components/02-molecules/meta/event-meta/event-localist.yml
+++ b/components/02-molecules/meta/event-meta/event-localist.yml
@@ -3,14 +3,20 @@ event_dates:
     formatted_end_date: Friday, May 3rd, 2024
     formatted_start_time: 8:30 am EDT
     formatted_end_time: 9:30 am EDT
+    original_start: 1714739400
+    original_end: 1714743000
   - formatted_start_date: Saturday, May 4th, 2024
     formatted_end_date: Saturday, May 4th, 2024
     formatted_start_time: 8:30 am EDT
     formatted_end_time: 9:30 am EDT
+    original_start: 1714825800
+    original_end: 1714829400
   - formatted_start_date: Sunday, May 5th, 2024
     formatted_end_date: Sunday, May 5th, 2024
     formatted_start_time: 8:30 am EDT
     formatted_end_time: 9:30 am EDT
+    original_start: 1714912200
+    original_end: 1714915800
 ticket_cost: $40 pre registration, $60 at the door
 ticket_url: https://www.yale.edu
 event_meta__cta_primary__content: Event Name Website

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -137,18 +137,14 @@
       {% if event_dates %}
         <div {{ bem('date', [], event_meta__base_class) }}>
           {% if event_dates.0.formatted_start_date == event_dates.0.formatted_end_date %}
-            {{event_dates.0.formatted_start_date| date('D M j, Y')}}
-            {{ event_dates.0.formatted_start_time| date('g:ia') }}
+            {{ event_dates.0.original_start|date('D M j, Y g:ia') }}
             -
-            {{ event_dates.0.formatted_end_time| date('g:ia') }}
+            {{ event_dates.0.original_end|date('g:ia') }}
           {% else %}
-            {{ event_dates.0.formatted_start_date }}
-            {{ event_dates.0.formatted_start_time }}
+            {{ event_dates.0.original_start|date('D M j, Y g:ia') }}
             -
-            {{ event_dates.0.formatted_end_date }}
-            {{ event_dates.0.formatted_end_time }}
+            {{ event_dates.0.original_end|date('D M j, Y g:ia') }}
           {% endif %}
-
         </div>
       {% endif %}
     {% endblock %}
@@ -181,16 +177,13 @@
               {% for event_date in event_dates %}
                 <li {{ bem('multiple-dates__date', [], event_meta__base_class) }}>
                   {% if event_date.formatted_start_date == event_date.formatted_end_date %}
-                    {{event_date.formatted_start_date| date('D M j, Y')}}
-                    {{ event_date.formatted_start_time| date('g:ia') }}
+                    {{ event_date.original_start|date('D M j, Y g:ia') }}
                     -
-                    {{ event_date.formatted_end_time| date('g:ia') }}
+                    {{ event_date.original_end|date('g:ia') }}
                   {% else %}
-                    {{ event_date.formatted_start_date }}
-                    {{ event_date.formatted_start_time }}
+                    {{ event_date.original_start|date('D M j, Y g:ia') }}
                     -
-                    {{ event_date.formatted_end_date }}
-                    {{ event_date.formatted_end_time }}
+                    {{ event_date.original_end|date('D M j, Y g:ia') }}
                   {% endif %}
                 </li>
 


### PR DESCRIPTION
## [YSP-649: EDT vs EST from Localist causing incorrect time render](https://yaleits.atlassian.net/browse/YSP-649)

By not having the date with the formatted time, it's impossible for the date formatter to know how to format based on daylight savings time or not.  By having the full UTC time, it can do this properly.

Work also done in [yalesites-project](https://github.com/yalesites-org/yalesites-project/pull/744)

### Description of work
- Passes the UTC `datetime` for the start and end to the twig file for more formatting to occur

### Testing Link(s)
- [ ] Navigate to the [Meta Event Localist Story](https://deploy-preview-408--dev-component-library-twig.netlify.app/?path=/story/molecules-meta--event-localist)

### Functional Review Steps
- [ ] Verify dates look correct
- [ ] Visit the [Multidev PR for more tests](https://github.com/yalesites-org/yalesites-project/pull/744)