### PR TITLE
YSP-822: Add Event Time to Event Display Modes

### DIFF
--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -46,15 +46,17 @@ format__day__long = Thursday, December 3, 2024
     'format__iso': 'c',
     'format__html_date': 'Y-m-d',
     'format__date': 'F j, Y',
-    'format__date__start': 'F j, Y' ~ em_dash,
+    'format__date__start': 'F j, Y',
     'format__day__full__start': "D M j \t\o",
     'format__day__full': 'D M j, Y',
-    'format__time__start': 'g:i a' ~ em_dash,
+    'format__time__start': 'g:i a',
     'format__time': 'g:i a',
     'format__all_day': "\\A\\l\\l \\D\\a\\y",
     'format__all_day__start': '',
     'format__day__long': 'l, F j, Y',
-    'format__day__long__start': 'l, F j, Y' ~ em_dash,
+    'format__day__long__start': 'l, F j, Y',
+    'format__same_day_diff_time__start': "D M j \t\o g:i a",
+    'format__same_day_diff_time': 'g:i a',
   } %}
 
 {% set format_defaults = {
@@ -63,14 +65,18 @@ format__day__long = Thursday, December 3, 2024
   "date_and_time": "format__day__full",
   "all_day": "format__all_day",
   "day__full": "format__day__full",
+  "same_day_diff_time": "format__same_day_diff_time",
   } %}
 
+{% set same_date = date_time__start|date(formats['format__html_date']) == date_time__end|date(formats['format__html_date']) %}
 {% set used_format = date_time__format_override|default(format_defaults[date_time__format]) %}
 
 {% if same_start_and_end %}
   {% set date_time = date_time__start|date(formats[used_format]) %}
+{% elseif same_date %}
+  {% set date_time = date_time__start|date(formats[used_format ~ "__start"]) ~ em_dash ~ date_time__end|date(formats[used_format]) %}
 {% else %}
-  {% set date_time = date_time__start|date(formats[used_format ~ "__start"]) ~ date_time__end|date(formats[used_format]) %}
+  {% set date_time = date_time__start|date(formats[used_format ~ "__start"]) ~ em_dash ~ date_time__end|date(formats[used_format ~ "__start"]) %}
 {% endif %}
 
 {# Add attributes #}

--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -46,17 +46,15 @@ format__day__long = Thursday, December 3, 2024
     'format__iso': 'c',
     'format__html_date': 'Y-m-d',
     'format__date': 'F j, Y',
-    'format__date__start': 'F j, Y',
+    'format__date__start': 'F j, Y' ~ em_dash,
     'format__day__full__start': "D M j \t\o",
     'format__day__full': 'D M j, Y',
-    'format__time__start': 'g:i a',
+    'format__time__start': 'g:i a' ~ em_dash,
     'format__time': 'g:i a',
     'format__all_day': "\\A\\l\\l \\D\\a\\y",
     'format__all_day__start': '',
     'format__day__long': 'l, F j, Y',
-    'format__day__long__start': 'l, F j, Y',
-    'format__same_day_diff_time__start': "D M j \t\o g:i a",
-    'format__same_day_diff_time': 'g:i a',
+    'format__day__long__start': 'l, F j, Y' ~ em_dash,
   } %}
 
 {% set format_defaults = {
@@ -65,18 +63,14 @@ format__day__long = Thursday, December 3, 2024
   "date_and_time": "format__day__full",
   "all_day": "format__all_day",
   "day__full": "format__day__full",
-  "same_day_diff_time": "format__same_day_diff_time",
   } %}
 
-{% set same_date = date_time__start|date(formats['format__html_date']) == date_time__end|date(formats['format__html_date']) %}
 {% set used_format = date_time__format_override|default(format_defaults[date_time__format]) %}
 
 {% if same_start_and_end %}
   {% set date_time = date_time__start|date(formats[used_format]) %}
-{% elseif same_date %}
-  {% set date_time = date_time__start|date(formats[used_format ~ "__start"]) ~ em_dash ~ date_time__end|date(formats[used_format]) %}
 {% else %}
-  {% set date_time = date_time__start|date(formats[used_format ~ "__start"]) ~ em_dash ~ date_time__end|date(formats[used_format ~ "__start"]) %}
+  {% set date_time = date_time__start|date(formats[used_format ~ "__start"]) ~ date_time__end|date(formats[used_format]) %}
 {% endif %}
 
 {# Add attributes #}

--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -20,7 +20,6 @@
 {% set same_start_and_end = date_time__start == date_time__end %}
 {% set date_time__format = date_time__format|default('date_and_time') %}
 
-
 {% if date_time__all_day == true %}
   {% set date_time__format = "all_day" %}
 {% endif %}
@@ -46,32 +45,53 @@ format__day__long = Thursday, December 3, 2024
     'format__iso': 'c',
     'format__html_date': 'Y-m-d',
     'format__date': 'F j, Y',
-    'format__date__start': 'F j, Y' ~ em_dash,
-    'format__day__full__start': "D M j \t\o",
+    'format__date__start': 'F j, Y',
+    'format__day__full__start': "D M j",
     'format__day__full': 'D M j, Y',
-    'format__time__start': 'g:i a' ~ em_dash,
+    'format__time__start': 'g:i a',
     'format__time': 'g:i a',
     'format__all_day': "\\A\\l\\l \\D\\a\\y",
     'format__all_day__start': '',
     'format__day__long': 'l, F j, Y',
-    'format__day__long__start': 'l, F j, Y' ~ em_dash,
+    'format__day__long__start': 'l, F j, Y',
+    'format__same_day_diff_time__start': 'D M j, Y g:i a',
+    'format__same_day_diff_time': 'g:i a',
   } %}
 
