### PR TITLE
IYY-389 :: Content collection bottom padding

### DIFF
--- a/components/01-atoms/controls/cta/_yds-cta.scss
+++ b/components/01-atoms/controls/cta/_yds-cta.scss
@@ -374,3 +374,9 @@ $cta-outline-weights: (
     margin-bottom: 0;
   }
 }
+
+.component-wrapper--cta-group {
+  .page-meta + .layout &:first-child {
+    margin-block-start: var(--spacing-page-section);
+  }
+}

--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -163,6 +163,10 @@ $break-grand-hero-banner: tokens.$break-m;
       --color-link-visited-hover: var(--color-purple-visited-hover);
     }
   }
+
+  .page-meta + .layout &:first-child {
+    margin-block-start: var(--spacing-page-section);
+  }
 }
 
 .grand-hero-banner__image {

--- a/components/02-molecules/image/_yds-content-image.scss
+++ b/components/02-molecules/image/_yds-content-image.scss
@@ -9,4 +9,8 @@
       max-width: var(--size-component-layout-width-content);
     }
   }
+
+  .page-meta + .layout &:first-child {
+    margin-block-start: var(--spacing-page-section);
+  }
 }

--- a/components/02-molecules/inline-message/_yds-inline-message.scss
+++ b/components/02-molecules/inline-message/_yds-inline-message.scss
@@ -76,6 +76,10 @@ $component-inline-message-themes: map.deep-get(
     --color-inline-message-background: var(--color-slot-five);
     --color-inline-message-text: var(--color-slot-eight);
   }
+
+  .page-meta + .layout &:first-child {
+    margin-block-start: var(--spacing-page-section);
+  }
 }
 
 .inline-message__inner {

--- a/components/02-molecules/taxonomy-display/_yds-taxonomy-display.scss
+++ b/components/02-molecules/taxonomy-display/_yds-taxonomy-display.scss
@@ -142,6 +142,10 @@ $component-taxonomy-display-port-themes: map.deep-get(
       --color-link-visited-hover: var(--color-purple-visited-hover);
     }
   }
+
+  .page-meta + .layout &:first-child {
+    margin-block-start: var(--spacing-page-section);
+  }
 }
 
 .taxonomy-display__inner {

--- a/components/02-molecules/wrapped-callout/_yds-wrapped-callout.scss
+++ b/components/02-molecules/wrapped-callout/_yds-wrapped-callout.scss
@@ -74,6 +74,10 @@ $wrapped-callout-component-themes: map.deep-get(
   &[data-component-theme='five'] {
     --color-wrapped-callout-theme: var(--color-slot-five);
   }
+
+  .page-meta + .layout &:first-child {
+    margin-block-start: var(--spacing-page-section);
+  }
 }
 
 .wrapped-callout__content-wrapper {

--- a/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
+++ b/components/02-molecules/wrapped-image/_yds-wrapped-image.scss
@@ -26,6 +26,10 @@ $wrapped-image-offset-max: 1550px;
     padding-inline-start: 0;
     padding-inline-end: 0;
   }
+
+  .page-meta + .layout &:first-child {
+    margin-block-start: var(--spacing-page-section);
+  }
 }
 
 .wrapped-image__inner {


### PR DESCRIPTION
## [IYY-389: Content collection bottom padding](https://fourkitchens.clickup.com/t/36718269/IYY-389)

### Description of work
- Fix content collection bottom padding to reveal bottom border.

### Functional testing steps:

- [ ] Refer to the steps provided in this [PR](https://github.com/yalesites-org/yalesites-project/pull/962).

### Work also done at:
- [Atomic](https://github.com/yalesites-org/atomic/pull/351)
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/509)