### PR TITLE
YSP-370: Add Offset/Inline Design Options to Landscape Spotlight Block

### DIFF
--- a/components/02-molecules/text-with-image/_yds-text-with-image.scss
+++ b/components/02-molecules/text-with-image/_yds-text-with-image.scss
@@ -203,6 +203,13 @@ $component-content-spotlight-themes: map.deep-get(
       align-items: flex-end;
     }
 
+    // Image Style Variatoins
+    [data-image-style='offset'] & {
+      --component-width: calc(
+        var(--size-component-layout-width-site) + var(--size-spacing-10)
+      );
+    }
+
     // Focus Options
     [data-component-focus='equal'] & {
       grid-template-columns: 1fr 1fr;
@@ -248,6 +255,15 @@ $component-content-spotlight-themes: map.deep-get(
 
     [data-image-position='image-right'] & {
       grid-area: primary;
+    }
+
+    // if offset, balance out the image offset with a margin on content
+    [data-image-style='offset'][data-image-position='image-right'] & {
+      margin-inline-start: var(--size-spacing-8);
+    }
+
+    [data-image-style='offset'][data-image-position='image-left'] & {
+      margin-inline-end: var(--size-spacing-8);
     }
   }
 

--- a/components/02-molecules/text-with-image/text-with-image.stories.js
+++ b/components/02-molecules/text-with-image/text-with-image.stories.js
@@ -39,6 +39,11 @@ export default {
       type: 'select',
       options: ['top', 'middle', 'bottom'],
     },
+    imageStyle: {
+      name: 'Image Style',
+      type: 'select',
+      options: ['inline', 'offset'],
+    },
     focus: {
       name: 'Focus',
       type: 'select',
@@ -75,6 +80,7 @@ export default {
     width: 'site',
     position: 'image-left',
     contentVerticalAlignment: 'top',
+    imageStyle: 'inline',
     focus: 'equal',
     overline: null,
     heading: textWithImageData.text_with_image__heading,
@@ -96,6 +102,7 @@ export const ContentSpotlightLandscape = ({
   linkContent,
   linkTwoContent,
   componentTheme,
+  imageStyle,
 }) =>
   textWithImageTwig({
     ...imageData.responsive_images['3x2'],
@@ -103,6 +110,7 @@ export const ContentSpotlightLandscape = ({
     text_with_image__width: width,
     text_with_image__position: position,
     text_with_image__vertical_align: contentVerticalAlignment,
+    text_with_image__style: imageStyle,
     text_with_image__focus: focus,
     text_with_image__overline: overline,
     text_with_image__heading: heading,

--- a/components/02-molecules/text-with-image/yds-text-with-image.twig
+++ b/components/02-molecules/text-with-image/yds-text-with-image.twig
@@ -3,6 +3,7 @@
  # - text_with_image__width: feature (default) or highlight
  # - text_with_image__position: image-left (default) or image-right
  # - text_with_image__focus: equal (default), image, or text
+ # - text_with_image__style: inline (default) or offset
  #
  # Available variables:
  # - text_with_image__overline (optional)
@@ -26,6 +27,7 @@
   'data-image-position': text_with_image__position|default('image-left'),
   'data-component-width': text_with_image__width|default('site'),
   'data-component-theme': text_with_image__theme|default('default'),
+  'data-image-style': text_with_image__style|default('inline'),
   'data-content-vertical-align': text_with_image__vertical_align|default('top'),
   class: bem(text_with_image__base_class)
 } %}


### PR DESCRIPTION
## [YSP-370: Add Offset/Inline Design Options to Landscape Spotlight Block](https://yaleits.atlassian.net/browse/YSP-370)

### Description of work
- add style option to text-with-image
- add imageStyle prop to stories
- add offset image style variations

### Testing Link(s)
- [ ] Navigate to the [Content Spotlight Landscape Story](https://deploy-preview-494--dev-component-library-twig.netlify.app/?path=/story/molecules-content-spotlight--content-spotlight-landscape)

### Functional Review Steps
- [ ] Verify that offset shortens the width of the content portion
