### PR TITLE
YSP-892: Design treatment for active Content Collect parent menu items

### DIFF
--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -356,12 +356,8 @@ $secondary-menu-sub-max-width: 19rem;
 
       &:has([class$='nav__item--active'])
         button.secondary-nav__toggle--with-sub {
-        font-weight: var(--font-weights-yalenew-bold);
-
-        &[aria-expanded='false'] {
-          border-bottom: var(--border-thickness-4) solid
-            var(--color-navigation-border);
-        }
+        border-bottom: var(--border-thickness-4) solid
+          var(--color-navigation-border);
       }
     }
   }

--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -353,6 +353,12 @@ $secondary-menu-sub-max-width: 19rem;
         flex-shrink: 0;
         display: flex;
       }
+
+      &:has([class$='nav__item--active'])
+        button.secondary-nav__toggle--with-sub {
+        border-bottom: var(--border-thickness-4) solid
+          var(--color-navigation-border);
+      }
     }
   }
 
@@ -519,8 +525,13 @@ $secondary-menu-sub-max-width: 19rem;
 // Active trail styles.
 .secondary-nav__link.secondary-nav__link--active {
   color: var(--menu-link-color);
-  text-decoration: underline;
   text-decoration-thickness: var(--border-thickness-2);
+
+  &.secondary-nav__link--level-0 {
+    // Provide underline treatment on the border instead of on the link.
+    border-bottom: var(--border-thickness-4) solid
+      var(--color-navigation-border);
+  }
 }
 
 .secondary-nav__link:not(

--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -334,7 +334,7 @@ $secondary-menu-sub-max-width: 19rem;
         var(--color-navigation-border);
       border-right: var(--border-thickness-1) solid
         var(--color-navigation-border);
-      border-bottom: var(--border-thickness-4) solid
+      border-bottom: var(--border-thickness-1) solid
         var(--color-navigation-border);
     }
 

--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -353,12 +353,6 @@ $secondary-menu-sub-max-width: 19rem;
         flex-shrink: 0;
         display: flex;
       }
-
-      &:has([class$='nav__item--active'])
-        button.secondary-nav__toggle--with-sub {
-        border-bottom: var(--border-thickness-4) solid
-          var(--color-navigation-border);
-      }
     }
   }
 
@@ -525,13 +519,8 @@ $secondary-menu-sub-max-width: 19rem;
 // Active trail styles.
 .secondary-nav__link.secondary-nav__link--active {
   color: var(--menu-link-color);
+  text-decoration: underline;
   text-decoration-thickness: var(--border-thickness-2);
-
-  &.secondary-nav__link--level-0 {
-    // Provide underline treatment on the border instead of on the link.
-    border-bottom: var(--border-thickness-4) solid
-      var(--color-navigation-border);
-  }
 }
 
 .secondary-nav__link:not(

--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -356,8 +356,12 @@ $secondary-menu-sub-max-width: 19rem;
 
       &:has([class$='nav__item--active'])
         button.secondary-nav__toggle--with-sub {
-        border-bottom: var(--border-thickness-4) solid
-          var(--color-navigation-border);
+        font-weight: var(--font-weights-yalenew-bold);
+
+        &[aria-expanded='false'] {
+          border-bottom: var(--border-thickness-4) solid
+            var(--color-navigation-border);
+        }
       }
     }
   }

--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -348,6 +348,17 @@ $secondary-menu-sub-max-width: 19rem;
   &--level-0 {
     @include tokens.body-s;
 
+    &:has(.secondary-nav__item--active),
+    &.secondary-nav__item--active {
+      border-bottom: var(--border-thickness-2) solid
+        var(--color-navigation-border);
+
+      & button,
+      & a.secondary-nav__link--active {
+        font-weight: var(--font-weights-yalenew-bold);
+      }
+    }
+
     .in-this-section & {
       @media (min-width: tokens.$break-mobile) {
         flex-shrink: 0;


### PR DESCRIPTION
## [YSP-892: Design treatment for active Content Collect parent menu items](https://yaleits.atlassian.net/browse/YSP-892)

### Description of work
- Added styles to target elements with class ending in `nav__item--active`.
- Updated `secondary-nav__toggle--with-sub` to include a border-bottom when its parent contains an active nav item.
- Adjusted `secondary-nav__link--level-0` to use border-bottom for underline treatment instead of text-decoration.

### Testing Link(s)
- [ ] Navigate to the [In this Section Story](https://deploy-preview-507--dev-component-library-twig.netlify.app/?path=/story/organisms-site-in-this-section--site-section)

### Functional Review Steps
- [ ] Verify that you see two active top level section links decorated by a border line below it
- [ ] Test this [in Drupal](https://github.com/yalesites-org/yalesites-project/pull/954)

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
