### PR TITLE
IYY-327: Support Video Embed on Image Banner

### DIFF
--- a/components/00-tokens/layout/_layout.scss
+++ b/components/00-tokens/layout/_layout.scss
@@ -64,7 +64,12 @@ html {
 $layout-widths: map.deep-get(tokens.$tokens, size, component-layout, width);
 
 [data-component-width] {
-  &:not([data-embedded-components] [data-component-width]) {
+  // if a component has nested components, we don't want to apply the padding to the nested components
+  // we also don't want to apply the padding to components with the data-full-width-component attribute
+  &:not(
+      [data-embedded-components] [data-component-width],
+      [data-full-width-component]
+    ) {
     padding-inline-start: var(--size-spacing-site-gutter);
     padding-inline-end: var(--size-spacing-site-gutter);
   }

--- a/components/02-molecules/banner/banner.stories.js
+++ b/components/02-molecules/banner/banner.stories.js
@@ -3,9 +3,11 @@ import tokens from '@yalesites-org/tokens/build/json/tokens.json';
 import bannerTwig from './action/yds-action-banner.twig';
 import grandHeroTwig from './grand-hero/yds-grand-hero.twig';
 import imageBannerTwig from './image/yds-image-banner.twig';
+import videoBannerTwig from './video/yds-video-banner.twig';
 
 import bannerData from './banner.yml';
 import grandHeroData from './grand-hero.yml';
+import videoBannerData from '../../01-atoms/videos/video-embed/video-embed.yml';
 
 import imageData from '../../01-atoms/images/image/image.yml';
 
@@ -138,6 +140,7 @@ GrandHeroBanner.argTypes = {
     defaultValue: false,
   },
 };
+
 export const ImageBanner = ({ bgColor, size, withVideo }) =>
   imageBannerTwig({
     ...imageData.responsive_images['16x9'],
@@ -158,4 +161,20 @@ ImageBanner.argTypes = {
     type: 'boolean',
     defaultValue: false,
   },
+};
+
+export const VideoBanner = ({ width }) =>
+  videoBannerTwig({
+    video_banner__content: videoBannerData.video_embed__content,
+    video_banner__width: width,
+  });
+VideoBanner.argTypes = {
+  width: {
+    name: 'Video Width',
+    type: 'select',
+    options: ['max', 'full'],
+  },
+};
+VideoBanner.args = {
+  width: 'max',
 };

--- a/components/02-molecules/banner/video/yds-video-banner.scss
+++ b/components/02-molecules/banner/video/yds-video-banner.scss
@@ -1,0 +1,17 @@
+@use '../../../00-tokens/tokens';
+@use '../../../01-atoms/atoms';
+@use '../../../00-tokens/functions/map';
+
+$break-video-banner: tokens.$break-m;
+
+.video-banner {
+  @include tokens.spacing-page-section(
+    $flush-top: true,
+    $flush-bottom: true,
+    $banner-spacing: true
+  );
+
+  &[data-component-width='max'] {
+    --component-width: var(--size-component-layout-width-max);
+  }
+}

--- a/components/02-molecules/banner/video/yds-video-banner.twig
+++ b/components/02-molecules/banner/video/yds-video-banner.twig
@@ -13,7 +13,7 @@
   class: bem(video_banner__base_class),
 } %}
 
-<div {{ add_attributes(video_banner__attributes) }} data-embedded-components>
+<div {{ add_attributes(video_banner__attributes) }} data-full-width-component>
   {% block prefix_suffix %}
   {% endblock %}
   <div {{ bem('inner', [], video_banner__base_class) }}>

--- a/components/02-molecules/banner/video/yds-video-banner.twig
+++ b/components/02-molecules/banner/video/yds-video-banner.twig
@@ -1,0 +1,26 @@
+{#
+ # Available Props:
+ # - video_banner__width
+ #
+ # Available Blocks:
+ # - video_banner__video
+ #}
+
+{% set video_banner__base_class = 'video-banner' %}
+
+{% set video_banner__attributes = {
+  'data-component-width' : video_banner__width|default('max'),
+  class: bem(video_banner__base_class),
+} %}
+
+<div {{ add_attributes(video_banner__attributes) }} data-embedded-components>
+  {% block prefix_suffix %}
+  {% endblock %}
+  <div {{ bem('inner', [], video_banner__base_class) }}>
+    {% block video_banner__video %}
+      {% include "@atoms/videos/video-embed/yds-video-embed.twig" with {
+        video_embed__content: video_banner__content,
+      } %}
+    {% endblock %}
+  </div>
+</div>

--- a/components/02-molecules/molecules.scss
+++ b/components/02-molecules/molecules.scss
@@ -35,3 +35,4 @@
 @forward './inline-message/yds-inline-message';
 @forward './banner/image/yds-image-banner';
 @forward './wrapped-callout/yds-wrapped-callout';
+@forward './banner/video/yds-video-banner';


### PR DESCRIPTION
## [IYY-327: Support Video Embed on Image Banner](https://fourkitchens.clickup.com/t/36718269/IYY-327)

### Description of work
- Adds new Video Banner component
- Allows for changing the width in a dial

### Testing Link(s)
- [ ] Navigate to the [Video Banner Component Story](https://deploy-preview-466--dev-component-library-twig.netlify.app/?path=/story/molecules-banners--video-banner)

### Functional Review Steps
- [ ] Navigate to https://deploy-preview-466--dev-component-library-twig.netlify.app/?path=/story/molecules-banners--video-banner
- [ ] Verify the default width for the video is set to `max`

https://github.com/user-attachments/assets/6a1e249b-6a61-4b56-aeb7-a67ddae1c46d

- [ ] Verify if you change to `full` the video becomes full-width

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
