### PR TITLE
fix(webpack): watched webpack keeps fonts

### DIFF
--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -50,6 +50,7 @@ module.exports = {
       'css/**/*.js', // Remove all unwanted, auto generated JS files from dist/css folder.
       'css/**/*.js.map',
       '!*.{png,jpg,gif,svg}',
+      '!fonts/**',
     ],
   }),
 };


### PR DESCRIPTION
## fix(webpack): watched webpack keeps fonts

When attempting to use `npm run develop`, the watched files in webpack would remove the fonts folder from dist on update, causing issues when we try to verify links and the like.  This ensures that it keeps them there on cleanups.

### Description of work
- Exclude fonts on webpack cleanups

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
