### PR TITLE
Hotfix: YSP-1103: Content Collection Fixes

### DIFF
--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -439,6 +439,10 @@ $secondary-menu-sub-max-width: 19rem;
   &--level-0 {
     @include secondary-nav-item-level-0;
 
+    &:hover {
+      background-color: var(--color-gray-100);
+    }
+
     &.secondary-nav__link--with-sub {
       display: none;
     }
@@ -574,6 +578,10 @@ $secondary-menu-sub-max-width: 19rem;
 
   &--level-0 {
     @include secondary-nav-item-level-0;
+
+    &:hover {
+      background-color: var(--color-gray-100);
+    }
   }
 }
 

--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -10,7 +10,7 @@ $secondary-nav-component-themes: map.deep-get(
 $secondary-menu-sub-max-width: 19rem;
 
 @mixin secondary-nav-item-level-0 {
-  @include tokens.body-s;
+  @include tokens.body-default;
 
   color: var(--color-heading);
   text-align: left;

--- a/components/03-organisms/site-in-this-section/_site-in-this-section.scss
+++ b/components/03-organisms/site-in-this-section/_site-in-this-section.scss
@@ -162,6 +162,7 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
   }
 
   @media (min-width: tokens.$break-mobile) {
+    border-top: var(--border-thickness-1) solid var(--color-navigation-border);
     border-bottom: var(--border-thickness-1) solid
       var(--color-navigation-border);
   }

--- a/components/03-organisms/site-in-this-section/_site-in-this-section.scss
+++ b/components/03-organisms/site-in-this-section/_site-in-this-section.scss
@@ -165,6 +165,7 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
     border-top: var(--border-thickness-1) solid var(--color-navigation-border);
     border-bottom: var(--border-thickness-1) solid
       var(--color-navigation-border);
+    padding-left: var(--size-spacing-5);
   }
 
   & .secondary-nav__menu--level-0:first-of-type {
@@ -197,7 +198,7 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
   &--left {
     left: 0;
     transform: rotate(90deg);
-    z-index: 0;
+    z-index: 1;
 
     [data-scroll-indicator='left'] &,
     [data-scroll-indicator='both'] & {

--- a/components/03-organisms/site-in-this-section/cl-site-in-this-section.scss
+++ b/components/03-organisms/site-in-this-section/cl-site-in-this-section.scss
@@ -1,0 +1,4 @@
+// Storybook-only spacing to make top border visible
+.in-this-section {
+  margin-top: var(--size-spacing-8);
+}

--- a/components/03-organisms/site-in-this-section/site-in-this-section.stories.js
+++ b/components/03-organisms/site-in-this-section/site-in-this-section.stories.js
@@ -6,6 +6,7 @@ import secondaryNavData from '../menu/secondary-nav/secondary-nav.yml';
 import '../menu/secondary-nav/yds-secondary-nav';
 import '../../02-molecules/menu/menu-in-this-section-toggle/yds-menu-in-this-section-toggle';
 import './yds-site-in-this-section';
+import './cl-site-in-this-section.scss';
 
 const colorPairingsData = Object.keys(tokens['component-themes']);
 


### PR DESCRIPTION
## [Hotfix: YSP-1103: Content Collection Fixes](https://yaleits.atlassian.net/browse/YSP-1103)

### Description of work
- Prevents menu content from appearing left of bounds in secondary navigation
- Adds top border and storybook spacing for content collections
- Increases font size for content collection navigation
- Adds light gray background on hover for content collection parent links

### Testing Link(s)
- [ ] Navigate to the [Secondary Nav Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-secondary-nav--secondary-nav)
- [ ] Navigate to the [Site In This Section Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/organisms-site-in-this-section--site-in-this-section)

### Functional Review Steps
- [ ] Verify secondary navigation content doesn't appear outside left bounds
- [ ] Verify content collection spacing and styling improvements
- [ ] Test hover states on parent links

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
- [ ] Test keyboard navigation functionality
- [ ] Ensure proper focus states are maintained