### PR TITLE
Feedback v1.13.0-1: Add empty state and style updates to taxonomy display

### DIFF
--- a/components/02-molecules/taxonomy-display/_yds-taxonomy-display--links.twig
+++ b/components/02-molecules/taxonomy-display/_yds-taxonomy-display--links.twig
@@ -10,19 +10,27 @@
     list__base_class: 'item__list'
   } %}
     {% block list__content %}
-      {% for item in taxonomy_display__item__terms %}
-        {% embed "@atoms/lists/_yds-list-item.twig" with {
-          list__item__blockname: taxonomy_display__base_class,
+      {% if taxonomy_display__item__terms|length > 0 %}
+        {% for item in taxonomy_display__item__terms %}
+          {% embed "@atoms/lists/_yds-list-item.twig" with {
+            list__item__blockname: taxonomy_display__base_class,
+          } %}
+            {% block list__item__content %}
+              {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+                link__blockname: taxonomy_display__base_class,
+                link__content: item.taxonomy_display__link__content ?? item['#title'],
+                link__url: item.taxonomy_display__link__url ?? item['#url'].toString(),
+              } %}
+            {% endblock %}
+          {% endembed %}
+        {% endfor %}
+      {% else %}
+        {% include "@atoms/typography/text/yds-text.twig" with {
+          text__blockname: taxonomy_display__base_class,
+          text__content: 'None',
+          text__base_class: 'item__label',
         } %}
-          {% block list__item__content %}
-            {% include "@atoms/controls/text-link/yds-text-link.twig" with {
-              link__blockname: taxonomy_display__base_class,
-              link__content: item.taxonomy_display__link__content ?? item['#title'],
-              link__url: item.taxonomy_display__link__url ?? item['#url'].toString(),
-            } %}
-          {% endblock %}
-        {% endembed %}
-      {% endfor %}
+      {% endif %}
     {% endblock %}
   {% endembed %}
 {% endset %}

--- a/components/02-molecules/taxonomy-display/_yds-taxonomy-display.scss
+++ b/components/02-molecules/taxonomy-display/_yds-taxonomy-display.scss
@@ -197,6 +197,10 @@ $component-taxonomy-display-port-themes: map.deep-get(
   font-weight: var(--font-weights-yalenew-bold);
   font-family: var(--font-families-mallory);
   font-size: var(--font-size-14);
+
+  &::after {
+    content: ':';
+  }
 }
 
 .taxonomy-display__item__list {
@@ -209,6 +213,16 @@ $component-taxonomy-display-port-themes: map.deep-get(
   flex-wrap: wrap;
   gap: var(--size-spacing-3);
   padding-bottom: var(--size-spacing-3);
+
+  &:has(.taxonomy-display__item__label) {
+    padding-bottom: 0;
+  }
+
+  & .taxonomy-display__item__label {
+    &::after {
+      content: '';
+    }
+  }
 }
 
 .taxonomy-display__link {

--- a/components/02-molecules/taxonomy-display/_yds-taxonomy-display.scss
+++ b/components/02-molecules/taxonomy-display/_yds-taxonomy-display.scss
@@ -219,6 +219,8 @@ $component-taxonomy-display-port-themes: map.deep-get(
   }
 
   & .taxonomy-display__item__label {
+    font-weight: inherit;
+
     &::after {
       content: '';
     }

--- a/components/02-molecules/taxonomy-display/taxonomy-display.stories.js
+++ b/components/02-molecules/taxonomy-display/taxonomy-display.stories.js
@@ -22,14 +22,21 @@ export default {
       type: 'select',
       options: colorPairingsData,
     },
+    showTaxonomy: {
+      name: 'Show Taxonomy',
+      type: 'boolean',
+    },
   },
   args: {
     componentTheme: 'default',
+    showTaxonomy: true,
   },
 };
 
-export const TaxonomyDisplay = ({ componentTheme }) =>
+export const TaxonomyDisplay = ({ componentTheme, showTaxonomy }) =>
   taxonomyDisplayTwig({
     taxonomy_display__theme: componentTheme,
-    taxonomy_display__items: taxonomyDisplayData.taxonomy_display__items,
+    taxonomy_display__items: showTaxonomy
+      ? taxonomyDisplayData.taxonomy_display__items
+      : taxonomyDisplayData.taxonomy_display__empty_items,
   });

--- a/components/02-molecules/taxonomy-display/taxonomy-display.yml
+++ b/components/02-molecules/taxonomy-display/taxonomy-display.yml
@@ -13,3 +13,10 @@ taxonomy_display__items:
     taxonomy_display__item__terms:
       - taxonomy_display__link__content: 'Learning'
         taxonomy_display__link__url: '#'
+taxonomy_display__empty_items:
+  - taxonomy_display__item__label: 'Audience'
+    taxonomy_display__item__terms:
+  - taxonomy_display__item__label: 'Type'
+    taxonomy_display__item__terms:
+  - taxonomy_display__item__label: 'Category'
+    taxonomy_display__item__terms:

--- a/components/02-molecules/taxonomy-display/yds-taxonomy-display.twig
+++ b/components/02-molecules/taxonomy-display/yds-taxonomy-display.twig
@@ -34,13 +34,10 @@
   {% endblock %}
 {% endset %}
 
-{# Only show if there is more than 1 item. #}
-{% if taxonomy_display__items|length %}
-  <div {{ add_attributes(taxonomy_display__attributes) }}>
-    <div {{ bem('inner', [], taxonomy_display__base_class) }}>
-      <div {{ bem('content', [], taxonomy_display__base_class) }}>
-        {{ taxonomy_display }}
-      </div>
+<div {{ add_attributes(taxonomy_display__attributes) }}>
+  <div {{ bem('inner', [], taxonomy_display__base_class) }}>
+    <div {{ bem('content', [], taxonomy_display__base_class) }}>
+      {{ taxonomy_display }}
     </div>
   </div>
-{% endif %}
+</div>


### PR DESCRIPTION
## Feedback v1.13.0 1

### Description of work
- Added condition to check if taxonomy_display__item__terms is empty and display 'None' text if true.
- Updated SCSS to add styles for empty state and adjust padding.
- Removed redundant condition in yds-taxonomy-display.twig to always show the taxonomy display container.

### Testing Link(s)
- [ ] Navigate to the [Taxonomy Display Story](https://deploy-preview-474--dev-component-library-twig.netlify.app/?path=/story/molecules-taxonomy-display--taxonomy-display)

### Functional Review Steps
- [ ] Verify the look both with and without taxonomies (a toggle in controls)

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
