### PR TITLE
YSP-665 :: Events: Display room number on event pages

### DIFF
--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -44,6 +44,12 @@
 {% set latLong = place.latitude ~ ',' ~ place.longitude %}
 {% set get_directions__url = place ? 'https://www.google.com/maps/dir/Current+Location/' ~ latLong : '' %}
 
+{# Set up location display with conditional room #}
+{% set location_display = place.name %}
+{% if room %}
+  {% set location_display = location_display ~ ', ' ~ room %}
+{% endif %}
+
 {% if event_experience %}
   {% set event_meta__format = event_experience.0.name %}
 {% endif %}
@@ -298,7 +304,7 @@
             <div {{ bem('location-wrapper', [], event_meta__base_class) }}>
               <label {{ bem('event__label', [], event_meta__base_class) }}>Location</label>
               <div {{ bem('location', [], event_meta__base_class) }}>
-                {{ place.name }}, {{ room }}<br>
+                {{ location_display }}<br>
                 {{ place.address }}
                 {{ place.city }}, {{ place.state }} {{ place.postal_code }}
               </div>


### PR DESCRIPTION
## [YSP-665 : Events: Display room number on event pages](https://yaleits.atlassian.net/browse/YSP-665)

### Description of work
- Adds room to event node template

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
