### PR TITLE
YSP-738 :: Reimplement hiding hamburger menu if no menu items exist

### DIFF
--- a/components/03-organisms/site-header/yds-site-header.twig
+++ b/components/03-organisms/site-header/yds-site-header.twig
@@ -13,7 +13,11 @@
 
 {% set site_header__base_class = 'site-header' %}
 
-{% set site_header__hamburger = 'yes' %}
+{% set site_header__hamburger = 'no' %}
+
+{% if utility_nav__items or primary_nav__items %}
+  {% set site_header__hamburger = 'yes' %}
+{% endif %}
 
 {% set site_header__attributes = {
   'data-main-menu-state': 'loaded',


### PR DESCRIPTION
## [YSP-738: Reimplement hiding hamburger menu if no menu items exist](https://yaleits.atlassian.net/browse/YSP-738)

### Description of work
- Hides the hamburger menu if there are no items in the main and utility menus.

### Functional testing steps:
- [ ] Go to administer menus for [main](https://pr-919-yalesites-platform.pantheonsite.io/admin/structure/menu/manage/main) and [utility](https://pr-919-yalesites-platform.pantheonsite.io/admin/structure/menu/manage/utility-navigation) menus
- [  ] Delete or disable all menu items in both menus, verify you cannot see the hamburger menu
- [  ] Enable at least one menu item in either menu, verify you can see the hamburger menu.