### PR TITLE
YSP-1112: Mobile Navigation Menu Appears Behind Content Collection

### DIFF
--- a/components/03-organisms/site-in-this-section/_site-in-this-section.scss
+++ b/components/03-organisms/site-in-this-section/_site-in-this-section.scss
@@ -133,7 +133,7 @@ $section-nav-component-themes: map.deep-get(tokens.$tokens, 'component-themes');
       display: flex;
       position: relative;
       background-color: var(--color-basic-white);
-      z-index: 2;
+      z-index: 1;
 
       &[aria-expanded='true'] {
         background-color: var(--color-gray-100);


### PR DESCRIPTION
## [YSP-1112: Mobile Navigation Menu Appears Behind Content Collection](https://yaleits.atlassian.net/browse/YSP-1112)

### Description of work
- Reduced the z-index of the section navigation menu from 2 to 1 to resolve potential stacking context issues with primary nav.

### Testing Link(s)
- [ ] Navigate to the [Basic Short Page Story](https://deploy-preview-556--dev-component-library-twig.netlify.app/?path=/story/page-examples-standard-pages--basic-short)

### Functional Review Steps
- [ ] Go into mobile views
- [ ] Expand the primary nav
- [ ] Ensure that the content collection does not show on top of the expanded menu
- [ ] Test in https://github.com/yalesites-org/yalesites-project/pull/1058

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
