### PR TITLE
YSP-564: Custom Cards on mobile responsiveness

### DIFF
--- a/components/02-molecules/cards/custom-card/_yds-custom-card.scss
+++ b/components/02-molecules/cards/custom-card/_yds-custom-card.scss
@@ -48,7 +48,7 @@ $global-card-themes: map.deep-get(tokens.$tokens, 'global-themes');
     }
   }
 
-  @media (min-width: tokens.$break-m) {
+  @media (min-width: tokens.$break-m) or (max-width: tokens.$break-s) {
     flex-basis: 100%;
     display: flex;
     flex-direction: column-reverse;
@@ -90,7 +90,7 @@ $global-card-themes: map.deep-get(tokens.$tokens, 'global-themes');
     }
   }
 
-  @media (min-width: tokens.$break-m) {
+  @media (min-width: tokens.$break-m) or (max-width: tokens.$break-s) {
     padding: var(--size-spacing-5) var(--size-spacing-6);
 
     [data-with-image='true'] & {

--- a/components/02-molecules/cards/custom-card/_yds-custom-card.scss
+++ b/components/02-molecules/cards/custom-card/_yds-custom-card.scss
@@ -18,44 +18,16 @@ $global-card-themes: map.deep-get(tokens.$tokens, 'global-themes');
   --color-card-bar-long: var(--color-blue-shale);
   --color-card-bar-short: var(--color-blue-horizon);
 
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  column-gap: var(--size-spacing-6);
-  grid-template-areas: 'image content';
+  flex-basis: 100%;
+  display: flex;
+  flex-direction: column-reverse;
 
   &[data-with-image='false'] {
-    grid-template-areas:
-      'image'
-      'content';
-    grid-template-columns: 1fr;
     border: var(--card-border);
   }
 
   &:hover {
     cursor: pointer;
-  }
-
-  @media (min-width: tokens.$break-s) {
-    &[data-with-image='true'] {
-      [data-collection-featured='true'] & {
-        grid-template-columns: repeat(2, 1fr);
-      }
-
-      [data-collection-featured='false'] & {
-        grid-template-columns: 1fr 2fr;
-        grid-template-areas: 'image content';
-      }
-    }
-  }
-
-  @media (min-width: tokens.$break-m) or (max-width: tokens.$break-s) {
-    flex-basis: 100%;
-    display: flex;
-    flex-direction: column-reverse;
-
-    &:hover {
-      box-shadow: var(--drop-shadow-level-1);
-    }
   }
 
   // Global themes: set color slots for each theme
@@ -90,7 +62,7 @@ $global-card-themes: map.deep-get(tokens.$tokens, 'global-themes');
     }
   }
 
-  @media (min-width: tokens.$break-m) or (max-width: tokens.$break-s) {
+  @media (min-width: tokens.$break-m) {
     padding: var(--size-spacing-5) var(--size-spacing-6);
 
     [data-with-image='true'] & {


### PR DESCRIPTION
## [YSP-564: Custom Cards on mobile responsiveness](https://yaleits.atlassian.net/browse/YSP-564)

### Description of work
- ~~Causes screen sizes smaller than `tokens.$break-s` to mimic full desktop mode to have image over the content instead of beside it.~~
- Make `flex` the default to allow the image to always appear above the content for a custom card.

### Testing Link(s)
- [ ] Navigate to the [Custom Card Story](https://deploy-preview-459--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--custom-card)
- [ ] Navigate to the [Original Custom Card Story](https://yalesites-org.github.io/component-library-twig/?path=/story/molecules-cards--custom-card) to compare against
- [ ] Navigate to the [YaleSites Platform PR](https://github.com/yalesites-org/yalesites-project/pull/856) to see this in action in Drupal

### Functional Review Steps
- [ ] Verify that on screen resize, the image for the custom card does not display next to the content

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
