### PR TITLE
YSP-1039: Embed: Google Calendar

### DIFF
--- a/components/02-molecules/embed/_yds-embed.scss
+++ b/components/02-molecules/embed/_yds-embed.scss
@@ -50,10 +50,30 @@ $heights: (
     aspect-ratio: 3 / 2;
     height: auto;
   }
+}
 
-  .layout--onecol & {
+// Calendar embeds need a little more width to be useful
+.embed__inner:has(iframe[data-embed-type='calendar']) {
+  & iframe {
+    position: static;
+    width: 100%;
+    margin-right: auto;
+    aspect-ratio: 16 / 9;
+    height: auto;
+  }
+}
+
+// Layout-specific overrides (higher specificity selectors go last)
+.layout--onecol {
+  .embed__inner:has(iframe[data-embed-type='map']) {
     iframe {
       width: 50%;
+    }
+  }
+
+  .embed__inner:has(iframe[data-embed-type='calendar']) {
+    iframe {
+      width: 66%;
     }
   }
 }

--- a/components/02-molecules/embed/_yds-embed.scss
+++ b/components/02-molecules/embed/_yds-embed.scss
@@ -12,6 +12,7 @@
 $heights: (
   'form': 90vh,
   'audio': 130px,
+  'map': 70vh,
   'unknown': 70vh,
 );
 

--- a/components/02-molecules/embed/embed.stories.js
+++ b/components/02-molecules/embed/embed.stories.js
@@ -111,7 +111,7 @@ export const EmbedGoogleCalendar = ({ width, type, loading }) =>
   });
 
 EmbedGoogleCalendar.args = {
-  type: 'form',
+  type: 'calendar',
 };
 
 export const EmbedBluesky = () => {

--- a/components/02-molecules/embed/embed.stories.js
+++ b/components/02-molecules/embed/embed.stories.js
@@ -99,6 +99,21 @@ EmbedGoogleMaps.args = {
   type: 'map',
 };
 
+export const EmbedGoogleCalendar = ({ width, type, loading }) =>
+  embedTwig({
+    embed__src:
+      'https://calendar.google.com/calendar/embed?src=en.usa%23holiday%40group.v.calendar.google.com&ctz=America%2FNew_York',
+    embed__title: 'Example Google Calendar',
+    embed__width: width,
+    embed__height: '100%',
+    embed__loading: loading,
+    embed__type: type,
+  });
+
+EmbedGoogleCalendar.args = {
+  type: 'form',
+};
+
 export const EmbedBluesky = () => {
   return `<blockquote class="bluesky-embed" data-bluesky-uri="at://did:plc:hptrw4dge4l5q4h5pl7wpw74/app.bsky.feed.post/3ltporonlrt2z" data-bluesky-cid="bafyreiera75ojf45nkakh3piwhu3rldjzobppl7tq3nlgsmxx5zq2msiga" data-bluesky-embed-color-mode="system"><p lang="">Congratulations to James West Davidson&#x27;s A Little History of the United States, which was listed on the New York Times Bestseller List!<br><br><a href="https://bsky.app/profile/did:plc:hptrw4dge4l5q4h5pl7wpw74/post/3ltporonlrt2z?ref_src=embed">[image or embed]</a></p>&mdash; Yale University Press (<a href="https://bsky.app/profile/did:plc:hptrw4dge4l5q4h5pl7wpw74?ref_src=embed">@yalepress.bsky.social</a>) <a href="https://bsky.app/profile/did:plc:hptrw4dge4l5q4h5pl7wpw74/post/3ltporonlrt2z?ref_src=embed">July 11, 2025 at 4:30 PM</a></blockquote><script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>`;
 };


### PR DESCRIPTION
## [YSP-1039: Embed: Google Calendare](https://yaleits.atlassian.net/browse/YSP-1039)

### Description of work
- Added a new story, EmbedGoogleCalendar, to demonstrate embedding a Google Calendar using the embedTwig component. Configured with example calendar URL, title, and default args.
- Other work completed in https://github.com/yalesites-org/yalesites-project/pull/1048

### Testing Link(s)
- [ ] Navigate to the [Google Calendar Embed Story](https://deploy-preview-550--dev-component-library-twig.netlify.app/?path=/story/molecules-embed--embed-google-calendar)

### Functional Review Steps
- [ ] Verify the calendar renders
- [ ] Test Drupal version in https://github.com/yalesites-org/yalesites-project/pull/1048

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
