### PR TITLE
fix(quick-links): remove white-space nowrap setting

### DIFF
--- a/lib/link-treatment/link-treatment.scss
+++ b/lib/link-treatment/link-treatment.scss
@@ -25,7 +25,6 @@ a.link-purpose {
   // appear next to each other.
   & a:has(span.link-purpose-spacer) {
     flex-direction: column;
-    white-space: nowrap;
 
     & span.link-purpose-spacer {
       display: none;


### PR DESCRIPTION
## fix(quick-links): remove white-space nowrap setting

This is causing some strange things for longer items, so we are removing it.  This may result in strange behavior for smaller items, but it still will display fine.

### Description of work
- Removes nowrap for quick links

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/file/OVfmCW5s1gI7xnrM8ibX2y/UI-Kit-Alpha-%5BYaleSites%5D)
- [ ] Review any new [Percy builds](https://percy.io/95144ff9/component-library-twig)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
