### PR TITLE
Hotfix: YSP-1086: Mega Menu "Explore" Font Change

### DIFF
--- a/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
+++ b/components/03-organisms/menu/primary-nav/_yds-primary-nav.scss
@@ -328,12 +328,8 @@ $menu-sub-max-width: 19rem;
 
   [data-menu-variation='mega']
     // Targets the explore link to the right of a dropdown menu.
-    // Only it should be capitalized.
-    &.primary-nav__link--level-1.primary-nav__link--with-icon.primary-nav__link--explore-bar {
-    @media (min-width: tokens.$break-mobile) {
-      @include tokens.heading(h6);
-    }
-  }
+    // Font styling is handled by --font-style-nav-primary-1 variable below.
+    // Removed heading(h6) mixin to prevent global font setting from affecting this element.
 
   &--level-1 {
     font: var(--font-style-nav-primary-1);


### PR DESCRIPTION
## [Hotfix: YSP-1086: Mega Menu "Explore" Font Change](https://yaleits.atlassian.net/browse/YSP-1086)

The "Explore <page title>" link in the mega menu was incorrectly switching to YaleNew font when the global font setting was set to YaleNew. This element should always display in Mallory font regardless of global settings.

Removed conflicting @include tokens.heading(h6) declaration that was overriding the intended navigation font styling. The explore bar link now relies solely on the font: var(--font-style-nav-primary-1) CSS variable which provides consistent Mallory styling.

This ensures proper visual hierarchy and maintains design consistency in the mega menu navigation component.

### Description of work
- Forces `Explore` link to always be Mallory font

### Testing Link(s)
- [ ] Navigate to the [Primary Menu Story](https://deploy-preview-549--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-primary-nav--primary-nav&args=menuVariation:mega)
- [ ] Navigate to the [Drupal Multidev](https://github.com/yalesites-org/yalesites-project/pull/1047)

### Functional Review Steps
- [ ] Verify that the rightmost menu in a mega menu is a Mallory font
- [ ] Test Drupal multidev

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
