### PR TITLE
YSP-680: PRESIDENT: Add dial to image banner to allow default and large image display

### DIFF
--- a/components/02-molecules/banner/banner.stories.js
+++ b/components/02-molecules/banner/banner.stories.js
@@ -132,23 +132,24 @@ GrandHeroBanner.argTypes = {
     defaultValue: false,
   },
 };
-export const ImageBanner = ({ withVideo, bgColor, styleVariation }) =>
+export const ImageBanner = ({ bgColor, size, withVideo }) =>
   imageBannerTwig({
     ...imageData.responsive_images['16x9'],
-    image_banner__video: withVideo ? 'true' : 'false',
     image_banner__content__background: bgColor,
-    image_banner__image_size: styleVariation,
+    image_banner__overlay_variation: 'full',
+    image_banner__size: size,
+    image_banner__video: withVideo ? 'true' : 'false',
   });
 ImageBanner.argTypes = {
+  size: {
+    name: 'Image Size',
+    type: 'select',
+    options: ['large', 'small'],
+    defaultValue: 'large',
+  },
   withVideo: {
     name: 'With Video',
     type: 'boolean',
     defaultValue: false,
-  },
-  styleVariation: {
-    name: 'Size',
-    type: 'select',
-    options: ['small', 'large'],
-    defaultValue: 'large',
   },
 };

--- a/components/02-molecules/banner/banner.stories.js
+++ b/components/02-molecules/banner/banner.stories.js
@@ -132,16 +132,23 @@ GrandHeroBanner.argTypes = {
     defaultValue: false,
   },
 };
-export const ImageBanner = ({ withVideo, bgColor }) =>
+export const ImageBanner = ({ withVideo, bgColor, styleVariation }) =>
   imageBannerTwig({
     ...imageData.responsive_images['16x9'],
     image_banner__video: withVideo ? 'true' : 'false',
     image_banner__content__background: bgColor,
+    image_banner__image_size: styleVariation,
   });
 ImageBanner.argTypes = {
   withVideo: {
     name: 'With Video',
     type: 'boolean',
     defaultValue: false,
+  },
+  styleVariation: {
+    name: 'Size',
+    type: 'select',
+    options: ['small', 'large'],
+    defaultValue: 'large',
   },
 };

