### PR TITLE
YSP-875: Text: Tables in a section have a color contrast issue

### DIFF
--- a/components/01-atoms/tables/_table.scss
+++ b/components/01-atoms/tables/_table.scss
@@ -20,10 +20,12 @@ table caption {
 
 tr:nth-child(even) {
   background-color: var(--color-gray-100);
+  color: var(--color-basic-black);
 }
 
 th {
   background-color: var(--color-gray-200);
+  color: var(--color-basic-black);
   padding: var(--size-spacing-3) var(--size-spacing-5);
   font-weight: var(--font-weights-mallory-medium);
   border: var(--size-thickness-1) solid var(--color-gray-200);


### PR DESCRIPTION
## [YSP-875: Text: Tables in a section have a color contrast issue](https://yaleits.atlassian.net/browse/YSP-875)

### Other related PRs
- [Atomic](https://github.com/yalesites-org/atomic/pull/346)
- [Multidev](https://github.com/yalesites-org/yalesites-project/pull/952)

### Description of work
- Added text color for table rows and headers to enhance readability. The changes include:
  - Setting text color to black for even rows.
  - Setting text color to black for table headers.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
