### PR TITLE
YSP-768: Update category styling on reference cards

### DIFF
--- a/components/01-atoms/lists/_yds-list.scss
+++ b/components/01-atoms/lists/_yds-list.scss
@@ -52,16 +52,13 @@ ol {
 }
 
 .taxonomy-list--categories {
-  @include tokens.h6-mallory-compact-medium;
+  @include tokens.body-s;
 
   color: var(--color-gray-500);
-  line-height: normal;
-  margin-bottom: var(--size-spacing-4);
-  text-transform: uppercase;
-
-  @media (min-width: tokens.$break-mobile) {
-    margin-bottom: var(--size-spacing-5);
-  }
+  font-variant-caps: small-caps;
+  font-variant-numeric: oldstyle-nums;
+  text-transform: lowercase;
+  letter-spacing: 0.5px;
 }
 
 .taxonomy-list--tags {

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -38,12 +38,6 @@ export default {
       name: 'Show Tags',
       type: 'boolean',
     },
-    tags: {
-      name: 'Tags',
-      type: 'array',
-      defaultValue: referenceCardData.reference_card__tags,
-      if: { arg: 'showTags' },
-    },
     withImage: {
       name: 'With Image',
       type: 'boolean',
@@ -66,7 +60,6 @@ export const PostCard = ({
   featured,
   withImage,
   showCategories,
-  tags,
   showTags,
 }) => `
 <div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
@@ -85,7 +78,7 @@ export const PostCard = ({
         reference_card__categories:
           referenceCardData.reference_card__categories,
         show_categories: showCategories,
-        reference_card__tags: tags,
+        reference_card__tags: referenceCardData.reference_card__tags,
         show_tags: showTags,
       })}
     </ul>
@@ -114,7 +107,6 @@ export const EventCard = ({
   multiDayEvent,
   headingPrefix,
   showCategories,
-  tags,
   showTags,
 }) => `
 <div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
@@ -139,7 +131,7 @@ export const EventCard = ({
         reference_card__categories:
           referenceCardData.reference_card__categories,
         show_categories: showCategories,
-        reference_card__tags: tags,
+        reference_card__tags: referenceCardData.reference_card__tags,
         show_tags: showTags,
       })}
     </ul>
@@ -191,7 +183,6 @@ export const ProfileCard = ({
   withImage,
   showCategories,
   showPronouns,
-  tags,
   showTags,
 }) => `
 <div class='card-collection' data-component-width='site' data-collection-source='profile' data-collection-type='${collectionType}' data-collection-featured="${featured}">
@@ -216,7 +207,7 @@ export const ProfileCard = ({
           referenceProfileCardData.reference_card__categories,
         show_categories: showCategories,
         show_pronouns: showPronouns,
-        reference_card__tags: tags,
+        reference_card__tags: referenceProfileCardData.reference_card__tags,
         show_tags: showTags,
       })}
     </ul>

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -35,12 +35,6 @@ export default {
       type: 'boolean',
       defaultValue: false,
     },
-    categories: {
-      name: 'Categories',
-      type: 'array',
-      defaultValue: referenceCardData.reference_card__categories,
-      if: { arg: 'showCategories' },
-    },
     showTags: {
       name: 'Show Tags',
       type: 'boolean',
@@ -78,7 +72,6 @@ export const PostCard = ({
   collectionType,
   featured,
   withImage,
-  categories,
   showCategories,
   tags,
   showTags,
@@ -97,7 +90,8 @@ export const PostCard = ({
         reference_card__featured: featured ? 'true' : 'false',
         reference_card__image: withImage ? 'true' : 'false',
         reference_card__url: referenceCardData.reference_card__url,
-        reference_card__categories: categories,
+        reference_card__categories:
+          referenceCardData.reference_card__categories,
         show_categories: showCategories,
         reference_card__tags: tags,
         show_tags: showTags,
@@ -128,7 +122,6 @@ export const EventCard = ({
   secondaryCTAURL,
   multiDayEvent,
   headingPrefix,
-  categories,
   showCategories,
   tags,
   showTags,
@@ -153,7 +146,8 @@ export const EventCard = ({
         reference_card__cta_secondary__href: secondaryCTAURL,
         reference_card__cta_secondary__content: secondaryCTAContent,
         multi_day_event: multiDayEvent,
-        reference_card__categories: categories,
+        reference_card__categories:
+          referenceCardData.reference_card__categories,
         show_categories: showCategories,
         reference_card__tags: tags,
         show_tags: showTags,
@@ -206,7 +200,6 @@ export const ProfileCard = ({
   collectionType,
   featured,
   withImage,
-  categories,
   showCategories,
   showPronouns,
   tags,
@@ -231,7 +224,8 @@ export const ProfileCard = ({
         reference_card__snippet:
           referenceProfileCardData.reference_card__snippet,
         reference_card__url: referenceProfileCardData.reference_card__url,
-        reference_card__categories: categories,
+        reference_card__categories:
+          referenceProfileCardData.reference_card__categories,
         show_categories: showCategories,
         show_pronouns: showPronouns,
         reference_card__tags: tags,

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -40,11 +40,6 @@ export default {
       type: 'boolean',
       defaultValue: false,
     },
-    showThumbnail: {
-      name: 'Show Thumbnail',
-      type: 'boolean',
-      defaultValue: true,
-    },
     tags: {
       name: 'Tags',
       type: 'array',
@@ -75,7 +70,6 @@ export const PostCard = ({
   showCategories,
   tags,
   showTags,
-  showThumbnail,
 }) => `
 <div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
@@ -95,7 +89,6 @@ export const PostCard = ({
         show_categories: showCategories,
         reference_card__tags: tags,
         show_tags: showTags,
-        show_thumbnail: showThumbnail,
       })}
     </ul>
   </div>
