### PR TITLE
Hotfix: v1.13.0: Add conditional calendar button

### DIFF
--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -29,6 +29,7 @@
 
 {# Set secondary CTA content #}
 {% set event_meta__cta_secondary__content = 'Add to Calendar' %}
+{% set event_meta__with_calendar = event_meta__with_calendar ?? TRUE %}
 
 {# Check if event has passed - if passed in localist, the event_dates array will be empty #}
 {% set event_has_passed = event_dates is empty %}
@@ -209,7 +210,7 @@
               } %}
             {% endif %}
             {# Add to calendar #}
-            {% if event_meta__cta_secondary__content and not event_has_passed %}
+            {% if event_meta__with_calendar and event_meta__cta_secondary__content and not event_has_passed %}
               {% include "@atoms/controls/cta/yds-cta.twig" with {
                 cta__content: event_meta__cta_secondary__content,
                 cta__href: ics_url ? ics_url : event_meta__cta_secondary__href,

--- a/components/02-molecules/meta/meta.stories.js
+++ b/components/02-molecules/meta/meta.stories.js
@@ -88,6 +88,7 @@ export const EventLocalist = ({
   ctaText,
   allDay,
   withImage,
+  withCalendar,
 }) =>
   eventLocalistMetaTwig({
     ...imageData.responsive_images['3x2'],
@@ -102,11 +103,17 @@ export const EventLocalist = ({
     cost_button_text: ctaText,
     event_meta__cta_secondary__content: 'Add to calendar',
     event_meta__cta_secondary__href: '#',
+    event_meta__with_calendar: !!withCalendar,
     event_meta__image: withImage ? 'true' : 'false',
     event_meta__all_day: allDay,
     ...eventLocalistData,
   });
 EventLocalist.argTypes = {
+  withCalendar: {
+    name: 'With Add to Calendar button',
+    type: 'boolean',
+    defaultValue: true,
+  },
   ...eventLocalistArgTypes,
 };
 

--- a/components/02-molecules/meta/meta.stories.js
+++ b/components/02-molecules/meta/meta.stories.js
@@ -103,7 +103,7 @@ export const EventLocalist = ({
     cost_button_text: ctaText,
     event_meta__cta_secondary__content: 'Add to calendar',
     event_meta__cta_secondary__href: '#',
-    event_meta__with_calendar: !!withCalendar,
+    event_meta__with_calendar: withCalendar == null ? true : !!withCalendar,
     event_meta__image: withImage ? 'true' : 'false',
     event_meta__all_day: allDay,
     ...eventLocalistData,

--- a/components/04-page-layouts/cl-page-args.js
+++ b/components/04-page-layouts/cl-page-args.js
@@ -99,6 +99,11 @@ export const eventLocalistArgTypes = {
     type: 'string',
     defaultValue: 'Davis Team Project Wins Award for Research',
   },
+  withCalendar: {
+    name: 'With Add to Calendar button',
+    type: 'boolean',
+    defaultValue: true,
+  },
 };
 
 export default argTypes;


### PR DESCRIPTION
## Hotfix: v1.13.0: Add conditional calendar button

Work also completed in [Yalesites Project](https://github.com/yalesites-org/yalesites-project/pull/901)

### Description of work
- Introduced `event_meta__with_calendar` to conditionally display the "Add to Calendar" button.
- Updated `meta.stories.js` to include `withCalendar` argument and default value.

### Testing Link(s)
- [ ] Navigate to the [Event Localist Story](https://deploy-preview-481--dev-component-library-twig.netlify.app/?path=/story/molecules-meta--event-localist)

### Functional Review Steps
- [ ] Verify that the `With Add to Calendar button` correctly displays or hides the add to calendar button
- [ ] Verify when first visiting the page that it's on by default

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
