### PR TITLE
YSP-803: Reduce Excessive Padding Between Breadcrumbs and Banner Blocks

### DIFF
--- a/components/02-molecules/page-title/_yds-page-title.scss
+++ b/components/02-molecules/page-title/_yds-page-title.scss
@@ -57,7 +57,7 @@
 // components/04-page-layouts/page-layouts.scss:page_layouts.scss:31-39
 div.page-title.visually-hidden + div,
 div.breadcrumbs__wrapper + :not(.page-title) {
-  margin-top: var(--size-spacing-10); // 4rem
+  margin-top: var(--size-spacing-0); // 0rem
 
   @media (max-width: tokens.$break-l) {
     margin-top: var(--size-spacing-8); // 2.5rem large breakpoints

--- a/components/03-organisms/layout/two-column/_yds-two-column.scss
+++ b/components/03-organisms/layout/two-column/_yds-two-column.scss
@@ -37,6 +37,10 @@ $break-layout-two-column-max: $break-layout-two-column - 0.05;
   @media (min-width: $break-layout-two-column) {
     flex: 1 0 var(--size-component-layout-width-content);
   }
+
+  & > *:first-child {
+    margin-top: 0;
+  }
 }
 
 .yds-two-column__secondary {

--- a/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
+++ b/components/03-organisms/menu/breadcrumbs/_yds-breadcrumbs.scss
@@ -10,27 +10,6 @@
   [data-embedded-components] & {
     margin-bottom: 0;
   }
-
-  /* Breadcrumb spacing issue */
-
-  /* https://yaleits.atlassian.net/browse/YSP-427 */
-  // Add margin to the following page-title display types:
-  //   - visually-hidden
-  //   - hidden (when no page-title div exists after the breadcrumbs__wrapper
-  // Margins borrowed from
-  // components/04-page-layouts/page-layouts.scss:page_layouts.scss:31-39
-  // See 02-molecules/page-title/page-title.js for JS logic (adds page-title-hidden).
-  [page-title-hidden='true'] .main-content & {
-    margin-bottom: var(--size-spacing-10); // 4rem
-
-    @media (max-width: tokens.$break-l) {
-      margin-bottom: var(--size-spacing-8); // 2.5rem large breakpoints
-    }
-
-    @media (max-width: tokens.$break-s) {
-      margin-bottom: var(--size-spacing-7); // 2rem small breakpoints
-    }
-  }
 }
 
 .breadcrumbs__button {

--- a/components/04-page-layouts/page-layouts.scss
+++ b/components/04-page-layouts/page-layouts.scss
@@ -31,7 +31,8 @@ body[data-body-frozen] {
 // it and the site header (size-spacing-6 and 9 below) - unless it is designated
 // as `$flush-top` above. Then it will have no top-margin separating it from the
 // site header.
-.main-content > *:first-child:not(.page-meta, .layout--banner) {
+.main-content
+  > *:first-child:not(.page-meta, .layout--banner, .breadcrumbs__wrapper) {
   margin-top: var(--main-content-top-margin, var(--size-spacing-6));
 }
 
@@ -50,8 +51,6 @@ body[data-body-frozen] {
 // Subtract to have a negative numbers so that the margin-top of the page
 // title does not affect the spacing when there are breadcrumbs.
 .main-content .breadcrumbs__wrapper {
-  margin-top: var(--main-content-top-margin, var(--size-spacing-6));
-
   // Subtract 2rem to the 4rem
   margin-bottom: var(--size-spacing-0);
 

--- a/components/04-page-layouts/page-layouts.scss
+++ b/components/04-page-layouts/page-layouts.scss
@@ -31,7 +31,7 @@ body[data-body-frozen] {
 // it and the site header (size-spacing-6 and 9 below) - unless it is designated
 // as `$flush-top` above. Then it will have no top-margin separating it from the
 // site header.
-.main-content > *:first-child:not(.layout--banner) {
+.main-content > *:first-child:not(.page-meta, .layout--banner) {
   margin-top: var(--main-content-top-margin, var(--size-spacing-6));
 }
 
@@ -63,6 +63,20 @@ body[data-body-frozen] {
   // Subtract 1rem to the 2rem
   @media (max-width: tokens.$break-s) {
     margin-bottom: calc(var(--size-spacing-5) - var(--size-spacing-7));
+  }
+}
+
+// .main-conent .page-meta that does not contain a .breadcrumbs__wrapper div
+// should have a top padding.
+.main-content .page-meta:not(:has(.breadcrumbs__wrapper)) {
+  margin-top: var(--main-content-top-margin, var(--size-spacing-6));
+
+  @media (max-width: tokens.$break-l) {
+    margin-top: var(--size-spacing-8); // 2.5rem large breakpoints
+  }
+
+  @media (max-width: tokens.$break-s) {
+    margin-top: var(--size-spacing-7); // 2rem small breakpoints
   }
 }
 

--- a/components/04-page-layouts/page-layouts.scss
+++ b/components/04-page-layouts/page-layouts.scss
@@ -31,12 +31,12 @@ body[data-body-frozen] {
 // it and the site header (size-spacing-6 and 9 below) - unless it is designated
 // as `$flush-top` above. Then it will have no top-margin separating it from the
 // site header.
-.main-content > *:first-child:not(.page-meta, .layout--banner) {
+.main-content > *:first-child:not(.layout--banner) {
   margin-top: var(--main-content-top-margin, var(--size-spacing-6));
 }
 
 .main-content .page-title:not(.visually-hidden) {
-  margin-top: var(--size-spacing-10); // 4rem
+  margin-top: var(--size-spacing-0); // 4rem
 
   @media (max-width: tokens.$break-l) {
     margin-top: var(--size-spacing-8); // 2.5rem large breakpoints
@@ -50,8 +50,10 @@ body[data-body-frozen] {
 // Subtract to have a negative numbers so that the margin-top of the page
 // title does not affect the spacing when there are breadcrumbs.
 .main-content .breadcrumbs__wrapper {
+  margin-top: var(--main-content-top-margin, var(--size-spacing-6));
+
   // Subtract 2rem to the 4rem
-  margin-bottom: calc(var(--size-spacing-7) - var(--size-spacing-10));
+  margin-bottom: var(--size-spacing-0);
 
   // Subtract 1.5rem to the 2.5rem
   @media (max-width: tokens.$break-l) {


### PR DESCRIPTION
## [YSP-803: Reduce Excessive Padding Between Breadcrumbs and Banner Blocks](https://yaleits.atlassian.net/browse/YSP-803)

### Description of work
- Adjusts css for layout--banner content, breadcrumbs, and title
- Remove two-column top margin on first element in the 70%

### Testing Link(s)
- [ ] Navigate to the [Layout Story](https://deploy-preview-500--dev-component-library-twig.netlify.app/?path=/story/page-layouts-page-layouts--full-width)
- [ ] Navigate to the [Event Page Story](https://deploy-preview-500--dev-component-library-twig.netlify.app/?path=/story/page-examples-events--event-page)
- [ ] Navigate to the [Profile Page Story](https://deploy-preview-500--dev-component-library-twig.netlify.app/?path=/story/page-examples-profiles--profile-page)
- [ ] Navigate to the [Standard Pages Story](https://deploy-preview-500--dev-component-library-twig.netlify.app/?path=/story/page-examples-standard-pages--basic)
- [ ] Navigate to the [Post Story](https://deploy-preview-500--dev-component-library-twig.netlify.app/?path=/story/page-examples-post--post-article)

### Functional Review Steps
- [ ] Verify that the spacing in these scenarios are appropriate and consistent

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
