### PR TITLE
YSP-761 :: Add available blocks to regions for new layouts

### DIFF
--- a/components/01-atoms/controls/control.stories.js
+++ b/components/01-atoms/controls/control.stories.js
@@ -1,15 +1,12 @@
 import tokens from '@yalesites-org/tokens/build/json/tokens.json';
+
 import ctaTwig from './cta/yds-cta.twig';
 import linkTwig from './text-link/yds-text-link.twig';
-
-import textCopyButton from './text-copy-button/yds-text-copy-button.twig';
+import textCopyButtonTwig from './text-copy-button/yds-text-copy-button.twig';
 
 import './text-link/yds-text-link';
 import './text-copy-button/yds-text-copy-button';
 
-import themeExamplesTwig from './cta/_yds-cta-examples.twig';
-
-const componentThemes = { themes: tokens['button-cta-themes'] };
 const componentThemeOptions = Object.keys(tokens['button-cta-themes']);
 
 /**
@@ -17,14 +14,39 @@ const componentThemeOptions = Object.keys(tokens['button-cta-themes']);
  */
 export default {
   title: 'Atoms/Controls',
+  argTypes: {
+    sectionTheme: {
+      name: 'Section Theme',
+      type: 'select',
+      options: ['default', 'one', 'two', 'three', 'four'],
+      control: { type: 'select' },
+    },
+  },
+  parameters: {
+    controls: {
+      sort: 'requiredFirst',
+    },
+  },
   args: {
-    componentTheme: 'one',
-    globalTheme: 'one',
+    sectionTheme: 'default',
   },
 };
 
+const Section = (sectionTheme, component) => `
+  <div class="yds-layout" data-component-theme="${sectionTheme}" data-component-width="site">
+    <div class="yds-layout__inner">
+      <div class="yds-layout__primary">
+        ${component}
+      </div>
+    </div>
+  </div>
+`;
+
 const ctaText = 'Call to action';
-export const Cta = ({ componentTheme }) => `
+export const Cta = ({ componentTheme, sectionTheme }) =>
+  Section(
+    sectionTheme,
+    `
   <h2>Filled</h2>
   <div class="cta-group">
     ${ctaTwig({
@@ -148,7 +170,8 @@ export const Cta = ({ componentTheme }) => `
       cta__component_theme: componentTheme,
     })}
   </div>
-  `;
+  `,
+  );
 
 Cta.argTypes = {
   componentTheme: {
@@ -158,7 +181,14 @@ Cta.argTypes = {
   },
 };
 
-export const textLink = () => `
+Cta.args = {
+  componentTheme: 'one',
+};
+
+export const textLink = ({ sectionTheme }) =>
+  Section(
+    sectionTheme,
+    `
   ${linkTwig({
     link__url: 'http://localhost:6006',
     link__content: 'This is a default link',
@@ -202,216 +232,15 @@ export const textLink = () => `
     link__content: 'This is a long link without animated underlines',
     link__style: 'no-underline-animation',
   })}<br/>
-`;
+`,
+  );
 
-export const CtaExamples = ({ componentTheme }) =>
-  themeExamplesTwig({
-    ...componentThemes,
-    example_content: `
-    <h2>Filled</h2>
-    <div class="cta-group">
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: 'https://google.com',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: 'https://google.com/download.pdf',
-        cta__radius: 'soft',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: '#',
-        cta__radius: 'pill',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: '#',
-        cta__radius: 'pill',
-        cta__component_theme: componentTheme,
-        cta__control_type: 'dropdown',
-      })}
-    </div>
-    <h2>Outline</h2>
-    <div class="cta-group">
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: '#',
-        cta__style: 'outline',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: '#',
-        cta__radius: 'soft',
-        cta__style: 'outline',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: '#',
-        cta__radius: 'pill',
-        cta__style: 'outline',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: '#',
-        cta__radius: 'outline',
-        cta__component_theme: componentTheme,
-        cta__control_type: 'dropdown',
-      })}
-    </div>
-    <h2>Outline Weights</h2>
-    <div class="cta-group">
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: '#',
-        cta__style: 'outline',
-        cta__outline_weight: '1',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: '#',
-        cta__style: 'outline',
-        cta__outline_weight: '2',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: ctaText,
-        cta__href: '#',
-        cta__style: 'outline',
-        cta__outline_weight: '4',
-        cta__component_theme: componentTheme,
-      })}
-    </div>
-    <h2>Hover Effects</h2>
-    <div class="cta-group">
-      ${ctaTwig({
-        cta__content: 'Fade',
-        cta__href: '#',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: 'Rise',
-        cta__hover_style: 'rise',
-        cta__href: '#',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: 'Wipe',
-        cta__hover_style: 'wipe',
-        cta__href: '#',
-        cta__component_theme: componentTheme,
-      })}
-    </div>
-    <div class="cta-group">
-      ${ctaTwig({
-        cta__content: 'Fade',
-        cta__style: 'outline',
-        cta__href: '#',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: 'Rise',
-        cta__style: 'outline',
-        cta__hover_style: 'rise',
-        cta__href: '#',
-        cta__component_theme: componentTheme,
-      })}
-      ${ctaTwig({
-        cta__content: 'Wipe',
-        cta__style: 'outline',
-        cta__hover_style: 'wipe',
-        cta__href: '#',
-        cta__component_theme: componentTheme,
-      })}
-    </div>
-    `,
-  });
-
-CtaExamples.argTypes = {
-  componentTheme: {
-    name: 'Component Theme (dial)',
-    options: componentThemeOptions,
-    type: 'select',
-  },
-};
-
-export const LinkExamples = ({ globalTheme, componentTheme }) =>
-  themeExamplesTwig({
-    ...componentThemes,
-    site_global__theme: globalTheme,
-    example_content: `
-      <div class="link-group" data-cta-theme="${componentTheme}">
-      ${linkTwig({
-        link__url: 'http://localhost:6006',
-        link__content: 'This is a default link',
-      })}<br />
-      ${linkTwig({
-        link__url: '#',
-        link__content: 'This is a "no-underline" link',
-        link__style: 'no-underline',
-        link__type: 'normal',
-      })}<br />
-      ${linkTwig({
-        link__url: 'https://google.com',
-        link__content: 'This is an "external" link',
-        link__style: 'underline-with-icon',
-        link__type: 'external',
-      })}
-      ${linkTwig({
-        link__url: '#',
-        link__content: 'This is a "new target" link',
-        link__style: 'underline-with-icon',
-        link__type: 'target-blank',
-        link__attributes: {
-          target: '_blank',
-        },
-      })}
-      ${linkTwig({
-        link__url: 'https://google.com/download.pdf',
-        link__content: 'This is a "download" link',
-        link__style: 'underline-with-icon',
-        link__type: 'download',
-      })}
-      ${linkTwig({
-        link__url: '#',
-        link__content: 'This is a link with chevron',
-        link__style: 'underline-with-icon',
-        link__type: 'with-chevron',
-        link__url_type: 'chevron',
-      })}
-      ${linkTwig({
-        link__url: '#',
-        link__content: 'This is a long link without animated underlines',
-        link__style: 'no-underline-animation',
-      })}<br/>
-      </div>
-      `,
-  });
-
-export const textCopyButtonExamples = ({ globalTheme, componentTheme }) =>
-  themeExamplesTwig({
-    ...componentThemes,
-    site_global__theme: globalTheme,
-    example_content: `
-      ${textCopyButton({
-        text_copy_button__pre_text: 'person@example.com',
-        text_copy_button__content: '(copy)',
-        text_copy_button__component_theme: componentTheme,
-      })}
-    `,
-  });
-
-textCopyButtonExamples.argTypes = {
-  componentTheme: {
-    name: 'Component Theme (dial)',
-    options: componentThemeOptions,
-    type: 'select',
-  },
-};
+export const textCopyButton = ({ sectionTheme }) =>
+  Section(
+    sectionTheme,
+    textCopyButtonTwig({
+      text_copy_button__pre_text: 'person@example.com',
+      text_copy_button__content: '(copy)',
+      text_copy_button__component_theme: 'two',
+    }),
+  );

