### PR TITLE
YSP-785: A11y: New Haven Green + ONHA Mega Footer link contrast

### DIFF
--- a/components/02-molecules/link-group/_yds-link-group.scss
+++ b/components/02-molecules/link-group/_yds-link-group.scss
@@ -102,12 +102,12 @@ $break-link-group-max: $break-link-group - 0.05;
 
   // used in footer context, we need theme colors for hover
   .site-footer__columns-inner & {
-    [data-footer-theme='one'] &,
-    [data-footer-theme='two'] &,
-    [data-footer-theme='three'] & {
+    [data-footer-theme='one'] & {
       --color-link-group-hover: var(--color-slot-two);
     }
 
+    [data-footer-theme='two'] &,
+    [data-footer-theme='three'] &,
     [data-footer-theme='four'] &,
     [data-footer-theme='five'] & {
       --color-link-group-hover: var(--color-slot-four);

--- a/components/02-molecules/link-group/_yds-link-group.scss
+++ b/components/02-molecules/link-group/_yds-link-group.scss
@@ -102,15 +102,10 @@ $break-link-group-max: $break-link-group - 0.05;
 
   // used in footer context, we need theme colors for hover
   .site-footer__columns-inner & {
-    [data-footer-theme='one'] & {
-      --color-link-group-hover: var(--color-slot-two);
-    }
-
+    [data-footer-theme='one'] &,
     [data-footer-theme='two'] &,
-    [data-footer-theme='three'] &,
-    [data-footer-theme='four'] &,
-    [data-footer-theme='five'] & {
-      --color-link-group-hover: var(--color-slot-four);
+    [data-footer-theme='three'] & {
+      --color-link-group-hover: var(--color-site-footer-text-color);
     }
 
     &:hover {

--- a/components/03-organisms/site-footer/_site-footer-mega.twig
+++ b/components/03-organisms/site-footer/_site-footer-mega.twig
@@ -29,10 +29,14 @@
   {# WYSIWYG #}
   <div {{ bem('content', [], site_footer__base_class) }}>
     {% block site_footer__content %}
-      {% include "@page-layouts/placeholder/yds-placeholder.twig" with {
-        placeholder: 'Content',
-        placeholder__type: 'element',
-      } %}
+      {% if site_footer__content_text %}
+        {{ site_footer__content_text }}
+      {% else %}
+        {% include "@page-layouts/placeholder/yds-placeholder.twig" with {
+          placeholder: 'Content',
+          placeholder__type: 'element',
+        } %}
+      {% endif %}
     {% endblock %}
   </div>
   {# Columns #}

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -300,7 +300,7 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     flex: 1 1 30%;
 
     & a {
-      @include atoms.plain-link;
+      color: var(--color-text);
     }
 
     @media (min-width: tokens.$break-l) {

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -90,8 +90,6 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     --color-site-footer-border-color: var(--color-slot-one);
     --color-site-footer-background-color: var(--color-basic-white);
     --color-site-footer-text-color: var(--color-site-footer-heading);
-    --color-link-visited-light: var(--color-slot-two);
-    --color-link-visited-light-hover: var(--color-slot-two);
   }
 
   &[data-footer-theme='two'] {
@@ -100,8 +98,8 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     --color-site-footer-background-color: var(--color-gray-800);
     --color-site-footer-text-color: var(--color-basic-white);
     --color-site-footer-divider-color: var(--color-basic-white);
-    --color-link-visited-light: var(--color-slot-four);
-    --color-link-visited-light-hover: var(--color-slot-four);
+    --color-link-visited-base: var(--color-link-visited-light);
+    --color-link-visited-hover: var(--color-link-visited-light-hover);
   }
 
   &[data-footer-theme='three'] {
@@ -110,12 +108,9 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     --color-site-footer-background-color: var(--color-blue-yale);
     --color-site-footer-divider-color: var(--color-basic-white);
     --color-site-footer-text-color: var(--color-basic-white);
-    --color-link-visited-light: var(--color-slot-four);
-    --color-link-visited-light-hover: var(--color-slot-four);
+    --color-link-visited-base: var(--color-link-visited-light);
+    --color-link-visited-hover: var(--color-link-visited-light-hover);
   }
-
-  --color-link-visited-base: var(--color-link-visited-light);
-  --color-link-visited-hover: var(--color-link-visited-light-hover);
 
   // Footer accents
   // Set border colors for each accent
@@ -298,8 +293,11 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
 
     flex: 1 1 30%;
 
-    & a {
-      @include atoms.plain-link;
+    & a,
+    & a:visited,
+    & a:hover,
+    & a:hover:visited {
+      color: var(--color-text);
     }
 
     @media (min-width: tokens.$break-l) {

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -1,7 +1,6 @@
 @use '~@yalesites-org/tokens/build/scss/tokens';
 @use '../../00-tokens/functions/map';
 @use '../../00-tokens/typography/typography';
-@use '../../01-atoms/atoms';
 
 $break-site-footer: tokens.$break-s;
 $break-site-footer-max: $break-site-footer - 0.05;

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -1,6 +1,7 @@
 @use '~@yalesites-org/tokens/build/scss/tokens';
 @use '../../00-tokens/functions/map';
 @use '../../00-tokens/typography/typography';
+@use '../../01-atoms/atoms';
 
 $break-site-footer: tokens.$break-s;
 $break-site-footer-max: $break-site-footer - 0.05;
@@ -297,6 +298,10 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     @include typography.body-s-condensed;
 
     flex: 1 1 30%;
+
+    & a {
+      @include atoms.plain-link;
+    }
 
     @media (min-width: tokens.$break-l) {
       grid-area: content;

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -90,6 +90,8 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     --color-site-footer-border-color: var(--color-slot-one);
     --color-site-footer-background-color: var(--color-basic-white);
     --color-site-footer-text-color: var(--color-site-footer-heading);
+    --color-link-visited-light: var(--color-slot-two);
+    --color-link-visited-light-hover: var(--color-slot-two);
   }
 
   &[data-footer-theme='two'] {
@@ -98,8 +100,8 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     --color-site-footer-background-color: var(--color-gray-800);
     --color-site-footer-text-color: var(--color-basic-white);
     --color-site-footer-divider-color: var(--color-basic-white);
-    --color-link-visited-base: var(--color-link-visited-light);
-    --color-link-visited-hover: var(--color-link-visited-light-hover);
+    --color-link-visited-light: var(--color-slot-four);
+    --color-link-visited-light-hover: var(--color-slot-four);
   }
 
   &[data-footer-theme='three'] {
@@ -108,9 +110,12 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     --color-site-footer-background-color: var(--color-blue-yale);
     --color-site-footer-divider-color: var(--color-basic-white);
     --color-site-footer-text-color: var(--color-basic-white);
-    --color-link-visited-base: var(--color-link-visited-light);
-    --color-link-visited-hover: var(--color-link-visited-light-hover);
+    --color-link-visited-light: var(--color-slot-four);
+    --color-link-visited-light-hover: var(--color-slot-four);
   }
+
+  --color-link-visited-base: var(--color-link-visited-light);
+  --color-link-visited-hover: var(--color-link-visited-light-hover);
 
   // Footer accents
   // Set border colors for each accent

--- a/components/03-organisms/site-footer/_yds-site-footer.scss
+++ b/components/03-organisms/site-footer/_yds-site-footer.scss
@@ -299,7 +299,7 @@ $global-footer-themes: map.deep-get(tokens.$tokens, 'global-themes');
     flex: 1 1 30%;
 
     & a {
-      color: var(--color-text);
+      @include atoms.plain-link;
     }
 
     @media (min-width: tokens.$break-l) {

--- a/components/03-organisms/site-footer/site-footer.stories.js
+++ b/components/03-organisms/site-footer/site-footer.stories.js
@@ -1,5 +1,4 @@
 import tokens from '@yalesites-org/tokens/build/json/tokens.json';
-import getGlobalThemes from '../../00-tokens/colors/color-global-themes';
 
 import siteFooterTwig from './yds-site-footer.twig';
 import siteFooterExamples from './_site-footer--examples.twig';
@@ -11,7 +10,6 @@ const siteFooterThemes = { themes: tokens['site-footer-themes'] };
 const siteGlobalThemes = { themes: tokens['global-themes'] };
 const borderThicknessOptions = Object.keys(tokens.border.thickness);
 const siteFooterThemeOptions = Object.keys(tokens['site-footer-themes']);
-const siteGlobalThemeOptions = getGlobalThemes(tokens['global-themes']);
 const siteFooterAccents = [
   'one',
   'two',
@@ -42,7 +40,6 @@ export default {
     siteFooterAccent: 'one',
     siteFooterTheme: 'one',
     siteFooterVariation: 'basic',
-    globalTheme: 'one',
   },
 };
 
@@ -61,11 +58,12 @@ export const Footer = ({
     site_footer__accent: siteFooterAccent,
     site_footer__variation: siteFooterVariation,
     site_footer__content_text:
-      'This is <a href="https://example.com">example text</a> for footer content with a link.',
+      'This is <a href="https://example.com">example text</a> for footer content <a href="https://example.com/blah">with a link</a>.',
   });
 
 Footer.argTypes = {
   siteFooterTheme: {
+    name: 'Footer Theme (dial)',
     options: siteFooterThemeOptions,
     type: 'select',
   },
@@ -83,7 +81,6 @@ Footer.argTypes = {
 
 export const FooterExamples = ({
   borderThickness,
-  globalTheme,
   siteFooterVariation,
   siteFooterAccent,
 }) =>
@@ -92,18 +89,12 @@ export const FooterExamples = ({
     ...siteFooterThemes,
     ...siteGlobalThemes,
     ...siteFooterAccents,
-    site_global__theme: globalTheme,
     site_footer__accent: siteFooterAccent,
     site_footer__border_thickness: borderThickness,
     site_footer__variation: siteFooterVariation,
   });
 
 FooterExamples.argTypes = {
-  globalTheme: {
-    name: 'Global Theme (lever)',
-    options: siteGlobalThemeOptions,
-    type: 'select',
-  },
   siteFooterAccent: {
     name: 'Footer Accent Color (dial)',
     options: siteFooterAccents,

--- a/components/03-organisms/site-footer/site-footer.stories.js
+++ b/components/03-organisms/site-footer/site-footer.stories.js
@@ -38,7 +38,6 @@ export default {
   args: {
     borderThickness: '8',
     siteFooterAccent: 'one',
-    siteFooterTheme: 'one',
     siteFooterVariation: 'basic',
   },
 };
@@ -60,6 +59,10 @@ export const Footer = ({
     site_footer__content_text:
       'This is <a href="https://example.com">example text</a> for footer content <a href="https://example.com/blah">with a link</a>.',
   });
+
+Footer.args = {
+  siteFooterTheme: 'one',
+};
 
 Footer.argTypes = {
   siteFooterTheme: {

--- a/components/03-organisms/site-footer/site-footer.stories.js
+++ b/components/03-organisms/site-footer/site-footer.stories.js
@@ -5,6 +5,7 @@ import siteFooterTwig from './yds-site-footer.twig';
 import siteFooterExamples from './_site-footer--examples.twig';
 
 import socialLinksData from '../../02-molecules/social-links/social-links.yml';
+import linkGroupData from '../../02-molecules/link-group/link-group.yml';
 
 const siteFooterThemes = { themes: tokens['site-footer-themes'] };
 const siteGlobalThemes = { themes: tokens['global-themes'] };
@@ -54,10 +55,13 @@ export const Footer = ({
   siteFooterTwig({
     ...socialLinksData,
     ...siteFooterAccents,
+    ...linkGroupData,
     site_footer__border_thickness: borderThickness,
     site_footer__theme: siteFooterTheme,
     site_footer__accent: siteFooterAccent,
     site_footer__variation: siteFooterVariation,
+    site_footer__content_text:
+      'This is <a href="https://example.com">example text</a> for footer content with a link.',
   });
 
 Footer.argTypes = {


### PR DESCRIPTION
## [YSP-785: A11y: New Haven Green + ONHA Mega Footer link contrast](https://yaleits.atlassian.net/browse/YSP-785)

### Description of work
- Fixes contrast issues for footer content links in multiple states
- Fixes footer link group contrast issues in multiple themes

### Testing Link(s)
- [ ] Navigate to the [Footer Story](https://deploy-preview-456--dev-component-library-twig.netlify.app/?path=/story/organisms-site-footer--footer&args=siteFooterVariation:mega)
- [ ] Navigate to the [Test Multidev](https://pr-855-yalesites-platform.pantheonsite.io/) to see this on the Drupal end

### Functional Review Steps
- [ ] In `Controls`, change `Footer Variation (dial)` to `mega`
- [ ] Verify the link groups pass contrast for unvisited, visited, hover, and visited hover states
- [ ] Verify the middle content links pass contrast for unvisited, visited, hover, and visited hover states
- [ ] Change `Footer Theme (dial)` from `one` to `two` and `three` and verify the same is true
- [ ] Toward the top of the page, set `Site: Global Theme (lever)` to a new theme and verify it all again
- [ ] Ensure all footer site themes in mega pass contrast in all link states for all global themes (What you hopefully did above)
- [ ] Visit the multidev, log in, and click `Theme settings` to play with the footer settings there
- [ ] Verify that on Drupal, all footer links pass contrast

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
