### PR TITLE
YSP-1113: Action banner CTA color contrast

### DIFF
--- a/components/01-atoms/controls/cta/_yds-cta.scss
+++ b/components/01-atoms/controls/cta/_yds-cta.scss
@@ -114,19 +114,6 @@ $cta-outline-weights: (
       --color-slot-eight: var(
         --global-themes-#{$globalTheme}-colors-slot-eight
       );
-
-      @if $globalTheme == 'one' {
-        --color-cta-text-hover: var(--color-slot-five);
-      }
-      @if $globalTheme == 'three' {
-        --color-cta-text-hover: var(--color-slot-five);
-      }
-      @if $globalTheme == 'four' {
-        --color-cta-text-hover: var(--color-slot-two);
-      }
-      @if $globalTheme == 'five' {
-        --color-cta-text-hover: var(--color-slot-five);
-      }
     }
   }
 

--- a/components/02-molecules/banner/action/_yds-action-banner.scss
+++ b/components/02-molecules/banner/action/_yds-action-banner.scss
@@ -104,7 +104,7 @@ $break-cta-banner-max: $break-cta-banner - 0.05;
     --color-banner-text: var(--color-slot-eight);
     --color-banner-heading: var(--color-slot-eight);
     --color-banner-action: var(--color-slot-eight);
-    --color-banner-action-secondary: var(--color-one);
+    --color-banner-action-secondary: var(--color-slot-one);
     --color-link-base: var(--color-banner-heading);
     --color-link-hover: var(--color-banner-heading);
     --color-link-visited-base: var(--color-link-visited-light);


### PR DESCRIPTION
## [YSP-1113: Action banner CTA color contrast](https://yaleits.atlassian.net/browse/YSP-1113)

### Description of work
- Removed temporary theme-specific hover color overrides in CTA SCSS that were used as a workaround.
- Fixed typo on action banner secondary color variable.

### Testing Link(s)
- [ ] Navigate to the [Action Banner Story](https://deploy-preview-554--dev-component-library-twig.netlify.app/?path=/story/molecules-banners--action-banner)
- [ ] Navigate to the [Callout Story](https://deploy-preview-554--dev-component-library-twig.netlify.app/?path=/story/molecules-callout--callout)

### Functional Review Steps
- [ ] Change to each component theme and check the hover contrast
- [ ] Change the global theme and repeat the component theme checks for contrast
- [ ] Test this also in the provided multidev: https://github.com/yalesites-org/yalesites-project/pull/1056

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
