### PR TITLE
YSP-765 Taxonomy display block (Frontend)

### DIFF
--- a/components/02-molecules/molecules.scss
+++ b/components/02-molecules/molecules.scss
@@ -24,6 +24,7 @@
 @forward './search-result/yds-search-result';
 @forward './social-links/yds-social-links';
 @forward './tabs/yds-tabs';
+@forward './taxonomy-display/yds-taxonomy-display';
 @forward './text/yds-text-field';
 @forward './text-with-image/yds-text-with-image';
 @forward './video/yds-video';

--- a/components/02-molecules/taxonomy-display/_yds-taxonomy-display--links.twig
+++ b/components/02-molecules/taxonomy-display/_yds-taxonomy-display--links.twig
@@ -1,0 +1,35 @@
+{% set taxonomy_display__base_class = 'taxonomy-display' %}
+{% set taxonomy_display__modifiers = taxonomy_display__modifiers|default([]) %}
+{% set taxonomy_display__item__terms = taxonomy_display__item__terms|default(terms) %}
+{% set taxonomy_display__item__label = taxonomy_display__item__label|default(label) %}
+
+{% set taxonomy_terms__list %}
+  {% embed "@atoms/lists/yds-list.twig" with {
+    list__modifiers: taxonomy_display__modifiers,
+    list__blockname: taxonomy_display__base_class,
+    list__base_class: 'item__list'
+  } %}
+    {% block list__content %}
+      {% for item in taxonomy_display__item__terms %}
+        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+          link__blockname: taxonomy_display__base_class,
+          link__content: item.taxonomy_display__link__content|default(item['#title']),
+          link__url: item.taxonomy_display__link__url|default(item['#url'].toString()),
+        } %}
+      {% endfor %}
+    {% endblock %}
+  {% endembed %}
+{% endset %}
+
+{% embed "@atoms/lists/_yds-list-item.twig" with {
+  list__item__blockname: taxonomy_display__base_class,
+} %}
+  {% block list__item__content %}
+    {% include "@atoms/typography/text/yds-text.twig" with {
+      text__blockname: taxonomy_display__base_class,
+      text__content: taxonomy_display__item__label,
+      text__base_class: 'item__label',
+    } %}
+    {{ taxonomy_terms__list }}
+  {% endblock %}
+{% endembed %}

