### PR TITLE
LIB: ST-Overlay-PNG

### DIFF
--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -324,3 +324,7 @@ $break-grand-hero-banner: tokens.$break-m;
   flex-flow: row wrap;
   gap: var(--size-spacing-7);
 }
+
+.grand-hero-banner__overlay-image img {
+  width: auto;
+}

--- a/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
+++ b/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
@@ -9,6 +9,7 @@
  # - grand_hero__link__content
  # - grand_hero__link__url
  # - video_background__button__background_color
+ # - grand_hero__replace_heading: Yes, No (default)
  #
  # Available Blocks:
  # - grand_hero__media
@@ -17,7 +18,7 @@
 {% set grand_hero__base_class = 'grand-hero-banner' %}
 {% set grand_hero__content__background = grand_hero__content__background|default('one') %}
 {% set grand_hero__overlay_variation = grand_hero__overlay_variation|default('contained') %}
-{% set grand_hero__display__mode = grand_hero__display__mode|default('text') %}
+{% set grand_hero__replace_heading = grand_hero__replace_heading|default('No') %}
 
 {% set grand_hero__size = grand_hero__size|default('full') %}
 
@@ -59,7 +60,7 @@
         <div {{ bem('content', [], grand_hero__base_class) }}>
           <div {{ bem('content-inner', [], grand_hero__base_class) }}>
 
-            {% if content.field_overlay_png.0['#media'] is defined and grand_hero__display__mode == 'Image' %}
+            {% if content.field_overlay_png.0['#media'] is defined and grand_hero__replace_heading == 'Yes' %}
               {% set overlay_media = content.field_overlay_png.0['#media'] %}
               {% if overlay_media.field_media_image.entity is defined %}
                 {% set overlay_url = overlay_media.field_media_image.entity.uri.value|image_style('grand_hero_overlay_image') %}
@@ -75,7 +76,7 @@
               {% endif %}
             {% endif %}
 
-            {% if grand_hero__heading is not empty and grand_hero__display__mode == 'Text' %}
+            {% if grand_hero__heading is not empty and grand_hero__replace_heading == 'No' %}
               {% include "@atoms/typography/headings/yds-heading.twig" with {
                 heading__level: grand_hero__heading__level|default('2'),
                 heading__blockname: grand_hero__base_class,

--- a/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
+++ b/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
@@ -56,7 +56,24 @@
       <div {{ bem('wrap', [], grand_hero__base_class) }}>
         <div {{ bem('content', [], grand_hero__base_class) }}>
           <div {{ bem('content-inner', [], grand_hero__base_class) }}>
-            {% if grand_hero__heading is not empty %}
+
+            {% if content.field_overlay_png.0['#media'] is defined %}
+              {% set overlay_media = content.field_overlay_png.0['#media'] %}
+              {% if overlay_media.field_media_image.entity is defined %}
+                {% set overlay_url = overlay_media.field_media_image.entity.uri.value|file_url %}
+                {% set overlay_alt = overlay_media.field_media_image.alt|default('Overlay Image') %}
+
+                <div {{ bem('overlay-image', [], grand_hero__base_class) }} style="max-width: 100%; height: auto;">
+                  {% include "@atoms/images/image/_responsive-image.twig" with {
+                    image__src: overlay_url,
+                    image__alt: overlay_alt,
+                    image__class: 'overlay-responsive-image',
+                  } %}
+                </div>
+              {% endif %}
+            {% endif %}
+
+            {% if grand_hero__heading is not empty and content.field_overlay_png.0['#media'] is not defined %}
               {% include "@atoms/typography/headings/yds-heading.twig" with {
                 heading__level: grand_hero__heading__level|default('2'),
                 heading__blockname: grand_hero__base_class,

--- a/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
+++ b/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
@@ -17,6 +17,8 @@
 {% set grand_hero__base_class = 'grand-hero-banner' %}
 {% set grand_hero__content__background = grand_hero__content__background|default('one') %}
 {% set grand_hero__overlay_variation = grand_hero__overlay_variation|default('contained') %}
+{% set grand_hero__display__mode = grand_hero__display__mode|default('text') %}
+
 {% set grand_hero__size = grand_hero__size|default('full') %}
 
 {% set grand_hero__attributes = {
@@ -57,10 +59,10 @@
         <div {{ bem('content', [], grand_hero__base_class) }}>
           <div {{ bem('content-inner', [], grand_hero__base_class) }}>
 
-            {% if content.field_overlay_png.0['#media'] is defined %}
+            {% if content.field_overlay_png.0['#media'] is defined and grand_hero__display__mode == 'Image' %}
               {% set overlay_media = content.field_overlay_png.0['#media'] %}
               {% if overlay_media.field_media_image.entity is defined %}
-                {% set overlay_url = overlay_media.field_media_image.entity.uri.value|file_url %}
+                {% set overlay_url = overlay_media.field_media_image.entity.uri.value|image_style('grand_hero_overlay_image') %}
                 {% set overlay_alt = overlay_media.field_media_image.alt|default('Overlay Image') %}
 
                 <div {{ bem('overlay-image', [], grand_hero__base_class) }}>
@@ -73,7 +75,7 @@
               {% endif %}
             {% endif %}
 
-            {% if grand_hero__heading is not empty and content.field_overlay_png.0['#media'] is not defined %}
+            {% if grand_hero__heading is not empty and grand_hero__display__mode == 'Text' %}
               {% include "@atoms/typography/headings/yds-heading.twig" with {
                 heading__level: grand_hero__heading__level|default('2'),
                 heading__blockname: grand_hero__base_class,

--- a/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
+++ b/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
@@ -63,7 +63,7 @@
                 {% set overlay_url = overlay_media.field_media_image.entity.uri.value|file_url %}
                 {% set overlay_alt = overlay_media.field_media_image.alt|default('Overlay Image') %}
 
-                <div {{ bem('overlay-image', [], grand_hero__base_class) }} style="max-width: 100%; height: auto;">
+                <div {{ bem('overlay-image', [], grand_hero__base_class) }}>
                   {% include "@atoms/images/image/_responsive-image.twig" with {
                     image__src: overlay_url,
                     image__alt: overlay_alt,

--- a/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
+++ b/components/02-molecules/banner/grand-hero/yds-grand-hero.twig
@@ -76,7 +76,7 @@
               {% endif %}
             {% endif %}
 
-            {% if grand_hero__heading is not empty and grand_hero__replace_heading == 'No' %}
+            {% if grand_hero__heading is not empty and grand_hero__replace_heading == 'No' or grand_hero__heading is not empty and grand_hero__replace_heading == 'Yes' and content.field_overlay_png.0['#media'] is not defined %}
               {% include "@atoms/typography/headings/yds-heading.twig" with {
                 heading__level: grand_hero__heading__level|default('2'),
                 heading__blockname: grand_hero__base_class,


### PR DESCRIPTION
## LIB: Overlay PNG replacing Grand Hero Heading

### Description of work
- Adds ability to replace Grand Hero heading with a PNG

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
