### PR TITLE
IYY-301: Add Link Grid component as an option in the new 1/2-1/2 layout

### DIFF
--- a/components/02-molecules/link-grid/_yds-link-grid.scss
+++ b/components/02-molecules/link-grid/_yds-link-grid.scss
@@ -65,6 +65,11 @@ $component-link-grid-themes: map.deep-get(tokens.$tokens, 'component-themes');
   &[data-component-theme='five'] {
     --color-link-grid-action: var(--color-slot-two);
   }
+
+  // if used in the layout component, remove the top margin
+  [data-component-layout] & {
+    margin-block-start: 0;
+  }
 }
 
 .link-grid__heading {

--- a/components/02-molecules/link-grid/_yds-link-grid.scss
+++ b/components/02-molecules/link-grid/_yds-link-grid.scss
@@ -110,6 +110,14 @@ $component-link-grid-themes: map.deep-get(tokens.$tokens, 'component-themes');
   &:first-of-type {
     border-width: var(--size-thickness-4);
   }
+
+  // if used in fifty-fifty layout and min-width 2xl
+  // make the columns 50% width
+  [data-component-layout='fifty-fifty'] & {
+    @media (min-width: tokens.$break-2xl) {
+      flex: 1 1 50%;
+    }
+  }
 }
 
 .link-grid__list-item {

--- a/components/03-organisms/layout/layout.stories.js
+++ b/components/03-organisms/layout/layout.stories.js
@@ -27,7 +27,7 @@ export default {
     layoutOption: {
       name: 'Layout',
       type: 'select',
-      options: ['fifty-fifty', 'thirty-thirty-thirty', 'two-thirds-one-thirds'],
+      options: ['fifty-fifty', 'thirty-thirty-thirty', 'seventy-thirty'],
       control: { type: 'select' },
     },
     theme: {

--- a/components/03-organisms/layout/layout/_layout--example.twig
+++ b/components/03-organisms/layout/layout/_layout--example.twig
@@ -6,6 +6,67 @@
   {% endblock %}
   {% block layout__secondary %}
     {% if component__layout == 'fifty-fifty' %}
+    {% include "@molecules/link-grid/yds-link-grid.twig" with {
+      link_grid__heading: 'Quick Links',
+      link_grid__theme: 'default',
+      link_grid__links_one: [
+        {
+          link_grid__link__content: 'Undergraduate Handbook',
+          link_grid__link__url: '#'
+        },
+        {
+          link_grid__link__content: 'Course List',
+          link_grid__link__url: '#'
+        },
+        {
+          link_grid__link__content: 'Placement Exams',
+          link_grid__link__url: '#'
+        },
+      ],
+      link_grid__links_two: [
+        {
+          link_grid__link__content: 'Laboratory Registration',
+          link_grid__link__url: '#'
+        },
+        {
+          link_grid__link__content: 'Premedical Students',
+          link_grid__link__url: '#'
+        },
+        {
+          link_grid__link__content: 'Major Requirements',
+          link_grid__link__url: '#'
+        },
+      ],
+      link_grid__links_three: [
+        {
+          link_grid__link__content: 'Yale College Programs of Study',
+          link_grid__link__url: '#'
+        },
+        {
+          link_grid__link__content: 'Yale College Programs of Study',
+          link_grid__link__url: '#'
+        },
+        {
+          link_grid__link__content: 'Yale College Programs of Study',
+          link_grid__link__url: '#'
+        },
+      ],
+      link_grid__links_four: [
+        {
+          link_grid__link__content: 'Yale College Programs of Study',
+          link_grid__link__url: '#'
+        },
+        {
+          link_grid__link__content: 'Yale College Programs of Study',
+          link_grid__link__url: '#'
+        },
+        {
+          link_grid__link__content: 'Yale College Programs of Study',
+          link_grid__link__url: '#'
+        },
+      ],
+    }%}
+
 	  {% include "@molecules/accordion/yds-accordion.twig" with {
       accordion__heading: 'Accordion Group',
       accordion__width: 'site',

--- a/components/03-organisms/layout/layout/_yds-layout.scss
+++ b/components/03-organisms/layout/layout/_yds-layout.scss
@@ -188,7 +188,7 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
     }
   }
 
-  [data-component-layout='two-thirds-one-thirds'] & {
+  [data-component-layout='seventy-thirty'] & {
     @media (min-width: $break-layout-layout) {
       flex: 1 0 var(--size-component-layout-width-content);
     }
@@ -211,7 +211,7 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
     }
   }
 
-  [data-component-layout='two-thirds-one-thirds'] & {
+  [data-component-layout='seventy-thirty'] & {
     @media (min-width: $break-layout-layout) {
       flex: 0 1 calc(37.5rem + var(--spacing-component-gutter));
     }
@@ -231,21 +231,21 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
 
 // Update font-size for headings based on layout
 h2 {
-  [data-component-layout='two-thirds-one-thirds'] &,
+  [data-component-layout='seventy-thirty'] &,
   [data-component-layout='thirty-thirty-thirty'] & {
     @include tokens.h3-yale-new;
   }
 }
 
 h3 {
-  [data-component-layout='two-thirds-one-thirds'] &,
+  [data-component-layout='seventy-thirty'] &,
   [data-component-layout='thirty-thirty-thirty'] & {
     @include tokens.h4-yale-new;
   }
 }
 
 h4 {
-  [data-component-layout='two-thirds-one-thirds'] &,
+  [data-component-layout='seventy-thirty'] &,
   [data-component-layout='thirty-thirty-thirty'] & {
     @include tokens.h5-yale-new;
   }

--- a/components/03-organisms/layout/layout/_yds-layout.scss
+++ b/components/03-organisms/layout/layout/_yds-layout.scss
@@ -91,6 +91,8 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
     --color-link-base: var(--color-slot-eight);
     --color-link-hover: var(--color-slot-eight);
     --color-layout-border: var(--color-slot-four);
+    --color-heading: var(--color-slot-eight);
+    --color-link-grid-action: var(--color-slot-eight);
   }
 
   &[data-component-theme='two'] {
@@ -100,6 +102,7 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
     --color-link-hover: var(--color-slot-seven);
     --color-heading: var(--color-slot-six);
     --color-layout-border: var(--color-slot-six);
+    --color-link-grid-action: var(--color-slot-six);
   }
 
   &[data-component-theme='three'] {
@@ -110,6 +113,8 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
     --color-link-base: var(--color-slot-eight);
     --color-link-hover: var(--color-slot-eight);
     --color-layout-border: var(--color-slot-four);
+    --color-heading: var(--color-slot-eight);
+    --color-link-grid-action: var(--color-slot-four);
   }
 
   &[data-component-theme='four'] {
@@ -120,6 +125,8 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
     --color-link-base: var(--color-slot-eight);
     --color-link-hover: var(--color-slot-eight);
     --color-layout-border: var(--color-slot-four);
+    --color-heading: var(--color-slot-eight);
+    --color-link-grid-action: var(--color-slot-four);
   }
 }
 
@@ -163,6 +170,8 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
 }
 
 .yds-layout__primary {
+  flex-flow: column nowrap;
+
   @media (max-width: $break-layout-layout-max) {
     margin-bottom: var(--spacing-page-inner);
   }
@@ -188,6 +197,7 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
 
 .yds-layout__secondary {
   display: flex;
+  flex-flow: column nowrap;
 
   [data-component-layout='fifty-fifty'] & {
     @media (min-width: $break-layout-layout) {
@@ -210,6 +220,7 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
 
 .yds-layout__tertiary {
   display: flex;
+  flex-flow: column nowrap;
 
   [data-component-layout='thirty-thirty-thirty'] & {
     @media (min-width: $break-layout-layout) {

--- a/components/03-organisms/layout/layout/_yds-layout.scss
+++ b/components/03-organisms/layout/layout/_yds-layout.scss
@@ -161,6 +161,13 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
   align-self: stretch;
   background-color: var(--color-layout-border);
   width: var(--border-thickness-2);
+  opacity: 0.5;
+
+  // gap affects the width of the divider, so we can increase the width of the
+  // divider in this instance.
+  [data-component-layout='seventy-thirty'] & {
+    width: calc(var(--border-thickness-2) + var(--border-thickness-1));
+  }
 
   @media (max-width: $break-layout-layout-max) {
     width: 100%;


### PR DESCRIPTION
## [IYY-301: Add Link Grid component as an option in the new 1/2-1/2 layout](https://fourkitchens.clickup.com/t/36718269/IYY-301)

### Description of work
- Adds Link Grid component to the layout fifty-fifty option
- The Layout acceptance criteria for allowed components is as follows: 
  - Fifty-Fifty
    - Text
    - Accordion
    - Media
    - Link Grid

  - Thirty-Thirty-Thirty
     - Text
     - Media


### Testing Link(s)
- [ ] Navigate to the [Layout Component Story](https://deploy-preview-445--dev-component-library-twig.netlify.app/?path=/story/organisms-layouts--layout)

### Functional Review Steps
- [ ] Verify you see the Link Grid component in the second column of the fifty-fifty layout
- [ ] Note: if you change the layout, the Link Grid and Accordion do not appear
- [ ] Verify that the Link Grid responds to the component/global themes you select

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
