### PR TITLE
YSP-912: Change default for social media sharing on Post content type

### DIFF
--- a/components/02-molecules/page-title/yds-page-title.twig
+++ b/components/02-molecules/page-title/yds-page-title.twig
@@ -4,13 +4,14 @@
  # - page_title__prefix
  # - page_title__meta (optional. Will fill in the `basic-meta` meta type.)
  # - page_title__display (optional. 'display', 'hidden', or 'visually-hidden')
+ # - page_title__show_social_media_sharing_links (optional. 'true' or 'false')
  #
  # Available Blocks
  # - page_title__meta
 #}
 
 {% set page_title__base_class = 'page-title' %}
-{% set page_title__show_social_links = page_title__show_social_links|default('false') %}
+{% set page_title__show_social_media_sharing_links = page_title__show_social_media_sharing_links|default('false') %}
 
 {% set page_title__attributes = {
   'data-component-width': page_title__width|default('site'),
@@ -48,7 +49,7 @@
         {% endif %}
       {% endblock %}
       {% block page_title__meta__extra %}{% endblock %}
-      {% if page_title__show_social_links == 'true' %}
+      {% if page_title__show_social_media_sharing_links == 'true' %}
         <div {{ bem('social-links', [], page_title__base_class) }}>
           {% block page_title__social_links %}
             {% include "@molecules/social-links/yds-social-links.twig" %}

--- a/components/05-page-examples/post/post-article.twig
+++ b/components/05-page-examples/post/post-article.twig
@@ -12,6 +12,7 @@
     } %}
     {% embed "@molecules/page-title/yds-page-title.twig" with {
         page_title__width: 'content',
+        page_title__show_social_media_sharing_links: page_title__show_social_media_sharing_links,
     }%}
       {% block page_title__meta__extra %}
         {% include "@molecules/read-time/yds-read-time.twig" with {

--- a/components/05-page-examples/post/post.stories.js
+++ b/components/05-page-examples/post/post.stories.js
@@ -54,11 +54,15 @@ export const PostArticle = ({
   footerBorderThickness = localStorage.getItem(
     'yds-cl-twig-footer-border-thickness',
   ),
+  showSocialMediaSharingLinks = false,
 }) =>
   postArticleTwig({
     site_name: siteName,
     page_title__heading: pageTitle,
     page_title__meta: meta,
+    page_title__show_social_media_sharing_links: showSocialMediaSharingLinks
+      ? 'true'
+      : 'false',
     site_animate_components: allowAnimatedItems,
     site_header__border_thickness: headerBorderThickness,
     site_header__branding_link: 'https://www.yale.edu',
@@ -88,6 +92,16 @@ export const PostArticle = ({
     ...socialLinksData,
     ...referenceCardData,
   });
+PostArticle.argTypes = {
+  showSocialMediaSharingLinks: {
+    name: 'Show Social Media Sharing Links',
+    type: 'boolean',
+    defaultValue: false,
+  },
+};
+PostArticle.args = {
+  showSocialMediaSharingLinks: false,
+};
 
 export const postGridCustom = ({
   allowAnimatedItems = localStorage.getItem('yds-cl-twig-animate-items'),


### PR DESCRIPTION
## [YSP-912: Change default for social media sharing on Post content type](https://yaleits.atlassian.net/browse/YSP-912)

### Description of work
- Renames `page_title__show_social_links` to `page_title__show_social_media_sharing_links`
- Defaults a `NULL` value of this to `FALSE`
- Add control to storybook to see the effect of changing this value
- Made appropriate [YaleSites Project](https://github.com/yalesites-org/yalesites-project/pull/971) changes to enable this to happen in Drupal

### Testing Link(s)
- [ ] Navigate to the [Post Article Story](https://deploy-preview-514--dev-component-library-twig.netlify.app/?path=/story/page-examples-post--post-article)

### Functional Review Steps
- [ ] Verify that social media links do not show
- [ ] Toggle it on via the controls
- [ ] Verify you see social media links

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