--- a/components/01-atoms/controls/cta/_yds-cta-examples.twig
+++ b/components/01-atoms/controls/cta/_yds-cta-examples.twig
@@ -1,5 +1,3 @@
-<div class="wrap-for-global-theme" data-global-theme="{{site_global__theme}}">
-  <div class="wrap-for-component-theme" data-cta-theme="{{site_component__theme}}">
-    {{example_content}}
-  </div>
+<div class="wrap-for-component-theme" data-cta-theme="{{site_component__theme}}">
+  {{example_content}}
 </div>

--- a/components/01-atoms/controls/cta/_yds-cta.scss
+++ b/components/01-atoms/controls/cta/_yds-cta.scss
@@ -329,6 +329,39 @@ $cta-outline-weights: (
       text-decoration: underline;
     }
   }
+
+  [data-component-theme]:not([data-component-theme='default']) & {
+    // &[data-cta-style='outline'] {
+    //   --color-cta-bg: transparent;
+    //   --color-cta-bg-hover: var(--color-action);
+    //   --color-cta-border: var(--color-action);
+    //   --color-cta-text: var(--color-action);
+    //   --color-cta-text-hover: var(--color-action-secondary);
+    // }
+    &[data-cta-style='filled'] {
+      --color-cta-text: var(--color-layout-theme);
+      --color-cta-text-hover: var(--color-layout-border);
+      --color-cta-bg: var(--color-layout-border);
+      --color-cta-bg-hover: transparent;
+      --color-cta-border: var(--color-layout-border);
+    }
+
+    &[data-cta-style='outline'] {
+      --color-cta-text: var(--color-layout-border);
+      --color-cta-text-hover: var(--color-layout-theme);
+      --color-cta-border: var(--color-layout-border);
+      --color-cta-bg-hover: var(--color-layout-border);
+    }
+
+    // background: transparent;
+    // color: var(--color-basic-white);
+    // border-color: var(--color-basic-white);
+
+    // &:hover {
+    //   background: var(--color-basic-white);
+    //   color: var(--color-layout-theme);
+    // }
+  }
 }
 
 .cta {

--- a/components/01-atoms/controls/cta/_yds-cta.scss
+++ b/components/01-atoms/controls/cta/_yds-cta.scss
@@ -329,39 +329,6 @@ $cta-outline-weights: (
       text-decoration: underline;
     }
   }
-
-  [data-component-theme]:not([data-component-theme='default']) & {
-    // &[data-cta-style='outline'] {
-    //   --color-cta-bg: transparent;
-    //   --color-cta-bg-hover: var(--color-action);
-    //   --color-cta-border: var(--color-action);
-    //   --color-cta-text: var(--color-action);
-    //   --color-cta-text-hover: var(--color-action-secondary);
-    // }
-    &[data-cta-style='filled'] {
-      --color-cta-text: var(--color-layout-theme);
-      --color-cta-text-hover: var(--color-layout-border);
-      --color-cta-bg: var(--color-layout-border);
-      --color-cta-bg-hover: transparent;
-      --color-cta-border: var(--color-layout-border);
-    }
-
-    &[data-cta-style='outline'] {
-      --color-cta-text: var(--color-layout-border);
-      --color-cta-text-hover: var(--color-layout-theme);
-      --color-cta-border: var(--color-layout-border);
-      --color-cta-bg-hover: var(--color-layout-border);
-    }
-
-    // background: transparent;
-    // color: var(--color-basic-white);
-    // border-color: var(--color-basic-white);
-
-    // &:hover {
-    //   background: var(--color-basic-white);
-    //   color: var(--color-layout-theme);
-    // }
-  }
 }
 
 .cta {
@@ -379,7 +346,6 @@ $cta-outline-weights: (
   }
 }
 
