### PR TITLE
YSP-896: Accessibility: Secondary scroll arrows unlabeled

### DIFF
--- a/components/03-organisms/site-in-this-section/yds-site-in-this-section.twig
+++ b/components/03-organisms/site-in-this-section/yds-site-in-this-section.twig
@@ -59,8 +59,7 @@
       control__blockname: site_section_wrap__base_class,
       control__modifiers: ['left'],
       control__attributes: {
-        'aria-hidden': 'true',
-        'tabindex': '-1',
+        'aria-label': 'Show more navigation items',
       },
     } %}
     {% include "@atoms/controls/base/yds-control.twig" with {
@@ -69,8 +68,7 @@
       control__blockname: site_section_wrap__base_class,
       control__modifiers: ['right'],
       control__attributes: {
-        'aria-hidden': 'true',
-        'tabindex': '-1',
+        'aria-label': 'Show more navigation items',
       },
     } %}
   </div>


### PR DESCRIPTION
## [YSP-896: Accessibility: Secondary scroll arrows unlabeled](https://yaleits.atlassian.net/browse/YSP-896)

### Description of work
- Replace 'aria-hidden' and 'tabindex' attributes with 'aria-label' to enhance accessibility for navigation controls.

### Testing Link(s)
- [ ] Navigate to the [Section Story](https://deploy-preview-508--dev-component-library-twig.netlify.app/?path=/story/organisms-site-in-this-section--site-section)
- [ ] Navigate to the [Page Examples / Standard Pages](https://yalesites-org.github.io/component-library-twig/?path=/story/page-examples-standard-pages--basic-short)
- [ ] Navigate to the [Multidev PR](https://github.com/yalesites-org/yalesites-project/pull/957) to test in Drupal

### Functional Review Steps
- [x] Verify functionality remains the same as the published versions:
  - [x] [Published Site in the Section version](https://yalesites-org.github.io/component-library-twig/?path=/story/organisms-site-in-this-section--site-section)
  - [x] [Published Standard Pages](https://yalesites-org.github.io/component-library-twig/?path=/story/page-examples-standard-pages--basic-short)
- [ ] Test this in Drupal by creating a content collection and visiting one of the pages

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
