### PR TITLE
Hotfix: YSP-951: Breadcrumbs not showing more than 2 trails levels

### DIFF
--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
@@ -12,25 +12,6 @@ import './yds-breadcrumbs';
  */
 export default {
   title: 'Organisms/Menu/Breadcrumbs',
-  argTypes: {
-    limitItems: {
-      name: 'Limit Items',
-      type: 'boolean',
-    },
-    trailLevel: {
-      name: 'Trail Level',
-      type: 'number',
-      if: {
-        arg: 'limitItems',
-        truthy: true,
-      },
-    },
-  },
-  args: {
-    limitItems: false,
-    trailLevel: 2,
-  },
 };
 
-export const Breadcrumbs = ({ trailLevel }) =>
-  breadcrumbsTwig({ ...breadcrumbsData, breadcrumbs__trail_level: trailLevel });
+export const Breadcrumbs = () => breadcrumbsTwig({ ...breadcrumbsData });

--- a/components/03-organisms/menu/breadcrumbs/yds-breadcrumbs.twig
+++ b/components/03-organisms/menu/breadcrumbs/yds-breadcrumbs.twig
@@ -32,10 +32,6 @@
   } %}
 {% endset %}
 
-{% if breadcrumbs__items.1 and breadcrumbs__trail_level %}
-  {% set breadcrumbs__items = breadcrumbs__items|slice(breadcrumbs__trail_level * -1) %}
-{% endif %}
-
 {# Only show breadbrumbs if there are two or more items. #}
 {% if breadcrumbs__items.1 or always_show_breadcrumbs %}
   <div {{ add_attributes(breadcrumbs__attributes) }}>


### PR DESCRIPTION
## [YSP-951: Breadcrumbs not showing more than 2 trails levels](https://yaleits.atlassian.net/browse/YSP-951)

### Description of work
- Removed the logic that sliced the breadcrumbs items array based on `breadcrumbs__trail_level`.
- Work also done in [Atomic](https://github.com/yalesites-org/atomic/pull/361)

### Testing Link(s)
- [ ] Navigate to the [Breadcrumb Story](https://deploy-preview-524--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-breadcrumbs--breadcrumbs)

### Functional Review Steps
- [ ] Verify all breadcrumbs show
- [ ] Test in [Drupal multidev](https://github.com/yalesites-org/yalesites-project/pull/985)

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