-// @TODO: Temporary place for this
 .cta-group {
   display: flex;
   flex-wrap: wrap;

--- a/components/01-atoms/controls/cta/_yds-cta.scss
+++ b/components/01-atoms/controls/cta/_yds-cta.scss
@@ -28,6 +28,7 @@ $cta-outline-weights: (
   text-decoration: none;
   text-align: center;
   min-height: var(--size-click-target-minimum);
+  cursor: pointer;
 
   &:hover {
     background-color: var(--color-cta-bg-hover);

--- a/components/01-atoms/divider/_yds-divider.scss
+++ b/components/01-atoms/divider/_yds-divider.scss
@@ -40,4 +40,8 @@ $divider-positions: left, center;
       @include tokens.expand-out;
     }
   }
+
+  [data-component-theme]:not([data-component-theme='default']) & {
+    --color-divider: var(--color-layout-border);
+  }
 }

--- a/components/01-atoms/divider/divider.stories.js
+++ b/components/01-atoms/divider/divider.stories.js
@@ -36,16 +36,29 @@ export default {
       type: 'select',
       defaultValue: 'center',
     },
+    sectionTheme: {
+      name: 'Section Theme',
+      type: 'select',
+      options: ['default', 'one', 'two', 'three', 'four'],
+      control: { type: 'select' },
+    },
   },
   args: {
     thickness: 'hairline',
     dividerColor: 'gray-500',
     width: 'View-All',
     position: 'center',
+    sectionTheme: 'default',
   },
 };
 
