### PR TITLE
YSP-874: Quote Block 'Bar Right' Style Alignment Issues in Narrow Sections

### DIFF
--- a/components/02-molecules/pull-quote/_yds-pull-quote.scss
+++ b/components/02-molecules/pull-quote/_yds-pull-quote.scss
@@ -113,6 +113,10 @@ blockquote {
 
     @media (min-width: tokens.$break-mobile) {
       margin-left: 9rem;
+
+      .yds-two-column & {
+        margin-left: 0;
+      }
     }
 
     &::before {


### PR DESCRIPTION
## [YSP-874: Quote Block 'Bar Right' Style Alignment Issues in Narrow Sections](https://yaleits.atlassian.net/browse/YSP-874)

### Description of work
- Added a specific rule to reset the left margin to 0rem for pull quotes inside the `.yds-two-column` container. This ensures proper alignment in two-column layouts while maintaining the default margin elsewhere.

### Testing Link(s)
- [ ] Navigate to the [Pull Quote Story](https://deploy-preview-502--dev-component-library-twig.netlify.app/?path=/story/molecules-quotes-pull-quote--pull-quote)

### Functional Review Steps
- [ ] Use the [multidev](https://github.com/yalesites-org/yalesites-project/pull/946) to test it in Drupal
- [ ] Create each type of section on a page, and add a pull quote with a right bar set
- [ ] Ensure that no bleeding along the right bar happens and that it looks acceptable
- [ ] Note: Since this is related to the 70/30, no Storybook instance is there to test.  We can change that if needed.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
