### PR TITLE
YSP-1069: Update pager aria page label text for clarity

### DIFF
--- a/components/02-molecules/pager/yds-pager.twig
+++ b/components/02-molecules/pager/yds-pager.twig
@@ -10,10 +10,10 @@
 {% set current_page = current|default(1) %}
 
 {# Page label variables - centralized for easy customization #}
-{% set page_label = 'Page '|t %}
-{% set current_page_label = 'Current page'|t %}
-{% set previous_page_label = 'Previous page'|t %}
-{% set next_page_label = 'Next page'|t %}
+{% set page_label = 'Go to '|t %}
+{% set current_page_label = 'Current'|t %}
+{% set previous_page_label = 'Previous'|t %}
+{% set next_page_label = 'Next'|t %}
 
 {# 
    PAGINATION PATTERN DETECTION


### PR DESCRIPTION
## [YSP-1069: Update pager aria page label text for clarity](https://yaleits.atlassian.net/browse/YSP-1069)

### Description of work
- Changed the pager labels to improve a11y experience:
  - "Page" to "Go to"
  - "Current page" to "Current"
  - "Previous page" to "Previous"
  - "Next page" to "Next"

### Testing Link(s)
- [ ] Navigate to the [Pager Story](https://deploy-preview-542--dev-component-library-twig.netlify.app/?path=/story/molecules-pager--interactive)

### Functional Review Steps
- [ ] Verify that the aria labels do not mention "Page" for next, current, previous, and individual page links.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
