### PR TITLE
Hotfix: YSP-1103: Content Collection Navigation Background Alternative Color

### DIFF
--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -133,12 +133,16 @@ $secondary-menu-sub-max-width: 19rem;
     --color-link-base: var(--color-slot-one);
     --color-link-hover: var(--color-slot-eight);
     --color-navigation-border: var(--color-slot-one);
+    --color-hover-background: var(--color-slot-one);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   [data-component-theme='two'] & {
     --color-link-base: var(--color-slot-one);
     --color-link-hover: var(--color-slot-seven);
     --color-navigation-border: var(--color-slot-two);
+    --color-hover-background: var(--color-slot-two);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   [data-component-theme='three'] & {
@@ -147,18 +151,24 @@ $secondary-menu-sub-max-width: 19rem;
     --color-link-base: var(--color-slot-one);
     --color-link-hover: var(--color-slot-eight);
     --color-navigation-border: var(--color-slot-three);
+    --color-hover-background: var(--color-slot-three);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   [data-component-theme='four'] & {
     --color-link-visited-base: var(--color-link-visited-light);
     --color-link-visited-hover: var(--color-link-visited-light-hover);
     --color-navigation-border: var(--color-slot-four);
+    --color-hover-background: var(--color-slot-three);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   [data-component-theme='five'] & {
     --color-section-nav-theme: var(--color-slot-three);
     --color-section-nav-content: var(--color-slot-seven);
     --color-navigation-border: var(--color-slot-five);
+    --color-hover-background: var(--color-slot-three);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   .in-this-section__inner & {
@@ -440,7 +450,14 @@ $secondary-menu-sub-max-width: 19rem;
     @include secondary-nav-item-level-0;
 
     &:hover {
-      background-color: var(--color-gray-100);
+      background-color: var(--color-hover-background);
+      color: var(--color-hover-text);
+    }
+
+    // Ensure active links also show accent hover states when hovered
+    &.secondary-nav__link--active:hover {
+      background-color: var(--color-hover-background);
+      color: var(--color-hover-text);
     }
 
     &.secondary-nav__link--with-sub {
@@ -580,7 +597,14 @@ $secondary-menu-sub-max-width: 19rem;
     @include secondary-nav-item-level-0;
 
     &:hover {
-      background-color: var(--color-gray-100);
+      background-color: var(--color-hover-background);
+      color: var(--color-hover-text);
+    }
+
+    // Ensure active toggle buttons also show accent hover states when hovered
+    &[aria-expanded='true']:hover {
+      background-color: var(--color-hover-background);
+      color: var(--color-hover-text);
     }
   }
 }

--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -439,6 +439,10 @@ $secondary-menu-sub-max-width: 19rem;
   &--level-0 {
     @include secondary-nav-item-level-0;
 
+    &:hover {
+      background-color: var(--color-gray-100);
+    }
+
     &.secondary-nav__link--with-sub {
       display: none;
     }
@@ -574,6 +578,10 @@ $secondary-menu-sub-max-width: 19rem;
 
   &--level-0 {
     @include secondary-nav-item-level-0;
+
+    &:hover {
+      background-color: var(--color-gray-100);
+    }
   }
 }
 

--- a/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
+++ b/components/03-organisms/menu/secondary-nav/_yds-secondary-nav.scss
@@ -10,7 +10,7 @@ $secondary-nav-component-themes: map.deep-get(
 $secondary-menu-sub-max-width: 19rem;
 
 @mixin secondary-nav-item-level-0 {
-  @include tokens.body-s;
+  @include tokens.body-default;
 
   color: var(--color-heading);
   text-align: left;

--- a/components/03-organisms/site-in-this-section/_site-in-this-section.scss
+++ b/components/03-organisms/site-in-this-section/_site-in-this-section.scss
@@ -162,6 +162,7 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
   }
 
   @media (min-width: tokens.$break-mobile) {
+    border-top: var(--border-thickness-1) solid var(--color-navigation-border);
     border-bottom: var(--border-thickness-1) solid
       var(--color-navigation-border);
   }

--- a/components/03-organisms/site-in-this-section/_site-in-this-section.scss
+++ b/components/03-organisms/site-in-this-section/_site-in-this-section.scss
@@ -95,12 +95,16 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
     --color-link-base: var(--color-slot-one);
     --color-link-hover: var(--color-slot-eight);
     --color-navigation-border: var(--color-slot-one);
+    --color-hover-background: var(--color-slot-one);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   &[data-component-theme='two'] {
     --color-link-base: var(--color-slot-one);
     --color-link-hover: var(--color-slot-seven);
     --color-navigation-border: var(--color-slot-two);
+    --color-hover-background: var(--color-slot-two);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   &[data-component-theme='three'] {
@@ -109,18 +113,24 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
     --color-link-base: var(--color-slot-one);
     --color-link-hover: var(--color-slot-eight);
     --color-navigation-border: var(--color-slot-three);
+    --color-hover-background: var(--color-slot-three);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   &[data-component-theme='four'] {
     --color-link-visited-base: var(--color-link-visited-light);
     --color-link-visited-hover: var(--color-link-visited-light-hover);
     --color-navigation-border: var(--color-slot-four);
+    --color-hover-background: var(--color-slot-three);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   &[data-component-theme='five'] {
     --color-section-nav-theme: var(--color-slot-three);
     --color-section-nav-content: var(--color-slot-seven);
     --color-navigation-border: var(--color-slot-five);
+    --color-hover-background: var(--color-slot-three);
+    --color-hover-text: var(--color-slot-eight);
   }
 
   .secondary-menu-toggle {
@@ -133,7 +143,8 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
       z-index: 2;
 
       &[aria-expanded='true'] {
-        background-color: var(--color-gray-100);
+        background-color: var(--color-hover-background);
+        color: var(--color-hover-text);
       }
     }
   }

--- a/components/03-organisms/site-in-this-section/_site-in-this-section.scss
+++ b/components/03-organisms/site-in-this-section/_site-in-this-section.scss
@@ -165,6 +165,7 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
     border-top: var(--border-thickness-1) solid var(--color-navigation-border);
     border-bottom: var(--border-thickness-1) solid
       var(--color-navigation-border);
+    padding-left: var(--size-spacing-5);
   }
 
   & .secondary-nav__menu--level-0:first-of-type {
@@ -197,7 +198,7 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
   &--left {
     left: 0;
     transform: rotate(90deg);
-    z-index: 0;
+    z-index: 1;
 
     [data-scroll-indicator='left'] &,
     [data-scroll-indicator='both'] & {

--- a/components/03-organisms/site-in-this-section/cl-site-in-this-section.scss
+++ b/components/03-organisms/site-in-this-section/cl-site-in-this-section.scss
@@ -1,0 +1,4 @@
+// Storybook-only spacing to make top border visible
+.in-this-section {
+  margin-top: var(--size-spacing-8);
+}

--- a/components/03-organisms/site-in-this-section/site-in-this-section.stories.js
+++ b/components/03-organisms/site-in-this-section/site-in-this-section.stories.js
@@ -6,6 +6,7 @@ import secondaryNavData from '../menu/secondary-nav/secondary-nav.yml';
 import '../menu/secondary-nav/yds-secondary-nav';
 import '../../02-molecules/menu/menu-in-this-section-toggle/yds-menu-in-this-section-toggle';
 import './yds-site-in-this-section';
+import './cl-site-in-this-section.scss';
 
 const colorPairingsData = Object.keys(tokens['component-themes']);
 


### PR DESCRIPTION
## [Hotfix: YSP-1103: Content Collection Navigation Background Alternative Color](https://yaleits.atlassian.net/browse/YSP-1103)

This PR piggybacks on the https://github.com/yalesites-org/component-library-twig/pull/546 PR. The request was to see how the secondary navigation would look if instead of a gray background that's present in the previous PR to make the background color an accent color, and make the text a contrast-friendly color, in this case white.  A decision will be made of which implementation to go with.

### Description of work
- Changes background hover color of secondary nav to be an accent color that is inside of the currently selected global theme
- Changes the foreground hover text color of secondary nav to be a contrast friendly white

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
