### PR TITLE
YSP-863 :: Add Section Padding Options

### DIFF
--- a/components/03-organisms/layout/layout.stories.js
+++ b/components/03-organisms/layout/layout.stories.js
@@ -30,6 +30,17 @@ export default {
       options: ['fifty-fifty', 'thirty-thirty-thirty', 'seventy-thirty'],
       control: { type: 'select' },
     },
+    layoutPadding: {
+      name: 'Padding',
+      type: 'select',
+      options: {
+        'Default (current padding)': 'default',
+        'No top padding': 'no-top',
+        'No bottom padding': 'no-bottom',
+        'No padding (top and bottom)': 'no-padding',
+      },
+      control: { type: 'select' },
+    },
     theme: {
       name: 'Component Theme',
       type: 'select',
@@ -40,17 +51,19 @@ export default {
   args: {
     divider: false,
     layoutOption: 'fifty-fifty',
+    layoutPadding: 'default',
     theme: 'default',
   },
 };
 
 export const TwoColumn = () => twoColumnTwig(textData);
-export const layout = ({ divider, theme, layoutOption }) =>
+export const layout = ({ divider, theme, layoutOption, layoutPadding }) =>
   layoutTwig({
     ...textData,
     ...accordionData,
     ...imageData.responsive_images['4x3'],
     layout__divider: divider ? 'true' : 'false',
+    layout__padding: layoutPadding,
     component__theme: theme,
     component__layout: layoutOption,
   });

--- a/components/03-organisms/layout/layout/_yds-layout.scss
+++ b/components/03-organisms/layout/layout/_yds-layout.scss
@@ -140,6 +140,16 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
     margin-bottom: var(--size-spacing-10);
   }
 
+  &[data-component-padding='no-top'],
+  &[data-component-padding='no-padding'] {
+    margin-top: 0;
+  }
+
+  &[data-component-padding='no-bottom'],
+  &[data-component-padding='no-padding'] {
+    margin-bottom: 0;
+  }
+
   // Styles applied only if the HTML element has the 'yds-storybook-cl' class  html:has(.yds-storybook-cl) &,
   html:has(.yds-storybook-cl) & {
     margin-block: 0;
@@ -149,6 +159,16 @@ $break-layout-layout-max: $break-layout-layout - 0.05;
 .yds-layout__inner {
   padding-block-start: var(--size-spacing-10);
   padding-block-end: var(--size-spacing-10);
+
+  [data-component-padding='no-top'] > &,
+  [data-component-padding='no-padding'] > & {
+    padding-block-start: 0;
+  }
+
+  [data-component-padding='no-bottom'] > &,
+  [data-component-padding='no-padding'] > & {
+    padding-block-end: 0;
+  }
 
   @media (min-width: $break-layout-layout) {
     display: flex;

--- a/components/03-organisms/layout/layout/yds-layout.twig
+++ b/components/03-organisms/layout/layout/yds-layout.twig
@@ -15,6 +15,7 @@
 
 {% set layout__attributes = {
   'data-component-has-divider': layout__divider == 'true' ? 'true' : 'false',
+  'data-component-padding': layout__padding|default('default'),
   'data-component-theme': component__theme|default('default'),
   'data-component-layout': component__layout|default('fifty-fifty'),
   'data-component-width': component__width|default('site'),

--- a/components/03-organisms/layout/two-column/_yds-two-column.scss
+++ b/components/03-organisms/layout/two-column/_yds-two-column.scss
@@ -5,6 +5,16 @@ $break-layout-two-column-max: $break-layout-two-column - 0.05;
 
 .yds-two-column {
   @include tokens.spacing-page-section;
+
+  &[data-component-padding='no-top'],
+  &[data-component-padding='no-padding'] {
+    margin-top: 0;
+  }
+
+  &[data-component-padding='no-bottom'],
+  &[data-component-padding='no-padding'] {
+    margin-bottom: 0;
+  }
 }
 
 .yds-two-column__inner {


### PR DESCRIPTION
## [YSP-863: Add Section Padding Options](https://yaleits.atlassian.net/browse/YSB-863)

### Description of work
- Implement padding_options for layout component

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-503--dev-component-library-twig.netlify.app/?path=/story/organisms-layouts--layout&args=divider:!true;layoutPadding:no-top;theme:three)

### Work also done at:
- [Yalesites Project](https://github.com/yalesites-org/yalesites-project/pull/938)
