### PR TITLE
YSP-670: Spotlights provide H2 in Banner Section

### DIFF
--- a/components/02-molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig
+++ b/components/02-molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig
@@ -7,6 +7,7 @@
  # Available variables:
  # - content_spotlight_portrait__overline (optional)
  # - content_spotlight_portrait__heading
+ # - content_spotlight_portrait__heading_level (optional)
  # - content_spotlight_portrait__subheading (optional)
  # - content_spotlight_portrait__text
  # - content_spotlight_portrait__link__content (optional)
@@ -17,6 +18,8 @@
  #}
 
 {% set content_spotlight_portrait__base_class = 'content-spotlight-portrait' %}
+
+{% set content_spotlight_portrait__heading_level = content_spotlight_portrait__heading_level|default('2') %}
 
 {% set content_spotlight_portrait__attributes = {
   'data-image-position': content_spotlight_portrait__position|default('image-left'),
@@ -44,7 +47,7 @@
       {% if content_spotlight_portrait__heading %}
         {% include "@atoms/typography/headings/yds-heading.twig" with {
           heading: content_spotlight_portrait__heading,
-          heading__level: '2',
+          heading__level: content_spotlight_portrait__heading_level,
           heading__blockname: content_spotlight_portrait__base_class,
         } %}
       {% endif %}

--- a/components/02-molecules/text-with-image/yds-text-with-image.twig
+++ b/components/02-molecules/text-with-image/yds-text-with-image.twig
@@ -7,6 +7,7 @@
  # Available variables:
  # - text_with_image__overline (optional)
  # - text_with_image__heading
+ # - text_with_image__heading_level (optional)
  # - text_with_image__subheading (optional)
  # - text_with_image__text
  # - text_with_image__link__content (optional)
@@ -17,6 +18,8 @@
  #}
 
 {% set text_with_image__base_class = 'text-with-image' %}
+
+{% set text_with_image__heading_level = text_with_image__heading_level|default('2') %}
 
 {% set text_with_image__attributes = {
   'data-component-focus': text_with_image__focus|default('equal'),
@@ -44,7 +47,7 @@
       {% if text_with_image__heading %}
         {% include "@atoms/typography/headings/yds-heading.twig" with {
           heading: text_with_image__heading,
-          heading__level: '2',
+          heading__level: text_with_image__heading_level,
           heading__blockname: text_with_image__base_class,
         } %}
       {% endif %}


### PR DESCRIPTION
## [YSP-670: Spotlights provide H2 in Banner Section](https://yaleits.atlassian.net/browse/YSP-670)

### Description of work
- Adds support for passing heading level through for spotlights

### Testing Link(s)
- [ ] Navigate to the [Spotlight Portrait Story](https://deploy-preview-419--dev-component-library-twig.netlify.app/?path=/story/molecules-content-spotlight--content-spotlight-portrait)
- [ ] Navigate to the [Spotlight Landscape Story](https://deploy-preview-419--dev-component-library-twig.netlify.app/?path=/story/molecules-content-spotlight--content-spotlight-landscape)

### Functional Review Steps
- [ ] Verify no change happened (should default to H2 and cannot be changed here--note: mimicking grand hero and action banner not having this option)

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
