### PR TITLE
IYY-385 :: Table stylign in two columns with a background color

### DIFF
--- a/components/01-atoms/tables/_table.scss
+++ b/components/01-atoms/tables/_table.scss
@@ -15,7 +15,16 @@ table {
   --header-cell-bg: var(--color-gray-200);
   --header-row-bg: var(--color-gray-200);
 
-  [data-component-theme]:not([data-component-theme='default']) & {
+  [data-component-theme='two'] & {
+    --header-cell-border: var(--color-gray-600);
+    --header-row-border: var(--color-gray-500);
+  }
+
+  [data-component-theme]:not(
+      [data-component-theme='default'],
+      [data-component-theme='two']
+    )
+    & {
     --header-cell-border: var(--color-gray-200);
     --header-row-border: var(--color-gray-400);
   }
@@ -88,7 +97,7 @@ th {
       bottom: -1px;
       left: 0;
       right: 0;
-      height: var(--size-thickness-2);
+      height: var(--size-thickness-1);
       background-color: var(--header-cell-border);
     }
 

--- a/components/01-atoms/tables/_table.scss
+++ b/components/01-atoms/tables/_table.scss
@@ -79,9 +79,33 @@ th {
   }
 
   tbody & {
-    left: 0;
-    border-right: var(--size-thickness-2) solid var(--header-cell-border);
-    border-bottom-color: var(--header-row-border);
+    left: -1px;
+    border-bottom: none;
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: -1px;
+      left: 0;
+      right: 0;
+      height: var(--size-thickness-2);
+      background-color: var(--header-cell-border);
+    }
+
+    &::before {
+      content: '';
+      position: absolute;
+      bottom: -1px;
+      right: -1px;
+      width: var(--size-thickness-2);
+      height: calc(100% + #{var(--size-thickness-2)});
+      background-color: var(--header-cell-border);
+    }
+  }
+
+  table:has(tbody th) thead &:first-child,
+  tbody tr:last-child &:first-child {
+    border-bottom: var(--size-thickness-1) solid var(--header-cell-border);
   }
 }
 

--- a/components/01-atoms/tables/_table.scss
+++ b/components/01-atoms/tables/_table.scss
@@ -3,10 +3,22 @@
 table {
   @include tokens.body-s-condensed;
 
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
   caption-side: bottom;
   border-collapse: collapse;
   text-align: left;
-  width: 100%;
+
+  --header-cell-border: var(--color-gray-700);
+  --header-row-border: var(--color-gray-300);
+  --header-cell-bg: var(--color-gray-200);
+  --header-row-bg: var(--color-gray-200);
+
+  [data-component-theme]:not([data-component-theme='default']) & {
+    --header-cell-border: var(--color-gray-200);
+    --header-row-border: var(--color-gray-400);
+  }
 }
 
 .table-wrapper {
@@ -18,31 +30,9 @@ table caption {
   margin-top: var(--size-spacing-4);
 }
 
-tr:nth-child(even) {
-  background-color: var(--color-gray-100);
-}
-
-th {
-  background-color: var(--color-gray-200);
-  padding: var(--size-spacing-3) var(--size-spacing-5);
-  font-weight: var(--font-weights-mallory-medium);
-  border: var(--size-thickness-1) solid var(--color-gray-200);
-  position: sticky;
-
-  thead & {
-    top: 0;
-    border-bottom: var(--size-thickness-2) solid var(--color-gray-700);
-  }
-
-  tbody & {
-    left: 0;
-    border-right: var(--size-thickness-2) solid var(--color-gray-700);
-  }
-}
-
 td {
   padding: var(--size-spacing-3) var(--size-spacing-5);
-  border: var(--size-thickness-1) solid var(--color-gray-300);
+  border: var(--size-thickness-1) solid var(--header-row-border);
   min-width: 8rem;
 
   &:first-child {
@@ -52,8 +42,51 @@ td {
   &:last-child {
     border-right: none;
   }
+}
 
-  tbody tr:last-child & {
-    border-bottom: var(--size-thickness-2) solid var(--color-gray-700);
+tr {
+  color: var(--color-gray-700);
+  background-color: transparent;
+
+  &:nth-child(even) td {
+    background-color: var(--header-row-bg);
   }
+
+  [data-component-theme]:not(
+      [data-component-theme='default'],
+      [data-component-theme='two']
+    )
+    & {
+    color: var(--color-basic-white);
+  }
+
+  tbody &:last-child td {
+    border-bottom: var(--size-thickness-2) solid var(--header-cell-border);
+  }
+}
+
+th {
+  background-color: var(--header-cell-bg);
+  padding: var(--size-spacing-3) var(--size-spacing-5);
+  font-weight: var(--font-weights-mallory-medium);
+  border: var(--size-thickness-1) solid var(--header-cell-border);
+  position: sticky;
+  color: inherit;
+
+  thead & {
+    top: 0;
+    border-bottom: var(--size-thickness-2) solid var(--header-cell-border);
+  }
+
+  tbody & {
+    left: 0;
+    border-right: var(--size-thickness-2) solid var(--header-cell-border);
+    border-bottom-color: var(--header-row-border);
+  }
+}
+
+.gin--dark-mode .table-wrapper tr:hover,
+.gin--dark-mode .table-wrapper tr:focus-within {
+  background: unset;
+  color: unset;
 }

--- a/components/01-atoms/tables/example-tables.twig
+++ b/components/01-atoms/tables/example-tables.twig
@@ -44,11 +44,11 @@
 <h2>Table with Column and Row Headers</h2>
 
 {% set table_with_column_and_row_headers %}
-  <div class="table-wrapper">
+  <div class="table-wrapper" tabindex="0">
     <table>
       <thead>
         <tr>
-          <th></th>
+          <th>-</th>
           <th>2020</th>
           <th>2021</th>
           <th>2022</th>

--- a/components/01-atoms/tables/example-tables.twig
+++ b/components/01-atoms/tables/example-tables.twig
@@ -1,38 +1,40 @@
 <h2>Table with Column Headers</h2>
 
 {% set table_with_column_headers %}
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Email</th>
-        <th>Phone Number</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Deanna Curtis</td>
-        <td>deanna.curtis@example.com</td>
-        <td>(316) 555-0116</td>
-      </tr>
-      <tr>
-        <td>Jessica Hanson</td>
-        <td>jessica.hanson@example.com</td>
-        <td>(208) 555-0112</td>
-      </tr>
-      <tr>
-        <td>Michelle Rivera</td>
-        <td>michelle.rivera@example.com</td>
-        <td>(219) 555-0114</td>
-      </tr>
-      <tr>
-        <td>Nathan Roberts</td>
-        <td>nathan.roberts@exxample.com</td>
-        <td>(229) 555-0109</td>
-      </tr>
-    </tbody>
-    <caption>Optional caption for the table here.</caption>
-  </table>
+  <div class="table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Phone Number</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Deanna Curtis</td>
+          <td>deanna.curtis@example.com</td>
+          <td>(316) 555-0116</td>
+        </tr>
+        <tr>
+          <td>Jessica Hanson</td>
+          <td>jessica.hanson@example.com</td>
+          <td>(208) 555-0112</td>
+        </tr>
+        <tr>
+          <td>Michelle Rivera</td>
+          <td>michelle.rivera@example.com</td>
+          <td>(219) 555-0114</td>
+        </tr>
+        <tr>
+          <td>Nathan Roberts</td>
+          <td>nathan.roberts@exxample.com</td>
+          <td>(229) 555-0109</td>
+        </tr>
+      </tbody>
+      <caption>Optional caption for the table here.</caption>
+    </table>
+  </div>
 {% endset %}
 
 {% include "@molecules/text/yds-text-field.twig" with {
@@ -42,78 +44,80 @@
 <h2>Table with Column and Row Headers</h2>
 
 {% set table_with_column_and_row_headers %}
-  <table>
-    <thead>
-      <tr>
-        <th></th>
-        <th>2020</th>
-        <th>2021</th>
-        <th>2022</th>
-        <th>2022</th>
-        <th>2022</th>
-        <th>2022</th>
-        <th>2022</th>
-        <th>2022</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th>Freshman</th>
-        <td>130</td>
-        <td>556</td>
-        <td>here's some long text, it's really long</td>
-        <td>here's some long text, it's really long</td>
-        <td>here's some long text, it's really long</td>
-        <td>here's some long text, it's really long</td>
-        <td>here's some long text, it's really long</td>
-        <td>here's some long text, it's really long</td>
-      </tr>
-      <tr>
-        <th>Sophomore</th>
-        <td>703</td>
-        <td>740</td>
-        <td>798</td>
-        <td>798</td>
-        <td>798</td>
-        <td>798</td>
-        <td>798</td>
-        <td>798</td>
-      </tr>
-      <tr>
-        <th>Junior</th>
-        <td>423</td>
-        <td>922</td>
-        <td>453</td>
-        <td>453</td>
-        <td>453</td>
-        <td>453</td>
-        <td>453</td>
-        <td>453</td>
-      </tr>
-      <tr>
-        <th>Senior</th>
-        <td>647</td>
-        <td>877</td>
-        <td>583</td>
-        <td>583</td>
-        <td>583</td>
-        <td>583</td>
-        <td>583</td>
-        <td>583</td>
-      </tr>
-      <tr>
-        <th>Graduate</th>
-        <td>357</td>
-        <td>826</td>
-        <td>492</td>
-        <td>492</td>
-        <td>492</td>
-        <td>492</td>
-        <td>492</td>
-        <td>492</td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>2020</th>
+          <th>2021</th>
+          <th>2022</th>
+          <th>2022</th>
+          <th>2022</th>
+          <th>2022</th>
+          <th>2022</th>
+          <th>2022</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th>Freshman</th>
+          <td>130</td>
+          <td>556</td>
+          <td>here's some long text, it's really long</td>
+          <td>here's some long text, it's really long</td>
+          <td>here's some long text, it's really long</td>
+          <td>here's some long text, it's really long</td>
+          <td>here's some long text, it's really long</td>
+          <td>here's some long text, it's really long</td>
+        </tr>
+        <tr>
+          <th>Sophomore</th>
+          <td>703</td>
+          <td>740</td>
+          <td>798</td>
+          <td>798</td>
+          <td>798</td>
+          <td>798</td>
+          <td>798</td>
+          <td>798</td>
+        </tr>
+        <tr>
+          <th>Junior</th>
+          <td>423</td>
+          <td>922</td>
+          <td>453</td>
+          <td>453</td>
+          <td>453</td>
+          <td>453</td>
+          <td>453</td>
+          <td>453</td>
+        </tr>
+        <tr>
+          <th>Senior</th>
+          <td>647</td>
+          <td>877</td>
+          <td>583</td>
+          <td>583</td>
+          <td>583</td>
+          <td>583</td>
+          <td>583</td>
+          <td>583</td>
+        </tr>
+        <tr>
+          <th>Graduate</th>
+          <td>357</td>
+          <td>826</td>
+          <td>492</td>
+          <td>492</td>
+          <td>492</td>
+          <td>492</td>
+          <td>492</td>
+          <td>492</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 {% endset %}
 
 {% include "@molecules/text/yds-text-field.twig" with {

--- a/components/01-atoms/tables/table.js
+++ b/components/01-atoms/tables/table.js
@@ -1,0 +1,35 @@
+Drupal.behaviors.table = {
+  attach(context) {
+    // Selectors
+    const items = context.querySelectorAll(
+      '[data-component-theme] .table-wrapper',
+    );
+
+    const filtered = Array.from(items).filter((el) => {
+      const theme = el
+        .closest('[data-component-theme]')
+        ?.getAttribute('data-component-theme');
+      return theme !== 'default';
+    });
+
+    function darkenRgb(rgbString, factor) {
+      const rgbMatch = rgbString.match(/\d+/g);
+      if (!rgbMatch) return rgbString;
+
+      const [r, g, b] = rgbMatch.map(Number);
+      const darken = (val) => Math.max(0, Math.floor(val * factor));
+
+      return `rgb(${darken(r)}, ${darken(g)}, ${darken(b)})`;
+    }
+
+    filtered.forEach((item) => {
+      const layout = item.closest('[data-component-theme]');
+      const styles = window.getComputedStyle(layout);
+      const table = item.querySelector('table');
+      const bg = styles.backgroundColor;
+
+      table.style.setProperty('--header-cell-bg', darkenRgb(bg, 0.6));
+      table.style.setProperty('--header-row-bg', darkenRgb(bg, 0.7));
+    });
+  },
+};

--- a/components/01-atoms/tables/table.js
+++ b/components/01-atoms/tables/table.js
@@ -28,8 +28,15 @@ Drupal.behaviors.table = {
       const table = item.querySelector('table');
       const bg = styles.backgroundColor;
 
-      table.style.setProperty('--header-cell-bg', darkenRgb(bg, 0.6));
-      table.style.setProperty('--header-row-bg', darkenRgb(bg, 0.7));
+      const { componentTheme } = layout.dataset;
+
+      if (componentTheme !== 'two') {
+        table.style.setProperty('--header-cell-bg', darkenRgb(bg, 0.6));
+        table.style.setProperty('--header-row-bg', darkenRgb(bg, 0.7));
+      } else {
+        table.style.setProperty('--header-cell-bg', darkenRgb(bg, 0.9));
+        table.style.setProperty('--header-row-bg', darkenRgb(bg, 0.9));
+      }
     });
   },
 };

--- a/components/01-atoms/tables/table.stories.js
+++ b/components/01-atoms/tables/table.stories.js
@@ -1,9 +1,35 @@
 // Markup.
 import tableTwig from './example-tables.twig';
 
+import './table';
+
 /**
  * Storybook Definition.
  */
-export default { title: 'Atoms/Table' };
+export default {
+  title: 'Atoms/Table',
+  argTypes: {
+    sectionTheme: {
+      name: 'Section Theme',
+      type: 'select',
+      options: ['default', 'one', 'two', 'three', 'four'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    sectionTheme: 'default',
+  },
+};
 
-export const Table = () => tableTwig();
+export const Table = ({ sectionTheme }) => `
+  ${tableTwig()}
+  <div data-component-has-divider="false" data-component-theme="${sectionTheme}" data-component-width="site" class="yds-layout" data-embedded-components="" data-spotlights-position="first">
+    <div class="yds-layout__inner">
+      <div class="yds-layout__primary">
+        <h2>Playground</h2>
+        <p>Use the StoryBook controls to see the table below implement the available variations and colors.</p>
+        ${tableTwig()}
+      </div>
+    </div>
+  </div>
+`;


### PR DESCRIPTION
## [YALB-385: Table stylign in two columns with a background color](https://app.clickup.com/t/36718269/IYY-385)

### Description of work
- Applies styling to a table within a section that has a background.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-505--dev-component-library-twig.netlify.app/?path=/story/atoms-table--table&args=sectionTheme:four&globals=globalTheme:two)
- [ ] Scroll down to the Playground section and try out different global and section colors to see how they behave in various scenarios.

<img width="1511" alt="Screenshot 2025-04-25 at 11 56 42 AM" src="https://github.com/user-attachments/assets/0f5fb1d7-d801-4a11-8bac-3942d12b211c" />

### Work also done at:
- [Atomic](https://github.com/yalesites-org/atomic/pull/347)