### PR TITLE
YSP-882: Quote styling doesn't adapt to section background colors

### DIFF
--- a/components/02-molecules/pull-quote/_yds-pull-quote.scss
+++ b/components/02-molecules/pull-quote/_yds-pull-quote.scss
@@ -59,7 +59,7 @@ blockquote {
   // Component theme overrides: set specific component themes overrides
   /// define component name spaced variables and map them to global theme slots.
   &[data-component-theme='one'] {
-    --color-pull-quote-accent: var(--color-slot-one);
+    --color-pull-quote-accent: var(--color-slot-two);
   }
 
   &[data-component-theme='two'] {

--- a/components/02-molecules/pull-quote/_yds-pull-quote.scss
+++ b/components/02-molecules/pull-quote/_yds-pull-quote.scss
@@ -60,10 +60,6 @@ blockquote {
   /// define component name spaced variables and map them to global theme slots.
   &[data-component-theme='one'] {
     --color-pull-quote-accent: var(--color-slot-one);
-
-    .yds-layout[data-component-theme='one'] & {
-      --color-pull-quote-accent: var(--color-slot-two);
-    }
   }
 
   &[data-component-theme='two'] {
@@ -81,6 +77,12 @@ blockquote {
     & {
     --color-pull-quote-quote: var(--color-basic-white);
     --color-pull-quote-attribution: var(--color-basic-white);
+  }
+
+  // If the yds-layout theme is not default, we assume we are inside of a
+  // colored layout, and so we match the layout border.
+  .yds-layout:not([data-component-theme='default']) & {
+    --color-pull-quote-accent: var(--color-layout-border);
   }
 }
 

--- a/components/02-molecules/pull-quote/_yds-pull-quote.scss
+++ b/components/02-molecules/pull-quote/_yds-pull-quote.scss
@@ -59,7 +59,11 @@ blockquote {
   // Component theme overrides: set specific component themes overrides
   /// define component name spaced variables and map them to global theme slots.
   &[data-component-theme='one'] {
-    --color-pull-quote-accent: var(--color-slot-two);
+    --color-pull-quote-accent: var(--color-slot-one);
+
+    .yds-layout[data-component-theme='one'] & {
+      --color-pull-quote-accent: var(--color-slot-two);
+    }
   }
 
   &[data-component-theme='two'] {

--- a/components/02-molecules/pull-quote/pull-quote.stories.js
+++ b/components/02-molecules/pull-quote/pull-quote.stories.js
@@ -21,16 +21,17 @@ export default {
       options: ['bar-left', 'bar-right', 'quote-left'],
       type: 'select',
     },
-    accentColor: {
-      name: 'Component Theme (dial)',
-      options: ['one', 'two', 'three'],
-      type: 'select',
-    },
     sectionTheme: {
       name: 'Section Theme',
       type: 'select',
       options: ['default', 'one', 'two', 'three', 'four'],
       control: { type: 'select' },
+    },
+    accentColor: {
+      name: 'Component Theme (dial)',
+      options: ['one', 'two', 'three'],
+      type: 'select',
+      if: { arg: 'sectionTheme', eq: 'default' },
     },
   },
   args: {


### PR DESCRIPTION
## [YSP-882: Quote styling doesn't adapt to section background colors](https://yaleits.atlassian.net/browse/YSP-882)

### Description of work
- Updated the accent color for the 'one' theme in the pull-quote component to use `--color-slot-two` instead of `--color-slot-one` only when inside of section layout `one`. This allows the same color to not be on top of each other.

### Testing Link(s)
- [ ] Navigate to the [Pull Quote Story](https://deploy-preview-501--dev-component-library-twig.netlify.app/?path=/story/molecules-quotes-pull-quote--pull-quote)
- [ ] Navigate to the [Drupal Multidev](https://github.com/yalesites-org/yalesites-project/pull/941)

### Functional Review Steps
- [ ] Verify the accept component/section themes display don't appear with the same color (hiding the accent color) in storybook
- [ ] Verify the same is true in a YaleSite using the multidev

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
