### PR TITLE
Hotfix: Revert "feat: ysp-738 add conditional to header component for nav dis…

### DIFF
--- a/components/03-organisms/site-header/yds-site-header.twig
+++ b/components/03-organisms/site-header/yds-site-header.twig
@@ -13,11 +13,7 @@
 
 {% set site_header__base_class = 'site-header' %}
 
-{% set site_header__hamburger = 'no' %}
-
-{% if utility_nav__items or primary_nav__items %}
-  {% set site_header__hamburger = 'yes' %}
-{% endif %}
+{% set site_header__hamburger = 'yes' %}
 
 {% set site_header__attributes = {
   'data-main-menu-state': 'loaded',


### PR DESCRIPTION
## [Hotfix: YSP-738: Revert "feat: ysp-738 add conditional to header component for nav dis…](https://yaleits.atlassian.net/browse/YSP-738)

### Description of work
- This reverts commit 5d688a1e91375138986d71ea165090ff1bfd1b3c.
- This sets the value to always show hamburger menu

It turns out we still have the issue of it always hiding only on live sites.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