--- a/components/02-molecules/taxonomy-display/_yds-taxonomy-display.scss
+++ b/components/02-molecules/taxonomy-display/_yds-taxonomy-display.scss
@@ -1,0 +1,212 @@
+@use '../../00-tokens/tokens';
+@use '../../01-atoms/atoms';
+@use '../../00-tokens/functions/map';
+
+// get global themes
+$global-taxonomy-display-port-themes: map.deep-get(
+  tokens.$tokens,
+  'global-themes'
+);
+$component-taxonomy-display-port-themes: map.deep-get(
+  tokens.$tokens,
+  'component-themes'
+);
+
+// Taxonomy Display
+.taxonomy-display {
+  // used by a element for animated hover underline
+  --color-text-shadow: var(--color-basic-white);
+
+  // if we're not using a component theme, add top and bottom margin
+  // Or if the spotlight is the only spotlight on the page
+  &[data-component-theme='default'] {
+    padding-block: var(--size-spacing-6);
+    background-color: var(--color-gray-100);
+  }
+
+  // If we're using a component theme, add padding and set background-color and color;
+  &:not([data-component-theme='default']) {
+    padding-block: var(--size-spacing-6);
+    background-color: var(--color-background);
+    color: var(--color-text);
+  }
+
+  // Component themes defaults: iterate over each component theme to establish
+  // default variables.
+  @each $theme, $value in $component-taxonomy-display-port-themes {
+    &[data-component-theme='#{$theme}'] {
+      --color-slot-one: var(--component-themes-#{$theme}-slot-one);
+      --color-slot-two: var(--component-themes-#{$theme}-slot-two);
+      --color-slot-three: var(--component-themes-#{$theme}-slot-three);
+      --color-slot-four: var(--component-themes-#{$theme}-slot-four);
+      --color-slot-five: var(--component-themes-#{$theme}-slot-five);
+      --color-slot-six: var(--component-themes-#{$theme}-slot-six);
+      --color-slot-seven: var(--component-themes-#{$theme}-slot-seven);
+      --color-slot-eight: var(--component-themes-#{$theme}-slot-eight);
+      --color-spotlight-text-shadow: var(--color-background);
+
+      // override text-shadow color for links in component themes
+      .taxonomy-display__link {
+        --color-text-shadow: var(--color-spotlight-text-shadow);
+        --color-link-hover: var(--color-link-hover);
+      }
+    }
+  }
+
+  // Global themes: set color slots for each theme
+  // This establishes `--color-slot-` variables name-spaced to the selector
+  // in which it is used. We can map component-level variables to global-level
+  // `--color-slot-` variables.
+  @each $globalTheme, $value in $global-taxonomy-display-port-themes {
+    [data-global-theme='#{$globalTheme}'] & {
+      --color-slot-one: var(--global-themes-#{$globalTheme}-colors-slot-one);
+      --color-slot-two: var(--global-themes-#{$globalTheme}-colors-slot-two);
+      --color-slot-three: var(
+        --global-themes-#{$globalTheme}-colors-slot-three
+      );
+      --color-slot-four: var(--global-themes-#{$globalTheme}-colors-slot-four);
+      --color-slot-five: var(--global-themes-#{$globalTheme}-colors-slot-five);
+      --color-slot-six: var(--global-themes-#{$globalTheme}-colors-slot-six);
+      --color-slot-seven: var(
+        --global-themes-#{$globalTheme}-colors-slot-seven
+      );
+      --color-slot-eight: var(
+        --global-themes-#{$globalTheme}-colors-slot-eight
+      );
+
+      @if $globalTheme == 'four' {
+        // Switch colors slot in order to have the selected background colors per component theme.
+        --color-slot-two: var(--global-themes-four-colors-slot-five);
+        --color-slot-five: var(--global-themes-four-colors-slot-two);
+
+        // Set color slot for the text on light background.
+        --color-slot-seven: var(--global-themes-four-colors-slot-six);
+      }
+    }
+  }
+
+  // Component theme overrides: set specific component themes overrides
+  /// define component name spaced variables and map them to global theme slots.
+  &[data-component-theme='one'] {
+    --color-background: var(--color-slot-one);
+    --color-text: var(--color-slot-eight);
+    --color-link-base: var(--color-slot-eight);
+    --color-link-hover: var(--color-slot-eight);
+    --color-link-visited-base: var(--color-link-visited-light);
+    --color-link-visited-hover: var(--color-link-visited-light-hover);
+  }
+
+  &[data-component-theme='two'] {
+    --color-background: var(--color-slot-four);
+    --color-text: var(--color-slot-seven);
+    --color-link-base: var(--color-slot-seven);
+    --color-link-hover: var(--color-slot-seven);
+  }
+
+  &[data-component-theme='three'] {
+    --color-background: var(--color-slot-five);
+    --color-text: var(--color-slot-eight);
+    --color-link-base: var(--color-slot-eight);
+    --color-link-hover: var(--color-slot-eight);
+    --color-link-visited-base: var(--color-link-visited-light);
+    --color-link-visited-hover: var(--color-link-visited-light-hover);
+
+    // For accessibility reason set lighter visited links color.
+    [data-global-theme='four'] & {
+      --color-link-visited-base: var(--color-gray-100);
+      --color-link-visited-hover: var(--color-slot-eight);
+    }
+  }
+
+  &[data-component-theme='four'] {
+    --color-background: var(--color-slot-three);
+    --color-text: var(--color-slot-seven);
+    --color-link-base: var(--color-slot-seven);
+    --color-link-hover: var(--color-slot-seven);
+  }
+
+  &[data-component-theme='five'] {
+    --color-background: var(--color-slot-two);
+    --color-text: var(--color-slot-eight);
+    --color-link-base: var(--color-slot-eight);
+    --color-link-hover: var(--color-slot-eight);
+    --color-link-visited-base: var(--color-link-visited-light);
+    --color-link-visited-hover: var(--color-link-visited-light-hover);
+
+    [data-global-theme='four'] & {
+      --color-background: var(--component-themes-five-background);
+      --color-text: var(--component-themes-five-text);
+      --color-link-base: var(--color-slot-one);
+      --color-link-hover: var(--color-slot-one);
+      --color-link-visited-base: var(--color-purple-visited);
+      --color-link-visited-hover: var(--color-purple-visited-hover);
+    }
+  }
+}
+
+.taxonomy-display__inner {
+  display: flex;
+  flex-flow: column nowrap;
+}
+
+.taxonomy-display__content {
+  @media (max-width: tokens.$break-mobile-max) {
+    order: 1;
+  }
+
+  @media (min-width: tokens.$break-mobile) {
+    width: 100%;
+    max-width: 80%;
+  }
+
+  > *:not(:last-child) {
+    margin-bottom: var(--size-spacing-5);
+  }
+}
+
+.taxonomy-display__list {
+  @include atoms.list-reset;
+
+  display: inline-flex;
+  flex-wrap: wrap;
+  column-gap: var(--size-spacing-8);
+  row-gap: var(--size-spacing-6);
+
+  @media (max-width: tokens.$break-mobile) {
+    column-gap: var(--size-spacing-6);
+  }
+}
+
+.taxonomy-display__item {
+  display: inline-flex;
+  gap: var(--size-spacing-5);
+  align-items: center;
+}
+
+.taxonomy-display__item__label {
+  text-transform: uppercase;
+  font-weight: var(--font-weights-yalenew-bold);
+  font-family: var(--font-families-mallory);
+  font-size: var(--font-size-14);
+}
+
+.taxonomy-display__item__list {
+  padding: 0;
+  margin: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--size-spacing-3);
+  align-items: center;
+}
+
+.taxonomy-display__link {
+  @include atoms.link;
+
+  font-size: var(--font-size-15);
+  font-weight: var(--font-weights-mallory-book);
+  color: var(--color-link-base);
+
+  &:not(:last-child)::after {
+    content: ',';
+  }
+}

--- a/components/02-molecules/taxonomy-display/taxonomy-display.stories.js
+++ b/components/02-molecules/taxonomy-display/taxonomy-display.stories.js
@@ -1,0 +1,35 @@
+import tokens from '@yalesites-org/tokens/build/json/tokens.json';
+
+// Twig templates
+import taxonomyDisplayTwig from './yds-taxonomy-display.twig';
+
+// Data files
+import taxonomyDisplayData from './taxonomy-display.yml';
+
+const colorPairingsData = Object.keys(tokens['component-themes']);
+
+/**
+ * Storybook Definition.
+ */
+export default {
+  title: 'Molecules/Taxonomy Display',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    componentTheme: {
+      name: 'Component Theme (dial)',
+      type: 'select',
+      options: colorPairingsData,
+    },
+  },
+  args: {
+    componentTheme: 'default',
+  },
+};
+
+export const TaxonomyDisplay = ({ componentTheme }) =>
+  taxonomyDisplayTwig({
+    taxonomy_display__theme: componentTheme,
+    taxonomy_display__items: taxonomyDisplayData.taxonomy_display__items,
+  });

--- a/components/02-molecules/taxonomy-display/taxonomy-display.yml
+++ b/components/02-molecules/taxonomy-display/taxonomy-display.yml
@@ -1,0 +1,15 @@
+taxonomy_display__items:
+  - taxonomy_display__item__label: 'Audience'
+    taxonomy_display__item__terms:
+      - taxonomy_display__link__content: 'Undergraduates'
+        taxonomy_display__link__url: '#'
+      - taxonomy_display__link__content: 'Graduates'
+        taxonomy_display__link__url: '#'
+  - taxonomy_display__item__label: 'Type'
+    taxonomy_display__item__terms:
+      - taxonomy_display__link__content: 'How To'
+        taxonomy_display__link__url: '#'
+  - taxonomy_display__item__label: 'Category'
+    taxonomy_display__item__terms:
+      - taxonomy_display__link__content: 'Learning'
+        taxonomy_display__link__url: '#'

--- a/components/02-molecules/taxonomy-display/yds-taxonomy-display.twig
+++ b/components/02-molecules/taxonomy-display/yds-taxonomy-display.twig
@@ -1,0 +1,46 @@
+{#
+ # Available Props:
+ # - taxonomy_display__width: feature (default) or highlight
+ # - taxonomy_display__theme: default (no theme), one, two, three
+ #
+ # Available variables:
+ # - taxonomy_display__items: array
+ #   - taxonomy_display__item__label: string
+ #   - taxonomy_display__item__terms: (array)
+ #     - title: Link title
+ #     - url: Link url
+ #}
+
+{% set taxonomy_display__base_class = 'taxonomy-display' %}
+
+{% set taxonomy_display__attributes = {
+  'data-component-width': taxonomy_display__width|default('site'),
+  'data-component-theme': taxonomy_display__theme|default('default'),
+  class: bem(taxonomy_display__base_class)
+} %}
+
+{% set taxonomy_display %}
+  {% block taxonomy_display__items %}
+    {% embed "@atoms/lists/yds-list.twig" with {
+      list__modifiers: taxonomy_display__modifiers,
+      list__blockname: taxonomy_display__base_class,
+    } %}
+      {% block list__content %}
+        {% for item in taxonomy_display__items %}
+          {% include "@molecules/taxonomy-display/_yds-taxonomy-display--links.twig" with item %}
+        {% endfor %}
+      {% endblock %}
+    {% endembed %}
+  {% endblock %}
+{% endset %}
+
+{# Only show if there is more than 1 item. #}
+{% if taxonomy_display__items|length %}
+  <div {{ add_attributes(taxonomy_display__attributes) }}>
+    <div {{ bem('inner', [], taxonomy_display__base_class) }}>
+      <div {{ bem('content', [], taxonomy_display__base_class) }}>
+        {{ taxonomy_display }}
+      </div>
+    </div>
+  </div>
+{% endif %}


### PR DESCRIPTION
## [YALB-765: New Block: Taxonomy display](https://yaleits.atlassian.net/browse/YALB-765)

### Description of work
- Adds new taxonomy display component

### Functional Review Steps
- [ ] Navigate to: https://deploy-preview-446--dev-component-library-twig.netlify.app/?path=/story/molecules-taxonomy-display--taxonomy-display
- [ ] Verify the themes apply as they should.
- [ ] Verify that the component matches the screenshot below.

![Screenshot 2024-12-12 at 3 49 12 PM](https://github.com/user-attachments/assets/2099567a-4168-48d0-9a0b-d63a47b23e8d)