-export const Dividers = ({ position, thickness, dividerColor, width }) => {
+export const Dividers = ({
+  position,
+  thickness,
+  dividerColor,
+  width,
+  sectionTheme,
+}) => {
   const customProperties = {
     '--thickness-theme-divider': `var(--size-thickness-${thickness})`,
   };
@@ -65,28 +78,33 @@ export const Dividers = ({ position, thickness, dividerColor, width }) => {
   <div style="--thickness-divider: var(--size-thickness-4)">${dividerTwig()}</div>
   <div style="--thickness-divider: var(--size-thickness-6)">${dividerTwig()}</div>
   <div style="--thickness-divider: var(--size-thickness-8)">${dividerTwig()}</div>
-  <div class="cl-divider-playground" style="
-    --color-divider: var(--color-${dividerColor});
-    --width-theme-divider: var(--layout-width-${width});
-  ">
-    <h2>Playground</h2>
-    <p>Use the StoryBook controls to see the dividers below implement the available positions, thicknesses, and colors.</p>
-    ${dividerTwig({
-      divider__width: `${viewAll ? '25' : width}`,
-      divider__position: `${position}`,
-    })}
-    ${dividerTwig({
-      divider__width: `${viewAll ? '50' : width}`,
-      divider__position: `${position}`,
-    })}
-    ${dividerTwig({
-      divider__width: `${viewAll ? '75' : width}`,
-      divider__position: `${position}`,
-    })}
-    ${dividerTwig({
-      divider__width: `${viewAll ? '100' : width}`,
-      divider__position: `${position}`,
-    })}
+  <div class="yds-layout cl-divider-playground" data-component-theme="${sectionTheme}">
+    <div class="yds-layout__inner" data-component-width="site" style="
+      --color-divider: var(--color-${dividerColor});
+      --width-theme-divider: var(--layout-width-${width});
+    ">
+      <div class="yds-layout__primary">
+        <h2>Playground</h2>
+        <p>Use the StoryBook controls to see the dividers below implement the available positions, thicknesses, and colors.</p>
+
+        ${dividerTwig({
+          divider__width: `${viewAll ? '25' : width}`,
+          divider__position: `${position}`,
+        })}
+        ${dividerTwig({
+          divider__width: `${viewAll ? '50' : width}`,
+          divider__position: `${position}`,
+        })}
+        ${dividerTwig({
+          divider__width: `${viewAll ? '75' : width}`,
+          divider__position: `${position}`,
+        })}
+        ${dividerTwig({
+          divider__width: `${viewAll ? '100' : width}`,
+          divider__position: `${position}`,
+        })}
+      </div>
+    </div>
   </div>
   <div class="padding-to-see-dividers-above">&nbsp;</div>
   `;

--- a/components/01-atoms/forms/_yds-form.scss
+++ b/components/01-atoms/forms/_yds-form.scss
@@ -38,7 +38,7 @@
 @mixin cta-submit {
   transition: color,
     background-color var(--animation-speed-default) ease-in-out 0ms;
-  border: var(--border-thickness-cta) solid var(--color-action);
+  border: var(--border-thickness-cta) solid var(--color-cta-border);
   font-weight: var(--font-weights-mallory-medium);
   padding: var(--size-spacing-3) var(--size-spacing-6);
   min-height: var(--size-click-target-minimum);

--- a/components/01-atoms/forms/contact-form-example.twig
+++ b/components/01-atoms/forms/contact-form-example.twig
@@ -16,6 +16,6 @@
     <textarea id="textarea" required="required" aria-required="true" class="form-item__textfield form-item__textarea form-item__textfield--required"  rows="8" cols="48" placeholder="Enter your message here"></textarea>
   </div>
   <div class="form-item form-actions">
-    <input class="webform-button--submit button cta button--primary js-form-submit form-submit form-item__textfield" data-drupal-selector="edit-actions-submit" type="submit" id="edit-actions-submit" name="op" value="Send Message" data-cta-radius="none" data-cta-theme="one" data-cta-style="filled" data-cta-outline-weight="2" data-cta-hover-style="fade">
+    <input class="webform-button--submit button cta button--primary js-form-submit form-submit form-item__textfield" data-drupal-selector="edit-actions-submit" type="submit" id="edit-actions-submit" name="op" value="Send Message" data-cta-radius="none" data-cta-theme="{{ buttonTheme }}" data-cta-style="filled" data-cta-outline-weight="2" data-cta-hover-style="fade">
   </div>
  </form>

--- a/components/01-atoms/forms/forms.stories.js
+++ b/components/01-atoms/forms/forms.stories.js
@@ -23,4 +23,33 @@ export const selectDropdowns = () => select(selectOptionsData);
 
 export const textfieldsExamples = () => textfields();
 
-export const exampleForm = () => formExample();
+export const exampleForm = ({ buttonTheme, sectionTheme }) => `
+  <div data-component-has-divider="false" data-component-theme="${sectionTheme}" data-component-width="site" class="yds-layout" data-embedded-components="" data-spotlights-position="first">
+    <div class="yds-layout__inner">
+      <div class="yds-layout__primary">
+        <h2>Pre-Built Form</h2>
+        ${formExample({ buttonTheme })}
+      </div>
+    </div>
+  </div>
+`;
+
+exampleForm.argTypes = {
+  sectionTheme: {
+    name: 'Section Theme',
+    type: 'select',
+    options: ['default', 'one', 'two', 'three', 'four'],
+    control: { type: 'select' },
+  },
+  buttonTheme: {
+    name: 'Button Theme',
+    type: 'select',
+    options: ['one', 'two', 'three', 'four', 'five', 'six', 'seven'],
+    control: { type: 'select' },
+  },
+};
+
+exampleForm.args = {
+  sectionTheme: 'default',
+  buttonTheme: 'one',
+};

--- a/components/01-atoms/forms/textfields/_yds-textfields.scss
+++ b/components/01-atoms/forms/textfields/_yds-textfields.scss
@@ -30,6 +30,13 @@ $form-item-icon-size: 1.7rem;
     margin: calc(var(--size-spacing-4) * 1) 0 0 0.2em;
     content: '*';
   }
+
+  [data-component-theme]:not([data-component-theme='default'], [data-component-theme='two'])
+    & {
+    &::after {
+      color: var(--color-basic-white);
+    }
+  }
 }
 
 .form-item__textfield {
@@ -37,6 +44,10 @@ $form-item-icon-size: 1.7rem;
   padding: var(--size-spacing-4);
   width: 100%;
   max-width: 100%;
+
+  &:not([type='submit']) {
+    background-color: var(--color-basic-white);
+  }
 
   .form--inline & {
     height: 100%;
@@ -112,5 +123,17 @@ $form-item-icon-size: 1.7rem;
     @include forms.cta-submit;
 
     border-radius: 100vmax; // Keep webform submit button rounded.
+
+    [data-component-theme]:not([data-component-theme='default'], [data-component-theme='two'])
+      & {
+      background: transparent;
+      color: var(--color-basic-white);
+      border-color: var(--color-basic-white);
+
+      &:hover {
+        background: var(--color-basic-white);
+        color: var(--color-layout-theme);
+      }
+    }
   }
 }

--- a/components/01-atoms/forms/textfields/_yds-textfields.scss
+++ b/components/01-atoms/forms/textfields/_yds-textfields.scss
@@ -31,7 +31,10 @@ $form-item-icon-size: 1.7rem;
     content: '*';
   }
 
-  [data-component-theme]:not([data-component-theme='default'], [data-component-theme='two'])
+  [data-component-theme]:not(
+      [data-component-theme='default'],
+      [data-component-theme='two']
+    )
     & {
     &::after {
       color: var(--color-basic-white);
@@ -124,7 +127,10 @@ $form-item-icon-size: 1.7rem;
 
     border-radius: 100vmax; // Keep webform submit button rounded.
 
-    [data-component-theme]:not([data-component-theme='default'], [data-component-theme='two'])
+    [data-component-theme]:not(
+        [data-component-theme='default'],
+        [data-component-theme='two']
+      )
       & {
       background: transparent;
       color: var(--color-basic-white);

--- a/components/01-atoms/forms/textfields/_yds-textfields.scss
+++ b/components/01-atoms/forms/textfields/_yds-textfields.scss
@@ -126,20 +126,5 @@ $form-item-icon-size: 1.7rem;
     @include forms.cta-submit;
 
     border-radius: 100vmax; // Keep webform submit button rounded.
-
-    [data-component-theme]:not(
-        [data-component-theme='default'],
-        [data-component-theme='two']
-      )
-      & {
-      background: transparent;
-      color: var(--color-basic-white);
-      border-color: var(--color-basic-white);
-
-      &:hover {
-        background: var(--color-basic-white);
-        color: var(--color-layout-theme);
-      }
-    }
   }
 }

--- a/components/02-molecules/accordion/_yds-accordion.scss
+++ b/components/02-molecules/accordion/_yds-accordion.scss
@@ -89,6 +89,7 @@ $accordion-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
       [data-component-theme='default'],
       [data-component-theme='two']
     )
+    .accordion
     & {
     color: var(--color-basic-white);
   }
@@ -143,7 +144,7 @@ $accordion-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
     max-width: var(--size-component-layout-width-content);
   }
 
-  [data-component-theme]:not([data-component-theme='default']) & {
+  .accordion[data-component-theme]:not([data-component-theme='default']) & {
     --color-link-base: var(--color-gray-700);
     --color-heading: var(--color-gray-700);
 

--- a/components/02-molecules/accordion/_yds-accordion.scss
+++ b/components/02-molecules/accordion/_yds-accordion.scss
@@ -84,6 +84,14 @@ $accordion-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
   @include tokens.h2-yale-new;
 
   margin-bottom: var(--size-spacing-5);
+
+  [data-component-theme]:not(
+      [data-component-theme='default'],
+      [data-component-theme='two']
+    )
+    & {
+    color: var(--color-basic-white);
+  }
 }
 
 .accordion__controls {
@@ -115,6 +123,7 @@ $accordion-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
   display: flex;
   gap: var(--size-spacing-3);
   align-items: center;
+  cursor: pointer;
 
   &:hover {
     color: var(--color-link-base);
@@ -135,11 +144,26 @@ $accordion-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
   }
 
   [data-component-theme]:not([data-component-theme='default']) & {
+    --color-link-base: var(--color-gray-700);
+    --color-heading: var(--color-gray-700);
+
     border-bottom: none;
     background-color: var(--color-gray-100);
     padding: var(--size-spacing-3) var(--size-spacing-4);
     border-left: var(--border-thickness-6) solid var(--color-accordion-accent);
     margin-bottom: var(--size-spacing-5);
+    color: var(--color-gray-700);
+
+    .text-field a {
+      --color-text-shadow: var(--color-gray-100);
+      --color-link-hover: var(--color-gray-700);
+      --color-link-base: var(--color-gray-700);
+    }
+  }
+
+  [data-global-theme='one'] [data-component-theme='two'] .accordion &,
+  [data-global-theme='five'] [data-component-theme='two'] .accordion & {
+    background-color: var(--color-basic-white);
   }
 }
 
@@ -161,6 +185,7 @@ $accordion-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
   width: 100%;
   padding: var(--size-spacing-3) var(--size-spacing-4) var(--size-spacing-3) 0;
   text-align: left;
+  cursor: pointer;
 
   &:hover {
     color: var(--color-link-base);

--- a/components/02-molecules/accordion/accordion.stories.js
+++ b/components/02-molecules/accordion/accordion.stories.js
@@ -26,12 +26,27 @@ export default {
       options: ['one', 'two', 'three', 'four', 'five'],
       type: 'select',
     },
+    sectionTheme: {
+      name: 'Section Theme',
+      type: 'select',
+      options: ['default', 'one', 'two', 'three', 'four'],
+      control: { type: 'select' },
+    },
+    itemsToDisplay: {
+      name: 'Items to Display',
+      options: {
+        'One Item': 1,
+        'Multiple Items': 3,
+      },
+      type: 'select',
+    },
   },
   args: {
     accordionHeading: accordionData.accordion__heading,
     heading: accordionData.accordion__item__heading,
     content: accordionData.accordion__item__content,
     themeColor: 'default',
+    itemsToDisplay: 3,
   },
 };
 
@@ -40,41 +55,41 @@ export const Accordion = ({
   heading,
   content,
   themeColor,
+  itemsToDisplay,
+  sectionTheme,
 }) => {
+  const accordionItems = Array.from({ length: itemsToDisplay }, (_, index) => ({
+    accordion__item__heading:
+      index === 0 ? heading : accordionData.accordion__item__heading,
+    accordion__item__content:
+      index === 0 ? content : accordionData.accordion__item__content,
+  }));
+
   return `
-  <h2>With multiple items</h2>
-  <div>
-    ${accordionTwig({
-      accordion__theme: themeColor,
-      accordion__heading: accordionHeading,
-      accordion__items: [
-        {
-          accordion__item__heading: heading,
-          accordion__item__content: content,
-        },
-        {
-          accordion__item__heading: accordionData.accordion__item__heading,
-          accordion__item__content: accordionData.accordion__item__content,
-        },
-        {
-          accordion__item__heading: accordionData.accordion__item__heading,
-          accordion__item__content: accordionData.accordion__item__content,
-        },
-      ],
-    })}
+    <div>
+      ${accordionTwig({
+        accordion__theme: themeColor,
+        accordion__heading: accordionHeading,
+        accordion__items: [
+          {
+            accordion__item__heading: heading,
+            accordion__item__content: content,
+          },
+        ],
+      })}
+    </div>
+    <div data-component-has-divider="false" data-component-theme="${sectionTheme}" data-component-width="site" class="yds-layout" data-embedded-components="" data-spotlights-position="first">
+    <div class="yds-layout__inner">
+      <div class="yds-layout__primary">
+        <h2>Playground</h2>
+        <p>Use the StoryBook controls to see the accordion below implement the available variations and colors.</p>
+        ${accordionTwig({
+          accordion__theme: themeColor,
+          accordion__heading: accordionHeading,
+          accordion__items: accordionItems,
+        })}
+      </div>
+    </div>
   </div>
-  <h2>With one item</h2>
-  <div>
-    ${accordionTwig({
-      accordion__theme: themeColor,
-      accordion__heading: accordionHeading,
-      accordion__items: [
-        {
-          accordion__item__heading: heading,
-          accordion__item__content: content,
-        },
-      ],
-    })}
-  </div>
-    `;
+  `;
 };

--- a/components/02-molecules/accordion/accordion.stories.js
+++ b/components/02-molecules/accordion/accordion.stories.js
@@ -23,7 +23,7 @@ export default {
     },
     themeColor: {
       name: 'Component Theme (dial)',
-      options: ['one', 'two', 'three', 'four', 'five'],
+      options: ['default', 'one', 'two', 'three', 'four', 'five'],
       type: 'select',
     },
     sectionTheme: {
@@ -46,6 +46,7 @@ export default {
     heading: accordionData.accordion__item__heading,
     content: accordionData.accordion__item__content,
     themeColor: 'default',
+    sectionTheme: 'default',
     itemsToDisplay: 3,
   },
 };

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -363,7 +363,7 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     }
 
     @media (min-width: tokens.$break-xl) {
-      grid-column: 3 / -1;
+      grid-column: 2 / -1;
       grid-row: 2 / 7;
       align-self: center;
     }

--- a/components/02-molecules/link-grid/_yds-link-grid.scss
+++ b/components/02-molecules/link-grid/_yds-link-grid.scss
@@ -140,8 +140,10 @@ $component-link-grid-themes: map.deep-get(tokens.$tokens, 'component-themes');
 
   // if used in thirty-thirty-thirty layout and min-width 2xl
   // make the columns 100% width
-  [data-component-layout='thirty-thirty-thirty'] & {
+  [data-component-layout='thirty-thirty-thirty'] &,
+  .yds-two-column .yds-two-column__secondary & {
     @media (min-width: tokens.$break-2xl) {
+      border-width: var(--size-thickness-4);
       margin-bottom: 0;
       flex: 1 1 100%;
     }

--- a/components/02-molecules/link-grid/_yds-link-grid.scss
+++ b/components/02-molecules/link-grid/_yds-link-grid.scss
@@ -77,6 +77,15 @@ $component-link-grid-themes: map.deep-get(tokens.$tokens, 'component-themes');
 
   flex: 1 0 100%;
   margin-bottom: var(--size-spacing-6);
+
+  [data-component-theme]:not(
+      [data-component-theme='default'],
+      [data-component-theme='two']
+    )
+    .link-grid
+    & {
+    color: var(--color-basic-white);
+  }
 }
 
 .link-grid__inner {
@@ -126,6 +135,15 @@ $component-link-grid-themes: map.deep-get(tokens.$tokens, 'component-themes');
   [data-component-layout='fifty-fifty'] & {
     @media (min-width: tokens.$break-2xl) {
       flex: 1 1 50%;
+    }
+  }
+
+  // if used in thirty-thirty-thirty layout and min-width 2xl
+  // make the columns 100% width
+  [data-component-layout='thirty-thirty-thirty'] & {
+    @media (min-width: tokens.$break-2xl) {
+      margin-bottom: 0;
+      flex: 1 1 100%;
     }
   }
 }

--- a/components/02-molecules/pull-quote/_yds-pull-quote.scss
+++ b/components/02-molecules/pull-quote/_yds-pull-quote.scss
@@ -76,7 +76,6 @@ blockquote {
     )
     & {
     --color-pull-quote-quote: var(--color-basic-white);
-    --color-pull-quote-accent: var(--color-layout-border);
     --color-pull-quote-attribution: var(--color-basic-white);
   }
 }

--- a/components/02-molecules/pull-quote/_yds-pull-quote.scss
+++ b/components/02-molecules/pull-quote/_yds-pull-quote.scss
@@ -69,6 +69,16 @@ blockquote {
   &[data-component-theme='three'] {
     --color-pull-quote-accent: var(--color-slot-five);
   }
+
+  [data-component-theme]:not(
+      [data-component-theme='default'],
+      [data-component-theme='two']
+    )
+    & {
+    --color-pull-quote-quote: var(--color-basic-white);
+    --color-pull-quote-accent: var(--color-layout-border);
+    --color-pull-quote-attribution: var(--color-basic-white);
+  }
 }
 
 .pull-quote__figure {

--- a/components/02-molecules/pull-quote/pull-quote.stories.js
+++ b/components/02-molecules/pull-quote/pull-quote.stories.js
@@ -26,16 +26,29 @@ export default {
       options: ['one', 'two', 'three'],
       type: 'select',
     },
+    sectionTheme: {
+      name: 'Section Theme',
+      type: 'select',
+      options: ['default', 'one', 'two', 'three', 'four'],
+      control: { type: 'select' },
+    },
   },
   args: {
     quote: pullQuoteData.pull_quote__quote,
     attribution: pullQuoteData.pull_quote__attribution,
     style: 'bar-left',
     accentColor: 'one',
+    sectionTheme: 'default',
   },
 };
 
