### PR TITLE
IYY-345: Breadcrumbs at level 2 instead of level 3

### DIFF
--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
@@ -13,24 +13,24 @@ import './yds-breadcrumbs';
 export default {
   title: 'Organisms/Menu/Breadcrumbs',
   argTypes: {
-    withDeep: {
+    limitItems: {
       name: 'Limit Items',
       type: 'boolean',
     },
-    deepLevel: {
+    trailLevel: {
       name: 'Trail Level',
       type: 'number',
       if: {
-        arg: 'withDeep',
+        arg: 'limitItems',
         truthy: true,
       },
     },
   },
   args: {
-    withDeep: false,
-    deepLevel: 2,
+    limitItems: false,
+    trailLevel: 2,
   },
 };
 
-export const Breadcrumbs = ({ deepLevel }) =>
-  breadcrumbsTwig({ ...breadcrumbsData, breadcrumbs__deep: deepLevel });
+export const Breadcrumbs = ({ trailLevel }) =>
+  breadcrumbsTwig({ ...breadcrumbsData, breadcrumbs__trail_level: trailLevel });

--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
@@ -10,6 +10,27 @@ import './yds-breadcrumbs';
 /**
  * Storybook Definition.
  */
-export default { title: 'Organisms/Menu/Breadcrumbs' };
+export default {
+  title: 'Organisms/Menu/Breadcrumbs',
+  argTypes: {
+    withDeep: {
+      name: 'With deep',
+      type: 'boolean',
+    },
+    deepLevel: {
+      name: 'Deep Level',
+      type: 'number',
+      if: {
+        arg: 'withDeep',
+        truthy: true,
+      },
+    },
+  },
+  args: {
+    withDeep: false,
+    deepLevel: 2,
+  },
+};
 
-export const Breadcrumbs = () => breadcrumbsTwig(breadcrumbsData);
+export const Breadcrumbs = ({ deepLevel }) =>
+  breadcrumbsTwig({ ...breadcrumbsData, breadcrumbs__deep: deepLevel });

--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
@@ -14,11 +14,11 @@ export default {
   title: 'Organisms/Menu/Breadcrumbs',
   argTypes: {
     withDeep: {
-      name: 'With deep',
+      name: 'Limit Items',
       type: 'boolean',
     },
     deepLevel: {
-      name: 'Deep Level',
+      name: 'Trail Level',
       type: 'number',
       if: {
         arg: 'withDeep',

--- a/components/03-organisms/menu/breadcrumbs/yds-breadcrumbs.twig
+++ b/components/03-organisms/menu/breadcrumbs/yds-breadcrumbs.twig
@@ -32,8 +32,8 @@
   } %}
 {% endset %}
 
-{% if breadcrumbs__items.1 and breadcrumbs__deep %}
-  {% set breadcrumbs__items = breadcrumbs__items|slice(breadcrumbs__deep * -1) %}
+{% if breadcrumbs__items.1 and breadcrumbs__trail_level %}
+  {% set breadcrumbs__items = breadcrumbs__items|slice(breadcrumbs__trail_level * -1) %}
 {% endif %}
 
 {# Only show breadbrumbs if there are two or more items. #}

--- a/components/03-organisms/menu/breadcrumbs/yds-breadcrumbs.twig
+++ b/components/03-organisms/menu/breadcrumbs/yds-breadcrumbs.twig
@@ -36,8 +36,8 @@
   {% set breadcrumbs__items = breadcrumbs__items|slice(breadcrumbs__deep * -1) %}
 {% endif %}
 
-{# Only show breadbrumbs if there are three or more items. #}
-{% if breadcrumbs__items.1 %}
+{# Only show breadbrumbs if there are two or more items. #}
+{% if breadcrumbs__items.1 or always_show_breadcrumbs %}
   <div {{ add_attributes(breadcrumbs__attributes) }}>
     {% set control__content %}
       <span {{ bem('visually-hidden') }}>Show all breadcrumbs</span>

--- a/components/03-organisms/menu/breadcrumbs/yds-breadcrumbs.twig
+++ b/components/03-organisms/menu/breadcrumbs/yds-breadcrumbs.twig
@@ -32,8 +32,12 @@
   } %}
 {% endset %}
 
-{# Only show breadbrumbs if there are three or more items or if always_show_breadcrumbs is set. #}
-{% if breadcrumbs__items.2 or always_show_breadcrumbs %}
+{% if breadcrumbs__items.1 and breadcrumbs__deep %}
+  {% set breadcrumbs__items = breadcrumbs__items|slice(breadcrumbs__deep * -1) %}
+{% endif %}
+
+{# Only show breadbrumbs if there are three or more items. #}
+{% if breadcrumbs__items.1 %}
   <div {{ add_attributes(breadcrumbs__attributes) }}>
     {% set control__content %}
       <span {{ bem('visually-hidden') }}>Show all breadcrumbs</span>


### PR DESCRIPTION
## [IYY-345: Breadcrumbs at level 2 instead of level 3](https://fourkitchens.clickup.com/t/36718269/IYY-345)

### Description of work
- Add breadcrumb depth functionality

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-491--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-breadcrumbs--breadcrumbs)

### Functional Review Steps
- [ ] Verify that the deep variable functions as expected

### Work also done at:
- [Atomic](https://github.com/yalesites-org/atomic/pull/330)


