### PR TITLE
YSP-844: Event Meta Block Date Visibility Improvements

### DIFF
--- a/components/02-molecules/cards/reference-card/yds-reference-card.twig
+++ b/components/02-molecules/cards/reference-card/yds-reference-card.twig
@@ -18,6 +18,8 @@
 {% set reference_card__image = reference_card__image|default('true') %}
 {% set reference_card__image_aria = reference_card__image_aria|default(reference_card__heading) %}
 
+{% set reference_card__aria = reference_card__heading.0.context.value|default(refernce_card__heading) %}
+
 {# If stats__item__attributes is not defined, set it to an empty object by default #}
 {% set reference_card__attributes = {
   'data-component-has-image': reference_card__image,
@@ -44,7 +46,7 @@
     {% if reference_card__overlay %}
       {% set heading__attributes = {
         'class': bem('heading', [], reference_card__base_class),
-        'aria-label': reference_card__overlay ~ ': ' ~ reference_card__heading,
+        'aria-label': reference_card__overlay ~ ': ' ~ reference_card__aria,
       } %}
     {% endif %}
     {% include "@atoms/typography/headings/yds-heading.twig" with {

--- a/components/02-molecules/cards/reference-card/yds-reference-card.twig
+++ b/components/02-molecules/cards/reference-card/yds-reference-card.twig
@@ -18,7 +18,7 @@
 {% set reference_card__image = reference_card__image|default('true') %}
 {% set reference_card__image_aria = reference_card__image_aria|default(reference_card__heading) %}
 
-{% set reference_card__aria = reference_card__heading.0.context.value|default(refernce_card__heading) %}
+{% set reference_card__aria = reference_card__heading[0]['#context'].value|default(reference_card__heading) %}
 
 {# If stats__item__attributes is not defined, set it to an empty object by default #}
 {% set reference_card__attributes = {

--- a/components/02-molecules/meta/event-meta/event-localist.yml
+++ b/components/02-molecules/meta/event-meta/event-localist.yml
@@ -5,18 +5,21 @@ event_dates:
     formatted_end_time: 9:30 am EDT
     original_start: 1714739400
     original_end: 1714743000
+    is_passed_event: true
   - formatted_start_date: Saturday, May 4th, 2024
     formatted_end_date: Saturday, May 4th, 2024
     formatted_start_time: 8:30 am EDT
     formatted_end_time: 9:30 am EDT
     original_start: 1714825800
     original_end: 1714829400
+    is_passed_event: true
   - formatted_start_date: Sunday, May 5th, 2024
     formatted_end_date: Sunday, May 5th, 2024
     formatted_start_time: 8:30 am EDT
     formatted_end_time: 9:30 am EDT
     original_start: 1714912200
     original_end: 1714915800
+    is_passed_event: true
 ticket_cost: $40 pre registration, $60 at the door
 ticket_url: https://www.yale.edu
 event_meta__cta_primary__content: Event Name Website
@@ -42,3 +45,11 @@ event_topics:
 description: '<p>Vel quasi dicta ut fugit molestiae ea sint voluptatem soluta repellendus quod qui fugit dolores illo. Tempora exercitationem laboriosam rerum dolores quisquam. Quasi vero error atque quisquam sed consectetur qui blanditiis aliquam.</p><p>Ipsam eligendi nam nisi facilis et sit fugiat sint eius ut dolorem sunt. Ut ut aliquid est dolorem nihil sunt debitis ad saepe. Asperiores voluptatem inventore sint doloremque nam.</p>'
 stream_url: https://www.example.com
 stream_embed_code: Watch the event
+event_featured_date:
+  formatted_start_date: Sunday, May 5th, 2024
+  formatted_end_date: Sunday, May 5th, 2024
+  formatted_start_time: 8:30 am EDT
+  formatted_end_time: 9:30 am EDT
+  original_start: 1714912200
+  original_end: 1714915800
+  is_passed_event: true

--- a/components/02-molecules/meta/event-meta/event-localist.yml
+++ b/components/02-molecules/meta/event-meta/event-localist.yml
@@ -5,21 +5,21 @@ event_dates:
     formatted_end_time: 9:30 am EDT
     original_start: 1714739400
     original_end: 1714743000
-    is_passed_event: true
+    is_past_event: true
   - formatted_start_date: Saturday, May 4th, 2024
     formatted_end_date: Saturday, May 4th, 2024
     formatted_start_time: 8:30 am EDT
     formatted_end_time: 9:30 am EDT
     original_start: 1714825800
     original_end: 1714829400
-    is_passed_event: true
+    is_past_event: true
   - formatted_start_date: Sunday, May 5th, 2024
     formatted_end_date: Sunday, May 5th, 2024
     formatted_start_time: 8:30 am EDT
     formatted_end_time: 9:30 am EDT
     original_start: 1714912200
     original_end: 1714915800
-    is_passed_event: true
+    is_past_event: true
 ticket_cost: $40 pre registration, $60 at the door
 ticket_url: https://www.yale.edu
 event_meta__cta_primary__content: Event Name Website
@@ -52,4 +52,4 @@ event_featured_date:
   formatted_end_time: 9:30 am EDT
   original_start: 1714912200
   original_end: 1714915800
-  is_passed_event: true
+  is_past_event: true

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -33,7 +33,7 @@
 
 {# Check if event has passed - if passed in localist, the event_dates array will be empty #}
 {# But in the event the featured date has already passed, we should already know about it as well #}
-{% set event_has_passed = event_dates is empty or (event_featured_date and event_featured_date.is_passed_event) %}
+{% set event_has_passed = event_dates is empty or (event_featured_date and event_featured_date.is_past_event) %}
 
 {# Set the event status based on event_has_passed variable #}
 {% set event_status = event_has_passed ? 'passed' : 'current' %}
@@ -185,7 +185,7 @@
             <ul {{ bem('multiple-dates', [], event_meta__base_class) }} aria-expanded="false">
               {% for event_date in event_dates %}
                 <li {{ bem('multiple-dates__date', [], event_meta__base_class) }}>
-                  {% if event_date.is_passed_event %}
+                  {% if event_date.is_past_event %}
                     Past Event: 
                   {% endif %}
                   {% if event_date.formatted_start_date == event_date.formatted_end_date %}

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -54,7 +54,7 @@
     icon__decorative: true,
     icon__blockname: event_meta__base_class,
     icon__modifiers: ['expand-more-dates'],
-    icon__visual_title: 'Show More Dates',
+    icon__visual_title: 'Show All Dates',
     icon__visual_title__modifiers: ['show-more-dates'],
   } %}
   {# collapse minus #}
@@ -63,7 +63,7 @@
     icon__decorative: true,
     icon__blockname: event_meta__base_class,
     icon__modifiers: ['collapse-more-dates'],
-    icon__visual_title: 'Hide More Dates',
+    icon__visual_title: 'Hide All Dates',
     icon__visual_title__modifiers: ['hide-more-dates'],
   } %}
 {% endset %}

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -140,16 +140,18 @@
       {# Date #}
       {% if event_dates %}
         <div {{ bem('date', [], event_meta__base_class) }}>
+          {# Fallback to old way of rendering if not passed #}
+          {% set event_featured_date = event_featured_date|default(event_dates.0) %}
 
-          {% if event_dates.0.formatted_start_date == event_dates.0.formatted_end_date %}
+          {% if event_featured_date.formatted_start_date == event_featured_date.formatted_end_date %}
           {#Replace am to a.m. and pm to p.m.#}
 
-            {{ event_dates.0.original_start|date('D M j, Y') }}
-            {{ event_dates.0.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}{{ em_dash }}{{ event_dates.0.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+            {{ event_featured_date.original_start|date('D M j, Y') }}
+            {{ event_featured_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}{{ em_dash }}{{ event_featured_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
           {% else %}
-            {{ event_dates.0.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+            {{ event_featured_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
             {{ em_dash }}
-            {{ event_dates.0.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+            {{ event_featured_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
           {% endif %}
         </div>
       {% endif %}

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -32,7 +32,8 @@
 {% set event_meta__with_calendar = event_meta__with_calendar ?? TRUE %}
 
 {# Check if event has passed - if passed in localist, the event_dates array will be empty #}
-{% set event_has_passed = event_dates is empty %}
+{# But in the event the featured date has already passed, we should already know about it as well #}
+{% set event_has_passed = event_dates is empty or (event_featured_date and event_featured_date.is_passed_event) %}
 
 {# Set the event status based on event_has_passed variable #}
 {% set event_status = event_has_passed ? 'passed' : 'current' %}

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -184,6 +184,9 @@
             <ul {{ bem('multiple-dates', [], event_meta__base_class) }} aria-expanded="false">
               {% for event_date in event_dates %}
                 <li {{ bem('multiple-dates__date', [], event_meta__base_class) }}>
+                  {% if event_date.is_passed_event %}
+                    Past Event: 
+                  {% endif %}
                   {% if event_date.formatted_start_date == event_date.formatted_end_date %}
                     {{ event_date.original_start|date('D M j, Y') }}
                     {{ event_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}{{ em_dash }}{{- event_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}

--- a/components/02-molecules/meta/meta.stories.js
+++ b/components/02-molecules/meta/meta.stories.js
@@ -1,12 +1,11 @@
 import tokens from '@yalesites-org/tokens/build/json/tokens.json';
 import {
-  eventArgTypes,
+  eventLocalistArgs,
   eventLocalistArgTypes,
 } from '../../04-page-layouts/cl-page-args';
 
 import eventLocalistData from './event-meta/event-localist.yml';
 import basicMetaTwig from './basic-meta/yds-basic-meta.twig';
-import eventMetaTwig from './event-meta/yds-event-meta.twig';
 import eventLocalistMetaTwig from './event-meta/yds-event-meta-localist.twig';
 import dateTimeTwig from '../../01-atoms/date-time/yds-date-time.twig';
 import profileMetaTwig from './profile-meta/yds-profile-meta.twig';
@@ -16,36 +15,11 @@ import './event-meta/event-meta-localist';
 
 const colorPairingsData = Object.keys(tokens['component-themes']);
 
-// Utility to convert dates to unix timestamps
-const toUnixTimeStamp = (date) => {
-  return Math.floor(Date.parse(date) / 1000);
-};
-
 /**
  * Storybook Definition.
  */
 export default {
   title: 'Molecules/Meta',
-  args: {
-    meta: `<span>By Charlyn Paradis</span>${dateTimeTwig({
-      date_time__start: '2022-01-25',
-      date_time__format: 'day__full',
-    })}`,
-    startDate: '2022-01-25',
-    endDate: '2022-01-25',
-    address: 'New Haven, CT',
-    pageTitle: 'Event Title',
-    heading: 'Meta Title',
-    titleLine: 'Professional Title',
-    subTitle: 'Subtitle',
-    department: 'Department name',
-    bgColor: 'one',
-    profileImageOrientation: 'landscape',
-    profileImageAlignment: 'right',
-    profileImageStyle: 'inline',
-    ctaText: 'Register',
-    allDay: false,
-  },
 };
 
 export const Basic = ({ meta }) => basicMetaTwig({ basic_meta: meta });
@@ -55,33 +29,14 @@ Basic.argTypes = {
     type: 'string',
   },
 };
-
-export const Event = ({
-  pageTitle,
-  startDate,
-  endDate,
-  format,
-  address,
-  ctaText,
-  allDay,
-}) =>
-  eventMetaTwig({
-    event_title__heading: pageTitle,
-    event_meta__date_start: toUnixTimeStamp(startDate),
-    event_meta__date_end: toUnixTimeStamp(endDate),
-    event_meta__format: format,
-    event_meta__address: address,
-    event_meta__cta_primary__content: ctaText,
-    event_meta__cta_primary__href: '#',
-    event_meta__cta_secondary__content: 'Add to calendar',
-    event_meta__cta_secondary__href: '#',
-    event_meta__all_day: allDay,
-  });
-Event.argTypes = {
-  ...eventArgTypes,
+Basic.args = {
+  meta: `<span>By Charlyn Paradis</span>${dateTimeTwig({
+    date_time__start: '2022-01-25',
+    date_time__format: 'day__full',
+  })}`,
 };
 
-export const EventLocalist = ({
+export const Event = ({
   pageTitle,
   format,
   address,
@@ -108,7 +63,7 @@ export const EventLocalist = ({
     event_meta__all_day: allDay,
     ...eventLocalistData,
   });
-EventLocalist.argTypes = {
+Event.argTypes = {
   withCalendar: {
     name: 'With Add to Calendar button',
     type: 'boolean',
@@ -116,6 +71,7 @@ EventLocalist.argTypes = {
   },
   ...eventLocalistArgTypes,
 };
+Event.args = eventLocalistArgs;
 
 export const Profile = ({
   heading,
@@ -194,4 +150,15 @@ Profile.argTypes = {
     options: ['inline', 'outdent'],
     defaultValue: 'inline',
   },
+};
+Profile.args = {
+  heading: 'Person Namerton',
+  titleLine: 'Professional Title',
+  subTitle: 'Subtitle',
+  department: 'Department name',
+  pronouns: 'They/They/Them',
+  bgColor: 'one',
+  profileImageOrientation: 'landscape',
+  profileImageAlignment: 'right',
+  profileImageStyle: 'inline',
 };

--- a/components/04-page-layouts/cl-page-args.js
+++ b/components/04-page-layouts/cl-page-args.js
@@ -106,4 +106,12 @@ export const eventLocalistArgTypes = {
   },
 };
 
+export const eventLocalistArgs = {
+  address: 'New Haven, CT',
+  pageTitle: 'Event Title',
+  ctaText: 'Register',
+  allDay: false,
+  withCalendar: true,
+};
+
 export default argTypes;


### PR DESCRIPTION
## [YSP-844: Event Meta Block Date Visibility Improvements](https://yaleits.atlassian.net/browse/YSP-844)
## [YSP-839: A11y: Reference card pinned aria-label incorrect](https://yaleits.atlassian.net/browse/YSP-839)

More work done at [YaleSites Project](https://github.com/yalesites-org/yalesites-project/pull/908)

### Description of work
- Indicated past events in event meta by adding a conditional check to display "Past Event:" for dates that have already passed.
- Added `is_passed_event` flag to each event date in `event-localist.yml`.
- Included `event_featured_date` with `is_passed_event` flag.
- Updated `yds-event-meta-localist.twig` to check `is_passed_event` flag for determining if an event has passed.
- Updated event date rendering logic by adding a fallback to the old way of rendering if `event_featured_date` is not passed.
- Replaced `event_dates.0` with `event_featured_date` for date comparisons and rendering.
- Changed "Show More Dates" to "Show All Dates" and "Hide More Dates" to "Hide All Dates".
- Fix Drupal-side error regarding passing arrays to string concatenation.

### Testing Link(s)
- [ ] Navigate to the [Event Meta Localist Story](https://deploy-preview-485--dev-component-library-twig.netlify.app/?path=/story/molecules-meta--event-localist)

### Functional Review Steps
- [ ] Verify past dates show `Past Event`

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
