### PR TITLE
YSP-738: Hide hamburger menu if no nav items exist

### DIFF
--- a/components/03-organisms/site-header/yds-site-header.twig
+++ b/components/03-organisms/site-header/yds-site-header.twig
@@ -13,8 +13,6 @@
 
 {% set site_header__base_class = 'site-header' %}
 
-{% set site_header__hamburger = 'yes' %}
-
 {% set site_header__attributes = {
   'data-main-menu-state': 'loaded',
   'data-component-width': 'site',
@@ -132,9 +130,7 @@
         } %}
       {% endif %}
       {# Mobile Menu Toggle #}
-      {% if site_header__hamburger == 'yes' %}
-        {% include "@molecules/menu/menu-toggle/yds-menu-toggle.twig" %}
-      {% endif %}
+      {% include "@molecules/menu/menu-toggle/yds-menu-toggle.twig" %}
     </div>
     <div {{ bem('menu-wrapper', [], site_header__base_class) }}>
     {# If header type is simple, load the simple component #}


### PR DESCRIPTION
## [YSP-738: Hide hamburger menu if no nav items exist](https://yaleits.atlassian.net/browse/YSP-738)

### Description of work
- Remove conditional logic for displaying the mobile menu toggle in the site header. The menu toggle is now always included, simplifying the template and removing the unused `site_header__hamburger` variable.

### Testing Link(s)
- [ ] Test in [multidev](https://github.com/yalesites-org/yalesites-project/pull/981) using instructions from [Atomic](https://github.com/yalesites-org/atomic/pull/360)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