-export const pullQuote = ({ style, accentColor, quote, attribution }) => `
+export const pullQuote = ({
+  style,
+  accentColor,
+  quote,
+  attribution,
+  sectionTheme,
+}) => `
   ${pullQuoteTwig({
     pull_quote__quote: pullQuoteData.pull_quote__quote,
     pull_quote__attribution: pullQuoteData.pull_quote__attribution,
@@ -49,14 +62,19 @@ export const pullQuote = ({ style, accentColor, quote, attribution }) => `
     pull_quote__attribution: pullQuoteData.pull_quote__attribution,
     pull_quote__style: 'quote-left',
   })}
-  <div style="--color-pull-quote-accent: var(--color-${accentColor})">
-    <h2>Playground</h2>
-    <p>Use the StoryBook controls to see the quote below implement the available variations and colors.</p>
-    ${pullQuoteTwig({
-      pull_quote__quote: quote,
-      pull_quote__attribution: attribution,
-      pull_quote__style: style,
-      pull_quote__accent_theme: accentColor,
-    })}
+  <div data-component-has-divider="false" data-component-theme="${sectionTheme}" data-component-width="site" class="yds-layout" data-embedded-components="" data-spotlights-position="first">
+    <div class="yds-layout__inner" style="--color-pull-quote-accent: var(--color-${accentColor})">
+      <div class="yds-layout__primary">
+        <h2>Playground</h2>
+        <p>Use the StoryBook controls to see the quote below implement the available variations and colors.</p>
+
+        ${pullQuoteTwig({
+          pull_quote__quote: quote,
+          pull_quote__attribution: attribution,
+          pull_quote__style: style,
+          pull_quote__accent_theme: accentColor,
+        })}
+      </div>
+    </div>
   </div>
 `;

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -18,6 +18,10 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   position: relative;
   border-bottom: var(--size-thickness-1) solid var(--color-border-selected);
 
+  .gin--dark-mode & {
+    border-color: var(--color-border-selected);
+  }
+
   [data-component-alignment='left'] & {
     max-width: var(--size-component-layout-width-content);
   }

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -78,6 +78,7 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   [data-component-theme]:not([data-component-theme='default']) & {
     --color-tabs-background: var(--color-layout-theme);
     --color-tabs-selected: var(--color-layout-theme);
+    --color-action: var(--color-layout-border);
   }
 }
 

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -45,6 +45,7 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
       --color-tabs-accent: var(--color-tabs-accent);
       --color-action: var(--color-tabs-action);
       --color-background: var(--color-tabs-background);
+      --color-selected: var(--color-tabs-selected);
     }
   }
 
