### PR TITLE
YSP-814 :: Remove `Show Thumbnails` in reference card to use `with-image`

### DIFF
--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -56,10 +56,6 @@ export default {
       name: 'Show Tags',
       type: 'boolean',
     },
-    showThumbnail: {
-      name: 'Show Thumbnail',
-      type: 'boolean',
-    },
     withImage: {
       name: 'With Image',
       type: 'boolean',
@@ -81,7 +77,6 @@ export default {
     showEyebrow: false,
     showCategories: false,
     showTags: false,
-    showThumbnail: true,
     showPronouns: false,
     date: referenceCardData.reference_card__date,
   },
@@ -99,7 +94,6 @@ export const PostCard = ({
   showCategories,
   showEyebrow,
   showTags,
-  showThumbnail,
   showPronouns,
   overlayText,
 }) => `
@@ -121,7 +115,6 @@ export const PostCard = ({
         show_categories: showCategories ? 'true' : 'false',
         show_eyebrow: showEyebrow ? 'true' : 'false',
         show_tags: showTags ? 'true' : 'false',
-        show_thumbnail: showThumbnail ? 'true' : 'false',
         show_pronouns: showPronouns ? 'true' : 'false',
         reference_card__categories:
           referenceCardData.reference_card__categories,

--- a/components/02-molecules/cards/reference-card/yds-reference-card.twig
+++ b/components/02-molecules/cards/reference-card/yds-reference-card.twig
@@ -116,16 +116,14 @@
     {% endif %}
   </div>
   {% if reference_card__image == 'true' %}
-    {% if show_thumbnail != '0' %}
-      <div {{ bem('image', [], reference_card__base_class) }}>
-        <a {{ bem('image-link', [], reference_card__base_class) }} href="{{ reference_card__url }}"
-                                                                   tabindex="-1" aria-hidden="true">
-          {% block reference_card__image %}
-            {% include "@atoms/images/image/_responsive-image.twig" %}
-          {% endblock %}
-        </a>
-      </div>
-    {% endif %}
+    <div {{ bem('image', [], reference_card__base_class) }}>
+      <a {{ bem('image-link', [], reference_card__base_class) }} href="{{ reference_card__url }}"
+                                                                  tabindex="-1" aria-hidden="true">
+        {% block reference_card__image %}
+          {% include "@atoms/images/image/_responsive-image.twig" %}
+        {% endblock %}
+      </a>
+    </div>
   {% endif %}
   {% if reference_card__overlay %}
     {% include "@atoms/typography/text/yds-text.twig" with {


### PR DESCRIPTION
## [YSP-814: Remove `Show Thumbnails` in reference card to use `with-image`](https://yaleits.atlassian.net/browse/YSP-814)

### Description of work
- Changes the reference_card__image property (which corresponds to 'withImage' in js files) to be set using the show_thumbnails property from ys_views_basic so that the show_thumbnail is no longer required in the component. 

Note: In the twig file, there were two properties being set to control the image display: reference_card__image and show_thumbnail. I have updated it so that it only uses reference_card__image which is set by 'Show Teaser Image' or 'withImage' if in Storybook, and is by default set to 'true' (the canonical node, Featured Card block).

### Testing Link(s)
- [ ] Multidev for testing here: https://pr-925-yalesites-platform.pantheonsite.io/

### Functional Review Steps
- [ ] In Storybook, verify the 'withImage' control works to show/hide the image in card components and card collections
- [ ] Log into the multidev, create a node featured card of any type, verify the image appears. I have been testing here: https://pr-925-yalesites-platform.pantheonsite.io/example-landing-page
- [ ] Create a view component of any type. Verify that "Show Teaser Image" toggles the image display

Uses Atomic branch: https://github.com/yalesites-org/atomic/pull/332