--- a/components/02-molecules/banner/banner.stories.js
+++ b/components/02-molecules/banner/banner.stories.js
@@ -144,8 +144,8 @@ ImageBanner.argTypes = {
   size: {
     name: 'Image Size',
     type: 'select',
-    options: ['large', 'small'],
-    defaultValue: 'large',
+    options: ['tall', 'short'],
+    defaultValue: 'tall',
   },
   withVideo: {
     name: 'With Video',

--- a/components/02-molecules/banner/image/yds-image-banner.scss
+++ b/components/02-molecules/banner/image/yds-image-banner.scss
@@ -2,28 +2,38 @@
 @use '../../../01-atoms/atoms';
 @use '../../../00-tokens/functions/map';
 
-// get global themes
 $global-image-banner-themes: map.deep-get(tokens.$tokens, 'global-themes');
 $component-image-banner-themes: map.deep-get(
   tokens.$tokens,
   'component-themes'
 );
-$break-image-banner-banner: tokens.$break-l;
-$break-image-banner-banner-max: $break-image-banner-banner;
+$break-image-banner: tokens.$break-m;
 
 .image-banner {
-  border: 1px solid red;
   @include tokens.spacing-page-section(
     $flush-top: true,
     $flush-bottom: true,
     $banner-spacing: true
   );
 
-  &[data-banner-size='small'] {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  align-items: end;
+  width: 100%;
+  max-width: tokens.$break-max-width;
+  margin: 0 auto;
+  background-color: var(--color-image-banner-background);
+
+  @media (min-width: $break-image-banner) {
+    align-items: center;
+  }
+
+  &[data-image-banner-size='small'] {
     min-height: 28rem;
   }
 
-  &[data-banner-size='large'] {
+  &[data-image-banner-size='large'] {
     min-height: calc(95vh - var(--site-header-height));
   }
 
@@ -31,7 +41,11 @@ $break-image-banner-banner-max: $break-image-banner-banner;
   // default variables.
   @each $theme, $value in $component-image-banner-themes {
     &[data-component-theme='#{$theme}'] {
-      --color-backgound: var(--color-banner-background);
+      --color-text: var(--color-image-banner-text);
+      --color-backgound: var(--color-image-banner-background);
+      --color-heading: var(--color-image-banner-heading);
+      --color-action: var(--color-image-banner-action);
+      --color-action-secondary: var(--color-image-banner-action-secondary);
       --color-slot-one: var(--component-themes-#{$theme}-slot-one);
       --color-slot-two: var(--component-themes-#{$theme}-slot-two);
       --color-slot-three: var(--component-themes-#{$theme}-slot-three);
@@ -63,153 +77,129 @@ $break-image-banner-banner-max: $break-image-banner-banner;
       --color-slot-eight: var(
         --global-themes-#{$globalTheme}-colors-slot-eight
       );
+
+      @if $globalTheme == 'four' {
+        // Switch colors slot in order to have the selected background colors per component theme.
+        --color-slot-two: var(--global-themes-four-colors-slot-five);
+        --color-slot-five: var(--global-themes-four-colors-slot-two);
+
+        // Switch color slot for the text on light background.
+        --color-slot-seven: var(--global-themes-four-colors-slot-six);
+      }
     }
   }
-
-  max-width: tokens.$break-max-width;
-  margin-inline-start: auto;
-  margin-inline-end: auto;
-  padding: 0;
-  background-color: var(--color-banner-background);
-
-  --banner-content-max-width: 37rem;
 
   // Component theme overrides: set specific component themes overrides
   /// define component name spaced variables and map them to global theme slots.
   &[data-component-theme='one'] {
-    --color-banner-background: var(--color-slot-one);
+    --color-image-banner-background: var(--color-slot-one);
+    --color-image-banner-text: var(--color-slot-eight);
+    --color-image-banner-heading: var(--color-slot-eight);
+    --color-image-banner-action: var(--color-slot-eight);
+    --color-image-banner-action-secondary: var(--color-slot-one);
+    --color-link-base: var(--color-image-banner-text);
+    --color-link-hover: var(--color-image-banner-text);
+    --color-link-visited-base: var(--color-link-visited-light);
+    --color-link-visited-hover: var(--color-link-visited-light-hover);
   }
 
   &[data-component-theme='two'] {
-    --color-banner-background: var(--color-slot-four);
+    --color-image-banner-background: var(--color-slot-four);
+    --color-image-banner-text: var(--color-slot-seven);
+    --color-image-banner-heading: var(--color-slot-seven);
+    --color-image-banner-action: var(--color-slot-seven);
+    --color-image-banner-action-secondary: var(--color-slot-eight);
+    --color-link-base: var(--color-image-banner-text);
+    --color-link-hover: var(--color-image-banner-text);
+
+    p > a {
+      color: var(--color-slot-seven);
+    }
   }
 
   &[data-component-theme='three'] {
-    --color-banner-background: var(--color-slot-five);
+    --color-image-banner-background: var(--color-slot-five);
+    --color-image-banner-text: var(--color-slot-eight);
+    --color-image-banner-heading: var(--color-slot-eight);
+    --color-image-banner-action: var(--color-slot-eight);
+    --color-image-banner-action-secondary: var(--color-slot-one);
+    --color-link-base: var(--color-image-banner-text);
+    --color-link-hover: var(--color-image-banner-text);
+    --color-link-visited-base: var(--color-link-visited-light);
+    --color-link-visited-hover: var(--color-link-visited-light-hover);
+
+    // For accessibility reason set lighter visited links color.
+    [data-global-theme='four'] & {
+      --color-link-visited-base: var(--color-gray-100);
+      --color-link-visited-hover: var(--color-slot-eight);
+    }
   }
-}
 
-.image-banner__content-wrapper {
-  position: relative;
+  &[data-component-theme='four'] {
+    --color-image-banner-background: var(--color-slot-three);
+    --color-image-banner-text: var(--color-slot-seven);
+    --color-image-banner-heading: var(--color-slot-seven);
+    --color-image-banner-action: var(--color-slot-seven);
+    --color-image-banner-action-secondary: var(--color-slot-eight);
+    --color-link-base: var(--color-image-banner-heading);
+    --color-link-hover: var(--color-image-banner-heading);
+  }
 
-  @media (min-width: $break-image-banner-banner) {
-    aspect-ratio: 16 / 5;
+  &[data-component-theme='five'] {
+    --color-image-banner-background: var(--color-slot-two);
+    --color-image-banner-text: var(--color-slot-eight);
+    --color-image-banner-heading: var(--color-slot-eight);
+    --color-image-banner-action: var(--color-slot-eight);
+    --color-image-banner-action-secondary: var(--color-slot-one);
+    --color-link-base: var(--color-image-banner-heading);
+    --color-link-hover: var(--color-image-banner-heading);
+    --color-link-visited-base: var(--color-link-visited-light);
+    --color-link-visited-hover: var(--color-link-visited-light-hover);
 
-    // Safari 14 fix for aspect-ratio
-    @supports not (aspect-ratio: 16 / 5) {
-      &::before {
-        float: left;
-        padding-top: 26.25%;
-        content: '';
-      }
-
-      &::after {
-        display: block;
-        content: '';
-        clear: both;
-      }
+    [data-global-theme='four'] & {
+      --color-image-banner-background: var(--component-themes-five-background);
+      --color-image-banner-text: var(--component-themes-five-text);
+      --color-image-banner-heading: var(--component-themes-five-heading);
+      --color-image-banner-action: var(--color-slot-seven);
+      --color-image-banner-action-secondary: var(--color-slot-eight);
+      --color-link-visited-base: var(--color-purple-visited);
+      --color-link-visited-hover: var(--color-purple-visited-hover);
     }
   }
 }
 
 .image-banner__image {
-  @media (max-width: ($break-image-banner-banner - 0.05)) {
-    aspect-ratio: 16 / 5;
-
-    // Safari 14 fix for aspect-ratio
-    @supports not (aspect-ratio: 16 / 5) {
-      &::before {
-        float: left;
-        padding-top: 26.25%;
-        content: '';
-      }
-
-      &::after {
-        display: block;
-        content: '';
-        clear: both;
-      }
-    }
-  }
-
-  @media (min-width: $break-image-banner-banner) {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-  }
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
 
   img {
-    object-fit: cover;
-    height: 100%;
     width: 100%;
+    height: 100%;
+    object-fit: cover;
 
-    [data-banner-size='small'] & {
-      min-height: 28rem;
-    }
-
-    [data-banner-size='large'] & {
+    [data-image-banner-size='large'] & {
       min-height: calc(95vh - var(--site-header-height));
     }
+
+    [data-image-banner-size='small'] & {
+      min-height: 28rem;
+    }
   }
 }
 
-.image-banner__outer-wrap {
+.image-banner__video {
+  top: 0;
+  left: 0;
   width: 100%;
-
-  [data-banner-content-layout='left'] &,
-  [data-banner-content-layout='right'] & {
-    @media (min-width: $break-image-banner-banner) {
-      max-width: var(--banner-content-max-width);
-    }
-  }
-}
-
-.image-banner__wrap {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
   height: 100%;
+  position: absolute;
 
-  // prettier-ignore
-  padding: var(--size-spacing-6) var(--size-spacing-7) var(--size-spacing-7);
-
-  [data-banner-content-layout='left'] &,
-  [data-banner-content-layout='right'] & {
+  video {
     width: 100%;
-    max-width: var(--size-component-layout-width-content);
-  }
-
-  [data-banner-content-layout='bottom'] & {
-    @media (min-width: $break-image-banner-banner) {
-      gap: var(--size-spacing-5);
-      flex-basis: 100%;
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
-      padding-block-start: var(--size-spacing-5);
-      padding-block-end: var(--size-spacing-5);
-      min-height: auto;
-      width: 100%;
-      max-width: 108rem; // 1728px
-      margin: 0 auto;
-    }
-  }
-
-  @media (min-width: $break-image-banner-banner) {
-    padding: var(--size-spacing-6) var(--size-spacing-site-gutter)
-      var(--size-spacing-7);
-  }
-
-  [data-banner-width='site'] & {
-    // prettier-ignore
-    max-width: calc(var(--size-component-layout-width-site) + (var(--size-spacing-10)));
-
-    @media (min-width: $break-image-banner-banner) {
-      // prettier-ignore
-      max-width: calc(var(--size-component-layout-width-site) + (var(--size-spacing-site-gutter) * 2));
-      margin: 0 auto;
-    }
+    height: 100%;
+    object-fit: cover;
   }
 }

--- a/components/02-molecules/banner/image/yds-image-banner.scss
+++ b/components/02-molecules/banner/image/yds-image-banner.scss
@@ -19,6 +19,14 @@ $break-image-banner-banner-max: $break-image-banner-banner;
     $banner-spacing: true
   );
 
+  &[data-banner-size='small'] {
+    min-height: 28rem;
+  }
+
+  &[data-banner-size='large'] {
+    min-height: calc(95vh - var(--site-header-height));
+  }
+
   // Component themes defaults: iterate over each component theme to establish
   // default variables.
   @each $theme, $value in $component-image-banner-themes {
@@ -136,20 +144,12 @@ $break-image-banner-banner-max: $break-image-banner-banner;
     object-fit: cover;
     height: 100%;
     width: 100%;
-  }
 
-  &[data-banner-size='small'] {
-    min-height: 28rem;
-
-    & img {
+    [data-banner-size='small'] & {
       min-height: 28rem;
     }
-  }
 
-  &[data-banner-size='large'] {
-    min-height: calc(95vh - var(--site-header-height));
-
-    & img {
+    [data-banner-size='large'] & {
       min-height: calc(95vh - var(--site-header-height));
     }
   }

--- a/components/02-molecules/banner/image/yds-image-banner.scss
+++ b/components/02-molecules/banner/image/yds-image-banner.scss
@@ -3,12 +3,16 @@
 @use '../../../00-tokens/functions/map';
 
 // get global themes
-$global-banner-themes: map.deep-get(tokens.$tokens, 'global-themes');
-$component-banner-themes: map.deep-get(tokens.$tokens, 'component-themes');
-$break-image-banner: tokens.$break-l;
-$break-image-banner-max: $break-image-banner - 0.05;
+$global-image-banner-themes: map.deep-get(tokens.$tokens, 'global-themes');
+$component-image-banner-themes: map.deep-get(
+  tokens.$tokens,
+  'component-themes'
+);
+$break-image-banner-banner: tokens.$break-l;
+$break-image-banner-banner-max: $break-image-banner-banner;
 
 .image-banner {
+  border: 1px solid red;
   @include tokens.spacing-page-section(
     $flush-top: true,
     $flush-bottom: true,
@@ -17,7 +21,7 @@ $break-image-banner-max: $break-image-banner - 0.05;
 
   // Component themes defaults: iterate over each component theme to establish
   // default variables.
-  @each $theme, $value in $component-banner-themes {
+  @each $theme, $value in $component-image-banner-themes {
     &[data-component-theme='#{$theme}'] {
       --color-backgound: var(--color-banner-background);
       --color-slot-one: var(--component-themes-#{$theme}-slot-one);
@@ -35,7 +39,7 @@ $break-image-banner-max: $break-image-banner - 0.05;
   // This establishes `--color-slot-` variables name-spaced to the selector
   // in which it is used. We can map component-level variables to global-level
   // `--color-slot-` variables.
-  @each $globalTheme, $value in $global-banner-themes {
+  @each $globalTheme, $value in $global-image-banner-themes {
     [data-global-theme='#{$globalTheme}'] & {
       --color-slot-one: var(--global-themes-#{$globalTheme}-colors-slot-one);
       --color-slot-two: var(--global-themes-#{$globalTheme}-colors-slot-two);
@@ -80,7 +84,7 @@ $break-image-banner-max: $break-image-banner - 0.05;
 .image-banner__content-wrapper {
   position: relative;
 
-  @media (min-width: $break-image-banner) {
+  @media (min-width: $break-image-banner-banner) {
     aspect-ratio: 16 / 5;
 
     // Safari 14 fix for aspect-ratio
@@ -101,7 +105,7 @@ $break-image-banner-max: $break-image-banner - 0.05;
 }
 
 .image-banner__image {
-  @media (max-width: ($break-image-banner - 0.05)) {
+  @media (max-width: ($break-image-banner-banner - 0.05)) {
     aspect-ratio: 16 / 5;
 
     // Safari 14 fix for aspect-ratio
@@ -120,7 +124,7 @@ $break-image-banner-max: $break-image-banner - 0.05;
     }
   }
 
-  @media (min-width: $break-image-banner) {
+  @media (min-width: $break-image-banner-banner) {
     position: absolute;
     top: 0;
     left: 0;
@@ -133,6 +137,22 @@ $break-image-banner-max: $break-image-banner - 0.05;
     height: 100%;
     width: 100%;
   }
+
+  &[data-banner-size='small'] {
+    min-height: 28rem;
+
+    & img {
+      min-height: 28rem;
+    }
+  }
+
+  &[data-banner-size='large'] {
+    min-height: calc(95vh - var(--site-header-height));
+
+    & img {
+      min-height: calc(95vh - var(--site-header-height));
+    }
+  }
 }
 
 .image-banner__outer-wrap {
@@ -140,7 +160,7 @@ $break-image-banner-max: $break-image-banner - 0.05;
 
   [data-banner-content-layout='left'] &,
   [data-banner-content-layout='right'] & {
-    @media (min-width: $break-image-banner) {
+    @media (min-width: $break-image-banner-banner) {
       max-width: var(--banner-content-max-width);
     }
   }
@@ -162,7 +182,7 @@ $break-image-banner-max: $break-image-banner - 0.05;
   }
 
   [data-banner-content-layout='bottom'] & {
-    @media (min-width: $break-image-banner) {
+    @media (min-width: $break-image-banner-banner) {
       gap: var(--size-spacing-5);
       flex-basis: 100%;
       flex-direction: row;
@@ -177,7 +197,7 @@ $break-image-banner-max: $break-image-banner - 0.05;
     }
   }
 
-  @media (min-width: $break-image-banner) {
+  @media (min-width: $break-image-banner-banner) {
     padding: var(--size-spacing-6) var(--size-spacing-site-gutter)
       var(--size-spacing-7);
   }
@@ -186,7 +206,7 @@ $break-image-banner-max: $break-image-banner - 0.05;
     // prettier-ignore
     max-width: calc(var(--size-component-layout-width-site) + (var(--size-spacing-10)));
 
-    @media (min-width: $break-image-banner) {
+    @media (min-width: $break-image-banner-banner) {
       // prettier-ignore
       max-width: calc(var(--size-component-layout-width-site) + (var(--size-spacing-site-gutter) * 2));
       margin: 0 auto;

--- a/components/02-molecules/banner/image/yds-image-banner.scss
+++ b/components/02-molecules/banner/image/yds-image-banner.scss
@@ -29,11 +29,11 @@ $break-image-banner: tokens.$break-m;
     align-items: center;
   }
 
-  &[data-image-banner-size='small'] {
+  &[data-image-banner-size='short'] {
     min-height: 28rem;
   }
 
-  &[data-image-banner-size='large'] {
+  &[data-image-banner-size='tall'] {
     min-height: calc(95vh - var(--site-header-height));
   }
 
@@ -180,11 +180,11 @@ $break-image-banner: tokens.$break-m;
     height: 100%;
     object-fit: cover;
 
-    [data-image-banner-size='large'] & {
+    [data-image-banner-size='tall'] & {
       min-height: calc(95vh - var(--site-header-height));
     }
 
-    [data-image-banner-size='small'] & {
+    [data-image-banner-size='short'] & {
       min-height: 28rem;
     }
   }

--- a/components/02-molecules/banner/image/yds-image-banner.twig
+++ b/components/02-molecules/banner/image/yds-image-banner.twig
@@ -4,10 +4,6 @@
  # - image_banner__overlay_variation: contained (default), full
  #
  # Available Variables:
- # - image_banner__heading
- # - image_banner__snippet
- # - image_banner__link__content
- # - image_banner__link__url
  # - video_background__button__background_color
  #
  # Available Blocks:
@@ -17,7 +13,7 @@
 {% set image_banner__base_class = 'image-banner' %}
 {% set image_banner__content__background = image_banner__content__background|default('one') %}
 {% set image_banner__overlay_variation = image_banner__overlay_variation|default('contained') %}
-{% set image_banner__size = image_banner__size|default('full') %}
+{% set image_banner__size = image_banner__size|default('tall') %}
 
 {% set image_banner__attributes = {
   'data-image-banner-overlay-variation': image_banner__overlay_variation,

--- a/components/02-molecules/banner/image/yds-image-banner.twig
+++ b/components/02-molecules/banner/image/yds-image-banner.twig
@@ -1,54 +1,54 @@
 {#
  # Available Props:
- # - image_banner__content__layout: bottom (default), left, or right
- # - image_banner__video: false (default) or true
- # - image_banner__content_background: one (default), two, three
- # - image_banner__image_size: large (default), small
+ # - image_banner__content__background
+ # - image_banner__overlay_variation: contained (default), full
+ #
+ # Available Variables:
+ # - image_banner__heading
+ # - image_banner__snippet
+ # - image_banner__link__content
+ # - image_banner__link__url
+ # - video_background__button__background_color
  #
  # Available Blocks:
- # - image_banner__image
+ # - image_banner__media
  #}
 
 {% set image_banner__base_class = 'image-banner' %}
 {% set image_banner__content__background = image_banner__content__background|default('one') %}
+{% set image_banner__overlay_variation = image_banner__overlay_variation|default('contained') %}
+{% set image_banner__size = image_banner__size|default('full') %}
 
 {% set image_banner__attributes = {
+  'data-image-banner-overlay-variation': image_banner__overlay_variation,
+  'data-image-banner-size': image_banner__size,
   'data-component-theme': image_banner__content__background,
   class: bem(image_banner__base_class),
 } %}
 
-{% if image_banner__image_size %}
-  {% set image_banner__attributes = image_banner__attributes|merge({
-    'data-banner-size': image_banner__image_size,
-  }) %}
-{% endif %}
-
 {% if image_banner__width %}
   {% set image_banner__attributes = image_banner__attributes|merge({
-    'data-banner-width': image_banner__width,
+    'data-image-banner-width': image_banner__width,
   }) %}
 {% endif %}
 
 <div {{ add_attributes(image_banner__attributes) }}>
   {% block prefix_suffix %}
   {% endblock %}
-  <div {{ bem('content-wrapper', [], image_banner__base_class) }}>
-    {% if image_banner__video == 'true' %}
-    <div {{ bem('video', [], image_banner__base_class) }}>
-      {% block image_banner__video %}
-        {% include "@atoms/videos/video-background/yds-video-background.twig" with {
-          video_background__content: video_background__content|default('https://ia800301.us.archive.org/17/items/VjmorphVjLoops4/SequinSparkle02.mp4'),
-          video_background__button__background_color: image_banner__content__background,
-        } %}
+  {% if image_banner__video == 'true' %}
+  <div {{ bem('video', [], image_banner__base_class) }}>
+    {% block image_banner__video %}
+      {% include "@atoms/videos/video-background/yds-video-background.twig" with {
+        video_background__content: video_background__content|default('https://ia800301.us.archive.org/17/items/VjmorphVjLoops4/SequinSparkle02.mp4'),
+        video_background__button__background_color: image_banner__content__background,
+      } %}
+    {% endblock %}
+  </div>
+  {% else %}
+    <div {{ bem('image', [], image_banner__base_class) }}>
+      {% block image_banner__image %}
+        {% include "@atoms/images/image/_responsive-image.twig" %}
       {% endblock %}
     </div>
-    {% else %}
-      <div {{ bem('image', [], image_banner__base_class) }}>
-        {% block image_banner__image %}
-          {% include "@atoms/images/image/_responsive-image.twig" %}
-        {% endblock %}
-      </div>
-    {% endif %}
-  </div>
+  {% endif %}
 </div>
-

--- a/components/02-molecules/banner/image/yds-image-banner.twig
+++ b/components/02-molecules/banner/image/yds-image-banner.twig
@@ -3,6 +3,7 @@
  # - image_banner__content__layout: bottom (default), left, or right
  # - image_banner__video: false (default) or true
  # - image_banner__content_background: one (default), two, three
+ # - image_banner__image_size: large (default), small
  #
  # Available Blocks:
  # - image_banner__image
@@ -15,6 +16,12 @@
   'data-component-theme': image_banner__content__background,
   class: bem(image_banner__base_class),
 } %}
+
+{% if image_banner__image_size %}
+  {% set image_banner__attributes = image_banner__attributes|merge({
+    'data-banner-size': image_banner__image_size,
+  }) %}
+{% endif %}
 
 {% if image_banner__width %}
   {% set image_banner__attributes = image_banner__attributes|merge({

--- a/components/02-molecules/molecules.scss
+++ b/components/02-molecules/molecules.scss
@@ -32,3 +32,4 @@
 @forward './facts-and-figures/yds-facts-and-figures';
 @forward './tile-item/yds-tile-item';
 @forward './inline-message/yds-inline-message';
+@forward './banner/image/yds-image-banner';


### PR DESCRIPTION
## [YSP-680: PRESIDENT: Add dial to image banner to allow default and large image display](https://yaleits.atlassian.net/browse/YSP-680)

### Other work to be reviewed:
- [YaleSites Project](https://github.com/yalesites-org/yalesites-project/pull/770)
- [Atomic](https://github.com/yalesites-org/atomic/pull/270)

### Description of work
- Adds size dial to image banner controls (tall and short)
- Mimic grand hero twig and SCSS to give similar experience and expectations

### Testing Link(s)
- [ ] Navigate to the [Image Banner Story](https://deploy-preview-423--dev-component-library-twig.netlify.app/?path=/story/molecules-banners--image-banner)

### Functional Review Steps
- [ ] Verify that you can change the `Image Size` control and notice the difference

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
