### PR TITLE
YSP-589: Add Page Content Type Support to Reference Card Block

### DIFF
--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -363,9 +363,13 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     }
 
     @media (min-width: tokens.$break-xl) {
-      grid-column: 2 / -1;
+      grid-column: 3 / -1;
       grid-row: 2 / 7;
       align-self: center;
+
+      .yds-two-column & {
+        grid-column: 2 / -1;
+      }
     }
   }
 

--- a/components/02-molecules/cards/reference-card/examples/page-card.yml
+++ b/components/02-molecules/cards/reference-card/examples/page-card.yml
@@ -1,0 +1,7 @@
+reference_card__heading: Your Story, Beautifully Told
+reference_card__snippet: YaleSites is purpose-built for handling data classified as low risk, ensuring a secure environment for your web content needs.
+reference_card__url: 'https://google.com'
+reference_card__categories:
+  - content: Page
+reference_card__tags:
+  - content: Page

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -2,6 +2,7 @@ import referenceCardTwig from './examples/_card--examples.twig';
 
 import referenceCardData from './examples/post-card.yml';
 import referenceProfileCardData from './examples/profile-card.yml';
+import referencePageCardData from './examples/page-card.yml';
 import imageData from '../../../01-atoms/images/image/image.yml';
 
 /**
@@ -272,4 +273,72 @@ ProfileCard.argTypes = {
     type: 'boolean',
     defaultValue: false,
   },
+};
+
+export const PageCard = ({
+  date,
+  eyebrow,
+  heading,
+  pronouns,
+  snippet,
+  collectionType,
+  featured,
+  withImage,
+  showCategories,
+  showEyebrow,
+  showTags,
+  showThumbnail,
+  showPronouns,
+  overlayText,
+}) => `
+<div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
+  <div class='card-collection__inner'>
+    <ul class='card-collection__cards'>
+      ${referenceCardTwig({
+        card_collection__source_type: 'page',
+        card_collection__type: collectionType,
+        ...imageData.responsive_images['3x2'],
+        reference_card__date: date,
+        reference_card__eyebrow: eyebrow,
+        reference_card__heading: heading,
+        reference_card__pronouns: pronouns,
+        reference_card__snippet: snippet,
+        reference_card__featured: featured ? 'true' : 'false',
+        reference_card__image: withImage ? 'true' : 'false',
+        reference_card__url: referencePageCardData.reference_card__url,
+        show_categories: showCategories ? 'true' : 'false',
+        show_eyebrow: showEyebrow ? 'true' : 'false',
+        show_tags: showTags ? 'true' : 'false',
+        show_thumbnail: showThumbnail ? 'true' : 'false',
+        show_pronouns: showPronouns ? 'true' : 'false',
+        reference_card__categories:
+          referencePageCardData.reference_card__categories,
+        reference_card__tags: referencePageCardData.reference_card__tags,
+        reference_card__overlay: overlayText,
+      })}
+    </ul>
+  </div>
+</div>
+`;
+PageCard.argTypes = {
+  date: {
+    name: 'Date',
+    type: 'string',
+    defaultValue: referencePageCardData.reference_card__date,
+  },
+};
+
+PageCard.args = {
+  heading: referencePageCardData.reference_card__heading,
+  snippet: referencePageCardData.reference_card__snippet,
+  categories: referencePageCardData.reference_card__categories,
+  tags: referencePageCardData.reference_card__tags,
+  collectionType: 'grid',
+  featured: true,
+  withImage: true,
+  showEyebrow: false,
+  showCategories: false,
+  showTags: false,
+  showThumbnail: true,
+  showPronouns: false,
 };


### PR DESCRIPTION
## [YSP-589: Add Page Content Type Support to Reference Card Block](https://yaleits.atlassian.net/browse/YSP-589)

### Description of work
- Updated the grid-column property for the reference card to improve layout alignment in two-column configurations, restoring the previously used alignment for single column configurations. Added a specific rule for `.yds-two-column` to ensure proper positioning/overriding.

### Testing Link(s)
- [ ] Navigate to the [Post Card Story](https://deploy-preview-499--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--post-card&args=collectionType:single)

### Functional Review Steps
- [ ] Change the `Collection Type` to `single`
- [ ] Verify that the overlay to the image looks mostly right justified such that you can see over 50% of the image.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
