### PR TITLE
YSP-892: Design treatment for active Content Collection parent menu items and location move

### DIFF
--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -182,6 +182,10 @@ $secondary-menu-sub-max-width: 19rem;
         margin-top: var(--size-spacing-3);
       }
     }
+
+    // & ul:first-of-type {
+    //   margin-left: calc(var(--size-spacing-5) * -1);
+    // }
   }
 }
 
@@ -350,9 +354,6 @@ $secondary-menu-sub-max-width: 19rem;
 
     &:has(.secondary-nav__item--active),
     &.secondary-nav__item--active {
-      border-bottom: var(--border-thickness-2) solid
-        var(--color-navigation-border);
-
       & button,
       & a.secondary-nav__link--active {
         font-weight: var(--font-weights-yalenew-bold);

--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -182,10 +182,6 @@ $secondary-menu-sub-max-width: 19rem;
         margin-top: var(--size-spacing-3);
       }
     }
-
-    // & ul:first-of-type {
-    //   margin-left: calc(var(--size-spacing-5) * -1);
-    // }
   }
 }
 

--- a/components/03-organisms/site-in-this-section/_site-in-this-section.scss
+++ b/components/03-organisms/site-in-this-section/_site-in-this-section.scss
@@ -165,6 +165,10 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
     border-bottom: var(--border-thickness-1) solid
       var(--color-navigation-border);
   }
+
+  & .secondary-nav__menu--level-0:first-of-type {
+    margin-left: calc(var(--size-spacing-5) * -1);
+  }
 }
 
 .in-this-section__control {

--- a/components/03-organisms/site-in-this-section/yds-site-in-this-section.js
+++ b/components/03-organisms/site-in-this-section/yds-site-in-this-section.js
@@ -29,7 +29,9 @@ Drupal.behaviors.inThisSection = {
      * overflow situation is in play.
      */
     function setOverflow() {
-      const secondaryNavLeft = secondaryNav.getBoundingClientRect().left;
+      const leftNavOffset = '16';
+      const secondaryNavLeft =
+        secondaryNav.getBoundingClientRect().left - leftNavOffset;
       const secondaryNavRight = secondaryNav.getBoundingClientRect().right;
       const firstSecondaryNavLeft = secondaryNav
         .querySelector('.secondary-nav__item--level-0:first-child')


### PR DESCRIPTION
## [YSP-892: Design treatment for active Content Collection parent menu items and location move](https://yaleits.atlassian.net/browse/YSP-892)

### Description of work
- Removes underline decoration of selected parent content collection menu item
- Left aligns content collection menu to match rest of content
- Update javascript to reflect this change in left alignment since it creates a negative margin, allowing the arrow to appear at the right time
- Work also done in [Atomic](https://github.com/yalesites-org/atomic/pull/349)

### Testing Link(s)
- [ ] Navigate to the [In This Section Story](https://deploy-preview-510--dev-component-library-twig.netlify.app/?path=/story/organisms-site-in-this-section--site-section)
- [ ] Navigate to the [Standard Basic Short Story](https://deploy-preview-510--dev-component-library-twig.netlify.app/?path=/story/page-examples-standard-pages--basic-short)
- [ ] Navigate to the [Multidev](https://github.com/yalesites-org/yalesites-project/pull/956) to test in Drupal

### Functional Review Steps
- [ ] Verify that the selected parent items are bolded
- [ ] Verify that expanding menu items looks correct
- [ ] Verify that the leftmost item looks left aligned to the line underneath it

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
