### PR TITLE
YSP-874: Button block in a 50/50 section color contrast

### DIFF
--- a/components/01-atoms/controls/cta/_yds-cta.scss
+++ b/components/01-atoms/controls/cta/_yds-cta.scss
@@ -330,14 +330,7 @@ $cta-outline-weights: (
     }
   }
 
-  [data-component-theme]:not([data-component-theme='default']) & {
-    // &[data-cta-style='outline'] {
-    //   --color-cta-bg: transparent;
-    //   --color-cta-bg-hover: var(--color-action);
-    //   --color-cta-border: var(--color-action);
-    //   --color-cta-text: var(--color-action);
-    //   --color-cta-text-hover: var(--color-action-secondary);
-    // }
+  .yds-layout[data-component-theme]:not([data-component-theme='default']) & {
     &[data-cta-style='filled'] {
       --color-cta-text: var(--color-layout-theme);
       --color-cta-text-hover: var(--color-layout-border);
@@ -352,15 +345,6 @@ $cta-outline-weights: (
       --color-cta-border: var(--color-layout-border);
       --color-cta-bg-hover: var(--color-layout-border);
     }
-
-    // background: transparent;
-    // color: var(--color-basic-white);
-    // border-color: var(--color-basic-white);
-
-    // &:hover {
-    //   background: var(--color-basic-white);
-    //   color: var(--color-layout-theme);
-    // }
   }
 }
 

--- a/components/01-atoms/controls/cta/_yds-cta.scss
+++ b/components/01-atoms/controls/cta/_yds-cta.scss
@@ -329,6 +329,39 @@ $cta-outline-weights: (
       text-decoration: underline;
     }
   }
+
+  [data-component-theme]:not([data-component-theme='default']) & {
+    // &[data-cta-style='outline'] {
+    //   --color-cta-bg: transparent;
+    //   --color-cta-bg-hover: var(--color-action);
+    //   --color-cta-border: var(--color-action);
+    //   --color-cta-text: var(--color-action);
+    //   --color-cta-text-hover: var(--color-action-secondary);
+    // }
+    &[data-cta-style='filled'] {
+      --color-cta-text: var(--color-layout-theme);
+      --color-cta-text-hover: var(--color-layout-border);
+      --color-cta-bg: var(--color-layout-border);
+      --color-cta-bg-hover: transparent;
+      --color-cta-border: var(--color-layout-border);
+    }
+
+    &[data-cta-style='outline'] {
+      --color-cta-text: var(--color-layout-border);
+      --color-cta-text-hover: var(--color-layout-theme);
+      --color-cta-border: var(--color-layout-border);
+      --color-cta-bg-hover: var(--color-layout-border);
+    }
+
+    // background: transparent;
+    // color: var(--color-basic-white);
+    // border-color: var(--color-basic-white);
+
+    // &:hover {
+    //   background: var(--color-basic-white);
+    //   color: var(--color-layout-theme);
+    // }
+  }
 }
 
 .cta {
@@ -346,6 +379,7 @@ $cta-outline-weights: (
   }
 }
 
+// @TODO: Temporary place for this
 .cta-group {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## [YSP-874: Button block in a 50/50 section color contrast](https://yaleits.atlassian.net/browse/YSP-874)

This is actually a product of a quick fix we did to fix callouts and other buttons.  Upon further investigation, it has to do with CTA buttons that are not inside of a split section vs those that are.  Certain color variables are set inside of these new sections vs the original one column section.

### Description of work
- Reverts callout fix
- Scopes targeting of CTA color overrides to those that would be inside of `.yds-layout`

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
