### PR TITLE
YSP-752: Storybook global config settings don't use localStorage any longer

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -52,4 +52,5 @@ export const globalTypes = {
 export const tags = ['autodocs', 'autodocs'];
 export const parameters = {
   actions: { argTypesRegex: '^on.*' },
+  controls: { disableSaveFromUI: true },
 };

--- a/components/_settings/config.stories.js
+++ b/components/_settings/config.stories.js
@@ -44,102 +44,113 @@ export default {
       name: 'Site: Animation Theme',
       options: siteAnimationOptions,
       type: 'select',
-      defaultValue: 'default',
     },
     thickness: {
       name: 'Site: Line thickness',
       options: thicknessOptions,
       type: 'select',
-      defaultValue: 'hairline',
     },
     dividerColor: {
       name: 'Site: Line color',
       options: ['gray-500', 'blue-yale', 'basic-brown-gray'],
       type: 'select',
-      defaultValue: 'gray-500',
     },
     dividerWidth: {
       name: 'Site: Divider width',
       options: [...widths],
       type: 'select',
-      defaultValue: '100',
     },
     dividerPosition: {
       name: 'Site: Divider position',
       options: layoutOptions,
       type: 'select',
-      defaultValue: 'center',
     },
     actionColor: {
       name: 'Action Color',
       options: ['blue-yale', 'basic-black'],
       type: 'select',
-      defaultValue: 'blue-yale',
     },
     menuVariation: {
       name: 'Site: Menu Variation',
       options: ['mega', 'basic', 'focus'],
       type: 'select',
-      defaultValue: localStorage.getItem('yds-cl-twig-menu-variation'),
     },
     primaryNavPosition: {
       name: 'Site: Navigation Position',
       options: ['left', 'center', 'right'],
       type: 'select',
-      defaultValue: localStorage.getItem('yds-cl-twig-primary-nav-position'),
     },
     siteHeaderTheme: {
       name: 'Header: Theme',
       options: siteHeaderThemeOptions,
       type: 'select',
-      defaultValue: localStorage.getItem('yds-cl-twig-site-header-theme'),
     },
     siteHeaderAccent: {
       name: 'Header: Accent Color (dial)',
       options: siteHeaderAccents,
       type: 'select',
-      defaultValue: localStorage.getItem('yds-cl-twig-site-header-accent'),
     },
     siteHeaderImage: {
       name: 'Header: With Image',
       type: 'boolean',
-      defaultValue: false,
     },
     siteHeaderSiteNameImage: {
       name: 'Header: Site Name Is An Image',
       type: 'boolean',
-      defaultValue: false,
     },
     headerBorderThickness: {
       name: 'Header: Border Thickness',
       options: borderThicknessOptions,
       type: 'select',
-      defaultValue: localStorage.getItem('yds-cl-twig-header-border-thickness'),
     },
     siteFooterVariation: {
       name: 'Footer: Variation',
       options: siteFooterVariations,
       type: 'select',
-      defaultValue: localStorage.getItem('yds-cl-twig-site-footer-variation'),
     },
     siteFooterTheme: {
       name: 'Footer: Theme',
       options: siteFooterThemeOptions,
       type: 'select',
-      defaultValue: localStorage.getItem('yds-cl-twig-site-footer-theme'),
     },
     siteFooterAccent: {
       name: 'Footer: Accent Color (dial)',
       options: siteFooterAccents,
       type: 'select',
-      defaultValue: localStorage.getItem('yds-cl-twig-site-footer-accent'),
     },
     footerBorderThickness: {
       name: 'Footer: Border thickness',
       options: borderThicknessOptions,
       type: 'select',
-      defaultValue: localStorage.getItem('yds-cl-twig-footer-border-thickness'),
     },
+  },
+  args: {
+    allowAnimatedItems:
+      localStorage.getItem('yds-cl-twig-animate-items') || 'default',
+    thickness: 'hairline',
+    dividerColor: 'gray-500',
+    dividerWidth: '100',
+    dividerPosition: 'center',
+    actionColor: 'blue-yale',
+    menuVariation: localStorage.getItem('yds-cl-twig-menu-variation') || 'mega',
+    primaryNavPosition:
+      localStorage.getItem('yds-cl-twig-primary-nav-position') || 'left',
+    siteHeaderTheme:
+      localStorage.getItem('yds-cl-twig-site-header-theme') || 'one',
+    siteHeaderAccent:
+      localStorage.getItem('yds-cl-twig-site-header-accent') || 'one',
+    siteHeaderImage: false,
+    siteHeaderSiteNameImage: false,
+    headerBorderThickness:
+      localStorage.getItem('yds-cl-twig-header-border-thickness') || 'hairline',
+    siteFooterVariation:
+      localStorage.getItem('yds-cl-twig-site-footer-variation') || 'basic',
+    siteFooterTheme:
+      localStorage.getItem('yds-cl-twig-site-footer-theme') || 'one',
+    siteFooterAccent:
+      localStorage.getItem('yds-cl-twig-site-footer-accent') || 'one',
+    footerBorderThickness:
+      localStorage.getItem('yds-cl-twig-footer-border-thickness') || 'hairline',
   },
 };
 

