### PR TITLE
YSP-1073: Update Mallory heading typography styling - change weight and reduce size

### DIFF
--- a/components/00-tokens/typography/_typography.scss
+++ b/components/00-tokens/typography/_typography.scss
@@ -180,21 +180,8 @@ code {
   }
 
   body[data-font-pairing='mallory'] & {
-    @if $style == 'book' {
-      @if $level == 'h1' {
-        @include h1-mallory-compact-book;
-      } @else if $level == 'h2' {
-        @include h2-mallory-compact-book;
-      } @else if $level == 'h3' {
-        @include h3-mallory-compact-book;
-      } @else if $level == 'h4' {
-        @include h4-mallory-compact-book;
-      } @else if $level == 'h5' {
-        @include h5-mallory-compact-book;
-      } @else if $level == 'h6' {
-        @include h6-mallory-compact-book;
-      }
-    } @else {
+    @if $style == 'medium' {
+      // Original behavior: Medium weight (500) - now requires explicit 'medium' parameter
       @if $level == 'h1' {
         @include h1-mallory-compact-medium;
       } @else if $level == 'h2' {
@@ -207,6 +194,21 @@ code {
         @include h5-mallory-compact-medium;
       } @else if $level == 'h6' {
         @include h6-mallory-compact-medium;
+      }
+    } @else {
+      // New default behavior: Book weight (400) - was previously Medium weight (500)
+      @if $level == 'h1' {
+        @include h1-mallory-compact-book;
+      } @else if $level == 'h2' {
+        @include h2-mallory-compact-book;
+      } @else if $level == 'h3' {
+        @include h3-mallory-compact-book;
+      } @else if $level == 'h4' {
+        @include h4-mallory-compact-book;
+      } @else if $level == 'h5' {
+        @include h5-mallory-compact-book;
+      } @else if $level == 'h6' {
+        @include h6-mallory-compact-book;
       }
     }
   }

--- a/components/01-atoms/controls/text-link/_yds-text-link.scss
+++ b/components/01-atoms/controls/text-link/_yds-text-link.scss
@@ -193,6 +193,17 @@ $global-link-themes: map.deep-get(tokens.$tokens, 'global-themes');
     font-weight: var(--font-weights-yalenew-bold);
     letter-spacing: var(--font-letter-spacing-yalenew-bold);
 
+    // When inside headings, inherit typography from parent heading to respect font-pairing
+    h1 &,
+    h2 &,
+    h3 &,
+    h4 &,
+    h5 &,
+    h6 & {
+      font-weight: inherit;
+      letter-spacing: inherit;
+    }
+
     // adjust position so the text-shadow aligns nicely with the text.
     --position: 0 1.05em;
 


### PR DESCRIPTION
## [YSP-1073: Update Mallory heading typography styling - change weight and reduce size](https://yaleits.atlassian.net/browse/YSP-1073)

The Office of Public Affairs and Communications requested changes to Mallory heading typography to improve visual hierarchy. Updated the heading mixin to default to Book weight (400) instead of Medium weight (500) for all Mallory headings (H1-H6).

This change ensures Mallory headings appear with the lighter Book weight while maintaining the existing component architecture and backward compatibility.

### Description of work
- Modified heading mixin logic to use Book weight as default for Mallory headings
- Added explicit 'medium' parameter for backward compatibility
- Added detailed comments documenting the change from old to new behavior
- YaleNew headings remain completely unaffected
- Other Medium weight text across the site remains unchanged
- Other work done in https://github.com/yalesites-org/yalesites-project/pull/1029

### Testing Link(s)
- [ ] Navigate to the [Standard Page Story](https://deploy-preview-539--dev-component-library-twig.netlify.app/?path=/story/page-examples-standard-pages--basic)
- [ ] Try any other pages that might target specific blocks you're interested in seeing the difference in
- [ ] Test in the [Drupal multidev](https://github.com/yalesites-org/yalesites-project/pull/1029)

### Functional Review Steps
- [ ] Verify that you can see the font changes in Storybook
- [ ] Ensure that YaleNew is not affected

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