@@ -53,22 +54,30 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   &[data-component-theme='one'] {
     --color-tabs-accent: var(--color-slot-one);
     --color-tabs-action: var(--color-slot-one);
-    --color-tabs-background: var(--color-basic-white);
+    --color-tabs-background: var(--color-gray-100);
+    --color-tabs-selected: var(--color-basic-white);
     --color-heading: var(--color-gray-700);
   }
 
   &[data-component-theme='two'] {
     --color-tabs-accent: var(--color-slot-two);
     --color-tabs-action: var(--color-slot-two);
-    --color-tabs-background: var(--color-basic-white);
+    --color-tabs-background: var(--color-gray-100);
+    --color-tabs-selected: var(--color-basic-white);
     --color-heading: var(--color-gray-700);
   }
 
   &[data-component-theme='three'] {
     --color-tabs-accent: var(--color-slot-five);
     --color-tabs-action: var(--color-slot-five);
-    --color-tabs-background: var(--color-basic-white);
+    --color-tabs-background: var(--color-gray-100);
+    --color-tabs-selected: var(--color-basic-white);
     --color-heading: var(--color-gray-700);
+  }
+
+  [data-component-theme]:not([data-component-theme='default']) & {
+    --color-tabs-background: var(--color-layout-theme);
+    --color-tabs-selected: var(--color-layout-theme);
   }
 }
 
