### PR TITLE
YSP-1013 :: Embed: Add Blue Sky posts

### DIFF
--- a/components/02-molecules/embed/embed.stories.js
+++ b/components/02-molecules/embed/embed.stories.js
@@ -98,3 +98,7 @@ export const EmbedGoogleMaps = ({ width, type, loading }) =>
 EmbedGoogleMaps.args = {
   type: 'map',
 };
+
+export const EmbedBluesky = () => {
+  return `<blockquote class="bluesky-embed" data-bluesky-uri="at://did:plc:hptrw4dge4l5q4h5pl7wpw74/app.bsky.feed.post/3ltporonlrt2z" data-bluesky-cid="bafyreiera75ojf45nkakh3piwhu3rldjzobppl7tq3nlgsmxx5zq2msiga" data-bluesky-embed-color-mode="system"><p lang="">Congratulations to James West Davidson&#x27;s A Little History of the United States, which was listed on the New York Times Bestseller List!<br><br><a href="https://bsky.app/profile/did:plc:hptrw4dge4l5q4h5pl7wpw74/post/3ltporonlrt2z?ref_src=embed">[image or embed]</a></p>&mdash; Yale University Press (<a href="https://bsky.app/profile/did:plc:hptrw4dge4l5q4h5pl7wpw74?ref_src=embed">@yalepress.bsky.social</a>) <a href="https://bsky.app/profile/did:plc:hptrw4dge4l5q4h5pl7wpw74/post/3ltporonlrt2z?ref_src=embed">July 11, 2025 at 4:30 PM</a></blockquote><script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>`;
+};


### PR DESCRIPTION
## [YSP-1013: Embed: Add Blue Sky posts](https://yaleits.atlassian.net/browse/YSP-1013)

### Description of work
- Adds Bluesky embed to storybook

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/molecules-embed--embed-bluesky)

### Functional Review Steps
- [ ] Verify you can select and view Bluesky embed. The example Bluesky post is the one in the ticket (from Yale University Press)

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
