### PR TITLE
YSP-928: Layout Builder Block Tables in Dark Mode Unreadable

### DIFF
--- a/components/01-atoms/tables/_table.scss
+++ b/components/01-atoms/tables/_table.scss
@@ -57,8 +57,14 @@ tr {
   color: var(--color-gray-700);
   background-color: transparent;
 
-  &:nth-child(even) td {
-    background-color: var(--header-row-bg);
+  tbody &:last-child td {
+    border-bottom: var(--size-thickness-2) solid var(--header-cell-border);
+  }
+
+  .yds-layout & {
+    &:nth-child(even) td {
+      background-color: var(--header-row-bg);
+    }
   }
 
   [data-component-theme]:not(
@@ -67,10 +73,6 @@ tr {
     )
     & {
     color: var(--color-basic-white);
-  }
-
-  tbody &:last-child td {
-    border-bottom: var(--size-thickness-2) solid var(--header-cell-border);
   }
 }
 

--- a/components/01-atoms/tables/_table.scss
+++ b/components/01-atoms/tables/_table.scss
@@ -54,14 +54,14 @@ td {
 }
 
 tr {
-  color: var(--color-gray-700);
-  background-color: transparent;
-
   tbody &:last-child td {
     border-bottom: var(--size-thickness-2) solid var(--header-cell-border);
   }
 
   .yds-layout & {
+    color: var(--color-gray-700);
+    background-color: transparent;
+
     &:nth-child(even) td {
       background-color: var(--header-row-bg);
     }


### PR DESCRIPTION
## [YSP-928: Layout Builder Block Tables in Dark Mode Unreadable](https://yaleits.atlassian.net/browse/YSP-928)

### Work also done in
- [ ] [Atomic](https://github.com/yalesites-org/atomic/pull/354)

While this originally worked for tables inside of sections, it did not work for layout builder tables created due to sub-item paragraphs.  This scopes it so that this still works for sections while allowing layout builder to not take on the new look.  We also adjusted this on the `move` functionality table, and made the weight link easier to read.

### Description of work
- Nested table styles under `.yds-layout` to scope specific styles.
- Removed unused dark mode hover and focus styles for `.table-wrapper`.
- Ensured consistent background and color handling for table rows.
- Ensured consistent background and color handling for `Move` table in Drupal when moving blocks
- Ensured weight toggle is easier to read when in the `Move` table

### Testing Link(s)
- [ ] Navigate to the [Table Story](https://deploy-preview-515--dev-component-library-twig.netlify.app/?path=/story/atoms-table--table)
- [ ] [Multidev](https://github.com/yalesites-org/yalesites-project/pull/973) to test layout builder tables

### Functional Review Steps
- [ ] Verify that the existing tables look fine in Storybook
- [ ] Test in both dark and light mode
- [ ] Test the [Multidev](https://github.com/yalesites-org/yalesites-project/pull/973)

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
