### PR TITLE
YSP-1141: RC: AI Palette missing colors in theme settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5354,9 +5354,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.35.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.35.0/1e35947381b8bc62ea3a08eec26e6e4948b1537b",
-      "integrity": "sha512-28WllxpLvHiNO29HMi/FUPpGXU53yi0EygIxUHDE9UEr5EP8g0F6NGequAzKqHJ5GfSW+zDxnT179SKM/OvbTw=="
+      "version": "1.36.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.36.0/bec7ac4f82ab8c61d4f7539d6fc1f4c9f0ccadda",
+      "integrity": "sha512-Smjy/TzR8z+wjDbWdSBIWNkhrZBV/1ku5P2EK5GX+GhGH3smxVRCjpT/JOj19FGsRNq/Dw2zavk6dq26YxyJKw=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",


### PR DESCRIPTION
## [YSP-1141: RC: AI Palette missing colors in theme settings](https://yaleits.atlassian.net/browse/YSP-1141)

### Description of work
- Actually use the latest tokens version

### Testing Link(s)
- [ ] Navigate to the [Global Theme Story](https://deploy-preview-564--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--color-global-themes)
- [ ] Navigate to the [Drupal multidev with this change](https://github.com/yalesites-org/yalesites-project/pull/1080)

### Functional Review Steps
- [ ] Ensure that the AI global theme shows in Storybook
- [ ] Ensure that the AI theme shows with colors in the Theme Selection in Drupal

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
