### PR TITLE
YSP-716 :: Add "Contained Narrow" Design Option to Grand Hero Block

### DIFF
--- a/components/02-molecules/banner/banner.stories.js
+++ b/components/02-molecules/banner/banner.stories.js
@@ -128,7 +128,7 @@ GrandHeroBanner.argTypes = {
   overlayVariation: {
     name: 'Content Overlay',
     type: 'select',
-    options: ['contained', 'full'],
+    options: ['contained', 'contained-narrow', 'full'],
   },
   size: {
     name: 'Content Size',

--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -196,7 +196,8 @@ $break-grand-hero-banner: tokens.$break-m;
 .grand-hero-banner__outer-wrap {
   width: 100%;
 
-  [data-grand-hero-overlay-variation='contained'] & {
+  [data-grand-hero-overlay-variation='contained'],
+  [data-grand-hero-overlay-variation='contained-narrow'] & {
     align-items: flex-end;
 
     @media (min-width: $break-grand-hero-banner) {
@@ -251,6 +252,14 @@ $break-grand-hero-banner: tokens.$break-m;
     @media (min-width: $break-grand-hero-banner) {
       width: auto;
       max-width: var(--size-component-layout-width-content);
+    }
+  }
+
+  [data-grand-hero-overlay-variation='contained-narrow'] & {
+    width: 100%;
+
+    @media (min-width: $break-grand-hero-banner) {
+      max-width: 28rem;
     }
   }
 

--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -218,7 +218,8 @@ $break-grand-hero-banner: tokens.$break-m;
   width: 100%;
   margin: 0 auto;
 
-  [data-grand-hero-overlay-variation='contained'] & {
+  [data-grand-hero-overlay-variation='contained'] &,
+  [data-grand-hero-overlay-variation='contained-narrow'] & {
     // prettier-ignore
     max-width: calc(var(--size-component-layout-width-max) + (var(--size-spacing-site-gutter) * 2) );
   }
@@ -259,7 +260,8 @@ $break-grand-hero-banner: tokens.$break-m;
     width: 100%;
 
     @media (min-width: $break-grand-hero-banner) {
-      max-width: 28rem;
+      width: auto;
+      max-width: calc(var(--size-component-layout-width-content) / 2);
     }
   }
 
@@ -332,4 +334,9 @@ $break-grand-hero-banner: tokens.$break-m;
   display: flex;
   flex-flow: row wrap;
   gap: var(--size-spacing-7);
+
+  [data-grand-hero-overlay-variation='contained-narrow'] & {
+    gap: var(--size-spacing-5);
+    margin-top: 1rem;
+  }
 }

--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -229,7 +229,8 @@ $break-grand-hero-banner: tokens.$break-m;
     align-items: center;
   }
 
-  [data-grand-hero-overlay-variation='contained'][data-grand-hero-width='site']
+  [data-grand-hero-overlay-variation='contained'][data-grand-hero-width='site'],
+  [data-grand-hero-overlay-variation='contained'][data-grand-hero-width='contained-narrow']
     & {
     // prettier-ignore
     max-width: calc(var(--size-component-layout-width-site) + (var(--size-spacing-site-gutter) * 2));

--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -262,6 +262,7 @@ $break-grand-hero-banner: tokens.$break-m;
     @media (min-width: $break-grand-hero-banner) {
       width: auto;
       max-width: calc(var(--size-component-layout-width-content) / 2);
+      padding: var(--size-spacing-7);
     }
   }
 
@@ -328,6 +329,10 @@ $break-grand-hero-banner: tokens.$break-m;
   [data-component-theme] & {
     --color-link-hover: var(--color-grand-hero-text);
   }
+
+  .grand-hero-banner__content-inner > & {
+    margin-top: var(--size-spacing-6);
+  }
 }
 
 .grand-hero-banner__button-group {
@@ -337,6 +342,6 @@ $break-grand-hero-banner: tokens.$break-m;
 
   [data-grand-hero-overlay-variation='contained-narrow'] & {
     gap: var(--size-spacing-5);
-    margin-top: 1rem;
+    margin-top: var(--size-spacing-6);
   }
 }

--- a/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
+++ b/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
@@ -1,7 +1,7 @@
 {#
  # Available Props:
  # - grand_hero__content__background
- # - grand_hero__overlay_variation: contained (default), full
+ # - grand_hero__overlay_variation: contained (default), contained-narrow, full
  #
  # Available Variables:
  # - grand_hero__heading


### PR DESCRIPTION
## [YSP-716: Add "Contained Narrow" Design Option to Grand Hero Block](https://yaleits.atlassian.net/browse/YSP-716)

### Description of work
- Adds option to block: Floating Box Narrow 

Note that the "contained" option has a label of "Floating Box", so I added another with the key "contained-narrow" for which the label is "Floating Box Narrow"

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