--- a/components/_settings/config.stories.js
+++ b/components/_settings/config.stories.js
@@ -34,6 +34,110 @@ const themesOneToEight = [
 const siteHeaderAccents = themesOneToEight;
 const siteFooterAccents = themesOneToEight;
 
+const valueConfig = {
+  allowAnimatedItems: {
+    storage: 'yds-cl-twig-animate-items',
+    defaultValue: 'default',
+  },
+  thickness: {
+    defaultValue: 'hairline',
+  },
+  dividerColor: {
+    defaultValue: 'gray-500',
+  },
+  dividerWidth: {
+    defaultValue: '100',
+  },
+  dividerPosition: {
+    defaultValue: 'center',
+  },
+  actionColor: {
+    defaultValue: 'blue-yale',
+  },
+  menuVariation: {
+    storage: 'yds-cl-twig-menu-variation',
+    defaultValue: 'mega',
+  },
+  primaryNavPosition: {
+    storage: 'yds-cl-twig-primary-nav-position',
+    defaultValue: 'left',
+  },
+  siteHeaderTheme: {
+    storage: 'yds-cl-twig-site-header-theme',
+    defaultValue: 'one',
+  },
+  siteHeaderAccent: {
+    storage: 'yds-cl-twig-site-header-accent',
+    defaultValue: 'one',
+  },
+  siteHeaderImage: {
+    defaultValue: false,
+  },
+  siteHeaderSiteNameImage: {
+    defaultValue: false,
+  },
+  headerBorderThickness: {
+    storage: 'yds-cl-twig-header-border-thickness',
+    defaultValue: 'hairline',
+  },
+  siteFooterVariation: {
+    storage: 'yds-cl-twig-site-footer-variation',
+    defaultValue: 'basic',
+  },
+  siteFooterTheme: {
+    storage: 'yds-cl-twig-site-footer-theme',
+    defaultValue: 'one',
+  },
+  siteFooterAccent: {
+    storage: 'yds-cl-twig-site-footer-accent',
+    defaultValue: 'one',
+  },
+  footerBorderThickness: {
+    storage: 'yds-cl-twig-footer-border-thickness',
+    defaultValue: 'hairline',
+  },
+};
+
+// Returns a function that knows about the config to look up values.
+const getLookupFor = (config) => {
+  return (key) => {
+    const { storage, defaultValue } = config[key];
+
+    if (storage) {
+      const value = localStorage.getItem(storage);
+
+      if (value && value !== undefined && value !== 'undefined') {
+        return value;
+      }
+    }
+    return defaultValue;
+  };
+};
+
+const getValueFor = getLookupFor(valueConfig);
+
+const config = {
+  allowAnimatedItems: getValueFor('allowAnimatedItems'),
+  thickness: getValueFor('thickness'),
+  dividerColor: getValueFor('dividerColor'),
+  dividerWidth: getValueFor('dividerWidth'),
+  dividerPosition: getValueFor('dividerPosition'),
+  actionColor: getValueFor('actionColor'),
+  menuVariation: getValueFor('menuVariation'),
+  primaryNavPosition: getValueFor('primaryNavPosition'),
+  siteHeaderTheme: getValueFor('siteHeaderTheme'),
+  siteHeaderAccent: getValueFor('siteHeaderAccent'),
+  siteHeaderImage: getValueFor('siteHeaderImage'),
+  siteHeaderSiteNameImage: getValueFor('siteHeaderSiteNameImage'),
+  headerBorderThickness: getValueFor('headerBorderThickness'),
+  siteFooterVariation: getValueFor('siteFooterVariation'),
+  siteFooterTheme: getValueFor('siteFooterTheme'),
+  siteFooterAccent: getValueFor('siteFooterAccent'),
+  footerBorderThickness: getValueFor('footerBorderThickness'),
+};
+
+console.log(config);
+
 export default {
   title: 'Config',
   parameters: {
@@ -124,34 +228,7 @@ export default {
       type: 'select',
     },
   },
-  args: {
-    allowAnimatedItems:
-      localStorage.getItem('yds-cl-twig-animate-items') || 'default',
-    thickness: 'hairline',
-    dividerColor: 'gray-500',
-    dividerWidth: '100',
-    dividerPosition: 'center',
-    actionColor: 'blue-yale',
-    menuVariation: localStorage.getItem('yds-cl-twig-menu-variation') || 'mega',
-    primaryNavPosition:
-      localStorage.getItem('yds-cl-twig-primary-nav-position') || 'left',
-    siteHeaderTheme:
-      localStorage.getItem('yds-cl-twig-site-header-theme') || 'one',
-    siteHeaderAccent:
-      localStorage.getItem('yds-cl-twig-site-header-accent') || 'one',
-    siteHeaderImage: false,
-    siteHeaderSiteNameImage: false,
-    headerBorderThickness:
-      localStorage.getItem('yds-cl-twig-header-border-thickness') || 'hairline',
-    siteFooterVariation:
-      localStorage.getItem('yds-cl-twig-site-footer-variation') || 'basic',
-    siteFooterTheme:
-      localStorage.getItem('yds-cl-twig-site-footer-theme') || 'one',
-    siteFooterAccent:
-      localStorage.getItem('yds-cl-twig-site-footer-accent') || 'one',
-    footerBorderThickness:
-      localStorage.getItem('yds-cl-twig-footer-border-thickness') || 'hairline',
-  },
+  args: config,
 };
 
 const intro = `

--- a/components/_settings/config.stories.js
+++ b/components/_settings/config.stories.js
@@ -136,8 +136,6 @@ const config = {
   footerBorderThickness: getValueFor('footerBorderThickness'),
 };
 
-console.log(config);
-
 export default {
   title: 'Config',
   parameters: {

--- a/components/_settings/config.stories.js
+++ b/components/_settings/config.stories.js
@@ -205,7 +205,6 @@ export const GlobalConfig = ({
 
   return `
   <script>
-  console.log(allowAnimatedItems);
     const resetAttributes = () => {
       Object.keys(localStorage).forEach((key) => {
         if (key.substring(0, 12) === 'yds-cl-twig-') {

--- a/components/_settings/config.stories.js
+++ b/components/_settings/config.stories.js
@@ -293,7 +293,7 @@ export const GlobalConfig = ({
 
   return `
   <script>
-    const resetAttributes = () => {
+    window.resetAttributes = () => {
       Object.keys(localStorage).forEach((key) => {
         if (key.substring(0, 12) === 'yds-cl-twig-') {
           localStorage.removeItem(key);

--- a/lib/link-treatment/link-treatment.scss
+++ b/lib/link-treatment/link-treatment.scss
@@ -1,4 +1,4 @@
-@import '../../node_modules/linkpurpose/css/linkpurpose';
+@use '../../node_modules/linkpurpose/css/linkpurpose';
 
 // For visited links, mirror the link color itself.
 a.link-purpose {


### PR DESCRIPTION
## [YSP-752: Storybook global config settings don't use localStorage any longer](https://yaleits.atlassian.net/browse/YSP-752)

### Description of work
- Uses `args` in config story
- Create way to use localStorage with a default fallback on values
- Remove "Save" feature when updating stories
- Use `@use` over `@import` for `link-treatment.scss`
- Remove `console.log` message
- Defined `resetAttributes` to the window object so we don't get redefinition errors

### Testing Link(s)
- [ ] Navigate to the [Global Config](https://deploy-preview-437--dev-component-library-twig.netlify.app/?path=/story/config--global-config)

### Functional Review Steps
- [ ] Verify that defaults appear in `Controls` section
- [ ] Verify that upon updating items that use localStorage, that they persist when you visit again
- [ ] Verify that on updating a control item, the "Save/Update" question at the bottom no longer shows
- [ ] Use resetAttributes and make changes noting that there are no console errors on resetAttributes already being defined