@@ -125,7 +118,6 @@ export const EventCard = ({
   showCategories,
   tags,
   showTags,
-  showThumbnail,
 }) => `
 <div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
@@ -151,7 +143,6 @@ export const EventCard = ({
         show_categories: showCategories,
         reference_card__tags: tags,
         show_tags: showTags,
-        show_thumbnail: showThumbnail,
       })}
     </ul>
   </div>
@@ -204,7 +195,6 @@ export const ProfileCard = ({
   showPronouns,
   tags,
   showTags,
-  showThumbnail,
 }) => `
 <div class='card-collection' data-component-width='site' data-collection-source='profile' data-collection-type='${collectionType}' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
@@ -230,7 +220,6 @@ export const ProfileCard = ({
         show_pronouns: showPronouns,
         reference_card__tags: tags,
         show_tags: showTags,
-        show_thumbnail: showThumbnail,
       })}
     </ul>
   </div>

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -41,11 +41,6 @@ export default {
       defaultValue: referenceCardData.reference_card__categories,
       if: { arg: 'showCategories' },
     },
-    showPronouns: {
-      name: 'Show Pronouns',
-      type: 'boolean',
-      defaultValue: false,
-    },
     showTags: {
       name: 'Show Tags',
       type: 'boolean',
@@ -247,3 +242,11 @@ export const ProfileCard = ({
   </div>
 </div>
 `;
+
+ProfileCard.argTypes = {
+  showPronouns: {
+    name: 'Show Pronouns',
+    type: 'boolean',
+    defaultValue: false,
+  },
+};

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -49,6 +49,9 @@ export default {
     collectionType: 'grid',
     featured: true,
     withImage: true,
+    showCategories: false,
+    showTags: false,
+    date: referenceCardData.reference_card__date,
   },
 };
 

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -33,12 +33,10 @@ export default {
     showCategories: {
       name: 'Show Categories/Affiliations',
       type: 'boolean',
-      defaultValue: false,
     },
     showTags: {
       name: 'Show Tags',
       type: 'boolean',
-      defaultValue: false,
     },
     tags: {
       name: 'Tags',


### PR DESCRIPTION
## [YSP-768: Update category styling on reference cards](https://yaleits.atlassian.net/browse/YSP-768)

### Description of work
- Adds styling for reference card categories to mimic the directory listing overline
- Cleans up Storybook to function a bit better for users

### Testing Link(s)
- [ ] Navigate to the [Post Card Story](https://deploy-preview-460--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--post-card&args=showCategories:!true)

### Functional Review Steps
- [ ] Verify you see a smaller category list than the released version
- [ ] If you do not see any categories, make sure to enable it in the Controls section

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
