### PR TITLE
feat: ysp-741 add vh height for map embed type

### DIFF
--- a/components/02-molecules/embed/_yds-embed.scss
+++ b/components/02-molecules/embed/_yds-embed.scss
@@ -11,6 +11,7 @@
 
 $heights: (
   'form': 90vh,
+  'map': 90vh,
   'audio': 130px,
   'unknown': 70vh,
 );


### PR DESCRIPTION
## [YALB-XX: Title](https://yaleits.atlassian.net/browse/YALB-XX)

### Description of work
- Adds functionality bullet item
- Fixes this or that bullet item

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