+{% set between_characters = {
+  'default': '',
+  'format__date': em_dash,
+  'format__day_full': " to ",
+  'format__time': em_dash,
+  'format__day__long': em_dash,
+  'format__same_day_diff_time': em_dash,
+} %}
+
+{# Set the default format to use if no format is provided. #}
 {% set format_defaults = {
   "time": "format__time",
   "date": "format__date",
   "date_and_time": "format__day__full",
   "all_day": "format__all_day",
   "day__full": "format__day__full",
+  "same_day_diff_time": "format__same_day_diff_time",
   } %}
 
-{% set used_format = date_time__format_override|default(format_defaults[date_time__format]) %}
 
+{% set used_format = date_time__format_override|default(format_defaults[date_time__format]) %}
+{% set is_same_day = date_time__start|date(formats['format__html_date']) == date_time__end|date(formats['format__html_date']) %}
+{% set start_format = formats[used_format ~ "__start"] %}
+{% set end_format = formats[used_format] %}
+{% set between_character = between_characters[used_format]|default(between_characters['default']) %}
+
+{# If the start and end dates are the same, use the same format for both. #}
+{% set date_time = date_time__start|date(start_format) ~ between_character ~ date_time__end|date(start_format) %}
 {% if same_start_and_end %}
-  {% set date_time = date_time__start|date(formats[used_format]) %}
-{% else %}
-  {% set date_time = date_time__start|date(formats[used_format ~ "__start"]) ~ date_time__end|date(formats[used_format]) %}
+  {% set date_time = date_time__start|date(end_format) %}
+{% elseif is_same_day %}
+  {% set date_time = date_time__start|date(start_format) ~ between_character ~ date_time__end|date(end_format) %}
 {% endif %}
+{% set date_time = date_time|replace({'am': 'a.m.', 'pm': 'p.m.'}) %}
 
 {# Add attributes #}
 {% set date_time__attribuites = {

--- a/components/02-molecules/meta/event-meta/yds-event-meta.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta.twig
@@ -8,23 +8,14 @@
 
 {% if event_meta__date_start %}
 
-  {% set event_meta__day %}
+  {% set event_meta__date %}
     {% include "@atoms/date-time/yds-date-time.twig" with {
       date_time__start: event_meta__date_start,
       date_time__end: event_meta__date_end,
-      date_time__format: 'day__full',
+      date_time__format: 'same_day_diff_time',
     } %}
   {% endset %}
-
-  {% set event_meta__time %}
-    {% include "@atoms/date-time/yds-date-time.twig" with {
-      date_time__start: event_meta__date_start,
-      date_time__end: event_meta__date_end,
-      date_time__format: 'time',
-      date_time__all_day: event_meta__all_day,
-    } %}
-  {% endset %}
-
+      
 {% endif %}
 
 {% set event_meta__base_class = 'event-meta' %}
@@ -60,16 +51,10 @@
         {# Date #}
         <div {{ bem('date', [], event_meta__base_class) }}>
 
-          {# Day #}
           <div {{ bem('day', [], event_meta__base_class) }}>
-            {{ event_meta__day }} 
+            {{ event_meta__date }}
           </div>
 
-          {# Time #}
-          <div {{ bem('time', [], event_meta__base_class) }}>
-            {{ event_meta__time|replace({'am': 'a.m.', 'pm': 'p.m.'}) }} {# 8:30 pm- to 8:30 p.m.- #} 
-            {#Replace am to a.m. and pm to p.m.#}
-          </div>
         </div>
         {# Event Details #}
         <div {{ bem('details', [], event_meta__base_class) }}>


### PR DESCRIPTION
## [YSP-822: Add Event Time to Event Display Modes](https://yaleits.atlassian.net/browse/YSP-822)

In order to properly display the time correctly in the views, a modification to how we handle date times to accommodate more logic on whether it's the same day or not, but different time was needed.

### Description of work
- Added new formats for same-day different time scenarios.
- Fixed formatting inconsistencies by directly using `em_dash`.
- Introduced `same_date` check to handle same-date formatting cases.
- Updated logic to ensure proper formatting for start and end times.

This enhances the flexibility and correctness of date-time formatting.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-497--dev-component-library-twig.netlify.app/)

### Functional Review Steps
- [ ] Verify that dates and date times work as intended in different components utilizing it

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