@@ -102,7 +111,8 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   height: calc(var(--size-tabs-control) - var(--size-thickness-2));
   background-color: var(--color-background);
   opacity: 0;
-  border: var(--size-thickness-1) solid var(--color-gray-700);
+  border: var(--size-thickness-1) solid var(--color-gray-400);
+  color: inherit;
 
   &--left {
     left: 0;
@@ -174,9 +184,9 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   position: relative;
   text-decoration: none;
   padding: var(--size-spacing-3) var(--size-spacing-7) var(--size-spacing-5);
-  color: var(--color-gray-700);
+  color: inherit;
   border-top: var(--size-thickness-6) solid transparent;
-  background-color: var(--color-gray-100);
+  background-color: var(--color-background);
   height: 100%;
 
   &:hover {
@@ -189,9 +199,8 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
 
   // Active tab.
   &[aria-selected='true'] {
-    color: var(--color-action);
     border-color: var(--color-action);
-    background-color: var(--color-basic-white);
+    background-color: var(--color-selected);
 
     &::before {
       content: '';
@@ -200,7 +209,7 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
       left: 0;
       right: 0;
       bottom: 0;
-      border-bottom: var(--size-spacing-3) solid var(--color-basic-white);
+      border-bottom: var(--size-spacing-3) solid var(--color-selected);
       z-index: 1;
     }
   }

--- a/components/02-molecules/tabs/_yds-tabs.scss
+++ b/components/02-molecules/tabs/_yds-tabs.scss
@@ -10,12 +10,13 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   @include tokens.spacing-page-section;
   @include tokens.animate(height);
 
+  --color-border: var(--color-gray-300);
+  --color-border-selected: var(--color-gray-500);
+  --size-tabs-control: 4rem;
+
   overflow: hidden;
   position: relative;
-  border-bottom: var(--size-thickness-1) solid var(--color-gray-500);
-
-  --color-tabs-accent: --color-gray-500;
-  --size-tabs-control: 4rem;
+  border-bottom: var(--size-thickness-1) solid var(--color-border-selected);
 
   [data-component-alignment='left'] & {
     max-width: var(--size-component-layout-width-content);
@@ -42,7 +43,6 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   @each $theme, $value in $component-tab-themes {
     &[data-component-theme='#{$theme}'] {
       // prettier-ignore
-      --color-tabs-accent: var(--color-tabs-accent);
       --color-action: var(--color-tabs-action);
       --color-background: var(--color-tabs-background);
       --color-selected: var(--color-tabs-selected);
@@ -52,7 +52,6 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   // Component theme overrides: set specific component themes overrides
   /// define component name spaced variables and map them to global theme slots.
   &[data-component-theme='one'] {
-    --color-tabs-accent: var(--color-slot-one);
     --color-tabs-action: var(--color-slot-one);
     --color-tabs-background: var(--color-gray-100);
     --color-tabs-selected: var(--color-basic-white);
@@ -60,7 +59,6 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   }
 
   &[data-component-theme='two'] {
-    --color-tabs-accent: var(--color-slot-two);
     --color-tabs-action: var(--color-slot-two);
     --color-tabs-background: var(--color-gray-100);
     --color-tabs-selected: var(--color-basic-white);
@@ -68,7 +66,6 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   }
 
   &[data-component-theme='three'] {
-    --color-tabs-accent: var(--color-slot-five);
     --color-tabs-action: var(--color-slot-five);
     --color-tabs-background: var(--color-gray-100);
     --color-tabs-selected: var(--color-basic-white);
@@ -79,6 +76,15 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
     --color-tabs-background: var(--color-layout-theme);
     --color-tabs-selected: var(--color-layout-theme);
     --color-action: var(--color-layout-border);
+  }
+
+  [data-component-theme]:not(
+      [data-component-theme='default'],
+      [data-component-theme='two']
+    )
+    & {
+    --color-border: var(--color-gray-400);
+    --color-border-selected: var(--color-basic-white);
   }
 }
 
@@ -95,7 +101,7 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
     left: 0;
     right: 0;
     width: 100%;
-    border-bottom: var(--size-thickness-1) solid var(--color-gray-500);
+    border-bottom: var(--size-thickness-1) solid var(--color-border-selected);
   }
 }
 
@@ -112,7 +118,7 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
   height: calc(var(--size-tabs-control) - var(--size-thickness-2));
   background-color: var(--color-background);
   opacity: 0;
-  border: var(--size-thickness-1) solid var(--color-gray-400);
+  border: var(--size-thickness-1) solid var(--color-border);
   color: inherit;
 
   &--left {
@@ -171,12 +177,20 @@ $component-tab-themes: map.deep-get(tokens.$tokens, 'component-themes');
 
 .tabs__item {
   flex-shrink: 0;
-  border-top: var(--size-thickness-1) solid var(--color-gray-300);
-  border-left: var(--size-thickness-1) solid var(--color-gray-300);
+  border-top: var(--size-thickness-1) solid var(--color-border);
+  border-left: var(--size-thickness-1) solid var(--color-border);
   overflow: hidden;
 
   &:last-child {
-    border-right: var(--size-thickness-1) solid var(--color-gray-300);
+    border-right: var(--size-thickness-1) solid var(--color-border);
+  }
+
+  &:has([aria-selected='true']) {
+    border-color: var(--color-border-selected);
+
+    + .tabs__item {
+      border-left-color: var(--color-border-selected);
+    }
   }
 }
 

--- a/components/02-molecules/tabs/tabs.stories.js
+++ b/components/02-molecules/tabs/tabs.stories.js
@@ -1,15 +1,44 @@
 import tabs from './yds-tabs.twig';
-
 import tabData from './tabs.yml';
-
 import './yds-tabs';
 
 /**
  * Storybook Definition.
  */
-export default { title: 'Molecules/Tabs' };
+export default {
+  title: 'Molecules/Tabs',
+  argTypes: {
+    componentThemeColor: {
+      name: 'Component Theme',
+      type: 'select',
+      options: ['one', 'two', 'three'],
+      control: { type: 'select' },
+    },
+    layoutThemeColor: {
+      name: 'Layout Theme',
+      type: 'select',
+      options: ['default', 'one', 'two', 'three', 'four'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    componentThemeColor: 'one',
+    layoutThemeColor: 'default',
+  },
+};
 
-export const Tabs = () => `
-  ${tabs(tabData)}
-  ${tabs({ ...tabData, tabs__id: '123' })}
+export const Tabs = ({ componentThemeColor, layoutThemeColor }) => `
+  ${tabs({ ...tabData, tabs__theme: componentThemeColor })}
+  <div data-component-has-divider="false" data-component-theme="${layoutThemeColor}" data-component-width="site" class="yds-layout" data-embedded-components="" data-spotlights-position="first">
+    <div class="yds-layout__inner">
+      <div class="yds-layout__primary">
+        <h2>Tabs Inside Layout</h2>
+        ${tabs({
+          ...tabData,
+          tabs__id: '123',
+          tabs__theme: componentThemeColor,
+        })}
+      </div>
+    </div>
+  </div>
 `;

--- a/components/02-molecules/tabs/tabs.stories.js
+++ b/components/02-molecules/tabs/tabs.stories.js
@@ -8,28 +8,28 @@ import './yds-tabs';
 export default {
   title: 'Molecules/Tabs',
   argTypes: {
-    componentThemeColor: {
+    componentTheme: {
       name: 'Component Theme',
       type: 'select',
       options: ['one', 'two', 'three'],
       control: { type: 'select' },
     },
-    layoutThemeColor: {
-      name: 'Layout Theme',
+    sectionTheme: {
+      name: 'Section Theme',
       type: 'select',
       options: ['default', 'one', 'two', 'three', 'four'],
       control: { type: 'select' },
     },
   },
   args: {
-    componentThemeColor: 'one',
-    layoutThemeColor: 'default',
+    componentTheme: 'one',
+    sectionTheme: 'default',
   },
 };
 
-export const Tabs = ({ componentThemeColor, layoutThemeColor }) => `
-  ${tabs({ ...tabData, tabs__theme: componentThemeColor })}
-  <div data-component-has-divider="false" data-component-theme="${layoutThemeColor}" data-component-width="site" class="yds-layout" data-embedded-components="" data-spotlights-position="first">
+export const Tabs = ({ componentTheme, sectionTheme }) => `
+  ${tabs({ ...tabData })}
+  <div data-component-has-divider="false" data-component-theme="${sectionTheme}" data-component-width="site" class="yds-layout" data-embedded-components="" data-spotlights-position="first">
     <div class="yds-layout__inner">
       <div class="yds-layout__primary">
         <h2>Playground</h2>
@@ -37,7 +37,7 @@ export const Tabs = ({ componentThemeColor, layoutThemeColor }) => `
         ${tabs({
           ...tabData,
           tabs__id: '123',
-          tabs__theme: componentThemeColor,
+          tabs__theme: componentTheme,
         })}
       </div>
     </div>

--- a/components/02-molecules/tabs/tabs.stories.js
+++ b/components/02-molecules/tabs/tabs.stories.js
@@ -32,7 +32,8 @@ export const Tabs = ({ componentThemeColor, layoutThemeColor }) => `
   <div data-component-has-divider="false" data-component-theme="${layoutThemeColor}" data-component-width="site" class="yds-layout" data-embedded-components="" data-spotlights-position="first">
     <div class="yds-layout__inner">
       <div class="yds-layout__primary">
-        <h2>Tabs Inside Layout</h2>
+        <h2>Playground</h2>
+        <p>Use the StoryBook controls to see the tabs below implement the available variations and colors.</p>
         ${tabs({
           ...tabData,
           tabs__id: '123',

--- a/components/03-organisms/layout/layout/_yds-layout.scss
+++ b/components/03-organisms/layout/layout/_yds-layout.scss
@@ -139,6 +139,11 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
   &[data-spotlights-position='last'] {
     margin-bottom: var(--size-spacing-10);
   }
+
+  // Styles applied only if the HTML element has the 'yds-storybook-cl' class  html:has(.yds-storybook-cl) &,
+  html:has(.yds-storybook-cl) & {
+    margin-block: 0;
+  }
 }
 
 .yds-layout__inner {


### PR DESCRIPTION
## [YSP-761: Add available blocks to regions for new layouts](https://yaleits.atlassian.net/browse/YSP-761)

### Description of work

- Tabs: Transparent tab buttons on dark backgrounds and improved text contrast.
- Pre-built Forms: Adjusted input background colors and fixed asterisk color for visibility.
- Quote: Dynamically adjusted text color based on section background.
- Divider: Updated color to adapt to section background.
- Button: Colors adjusted for proper contrast with section backgrounds.
- Accordion: Applied color adjustments similar to tabs.
- Reference Card: Repositioned text area for better text width and layout.

### Work also done at:
- [YaleSites Project](https://github.com/yalesites-org/yalesites-project/pull/898)
- [Atomic](https://github.com/yalesites-org/atomic/pull/331)

