### PR TITLE
v1.13.0 Hotfix: Reference card heading warning

### DIFF
--- a/components/02-molecules/cards/reference-card/yds-reference-card.twig
+++ b/components/02-molecules/cards/reference-card/yds-reference-card.twig
@@ -17,7 +17,6 @@
 {% set reference_card__base_class = 'reference-card' %}
 {% set reference_card__image = reference_card__image|default('true') %}
 {% set reference_card__image_aria = reference_card__image_aria|default(reference_card__heading) %}
-{% set reference_card__heading = reference_card__heading.0['#context']['value']|default(reference_card__heading|default('')) %}
 
 {# If stats__item__attributes is not defined, set it to an empty object by default #}
 {% set reference_card__attributes = {
@@ -38,7 +37,7 @@
     {% if reference_card__overlay %}
       {% set heading__attributes = {
         'class': bem('heading', [], reference_card__base_class),
-        'aria-label': reference_card__overlay ~ ': ' ~ reference_card__heading,
+        'aria-label': reference_card__overlay ~ ': ' ~ reference_card__heading.0['#context']['value']|default(reference_card__heading|default('')),
       } %}
     {% endif %}
     {% include "@atoms/typography/headings/yds-heading.twig" with {

--- a/components/02-molecules/cards/reference-card/yds-reference-card.twig
+++ b/components/02-molecules/cards/reference-card/yds-reference-card.twig
@@ -17,6 +17,7 @@
 {% set reference_card__base_class = 'reference-card' %}
 {% set reference_card__image = reference_card__image|default('true') %}
 {% set reference_card__image_aria = reference_card__image_aria|default(reference_card__heading) %}
+{% set reference_card__heading = reference_card__heading.0['#context']['value']|default(reference_card__heading|default('')) %}
 
 {# If stats__item__attributes is not defined, set it to an empty object by default #}
 {% set reference_card__attributes = {


### PR DESCRIPTION
## v1.13.0 Hotfix: Reference card heading warning

### Description of work
- Fixes Array to string warning for heading when pinned is active for `aria-label`, causing `<pinned label>: Array` text
- Did this directly vs changing `reference_card__heading` since we use it elsewhere

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
