### PR TITLE
YSP-1142: RC: Site menu z-index

### DIFF
--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -36,7 +36,7 @@ $site-name-as-logo-height-sm: 6.25rem; // 100px
   --color-text-shadow: var(--color-basic-white);
 
   position: relative;
-  z-index: 2;
+  z-index: 10;
 
   // Component themes defaults: iterate over each component theme to establish
   // default variables.


### PR DESCRIPTION
## [YSP-1142: RC: Site menu z-index](https://yaleits.atlassian.net/browse/YSP-1142)

### Description of work
- Raise the site header's z-index from 2 to 10 to resolve a bug where the site menu appears incorrectly when banner blocks are present. This ensures proper stacking order and visual consistency.

### Testing Link(s)
- [ ] Navigate to the [Drupal Multidev](https://github.com/yalesites-org/yalesites-project/pull/1081)

### Functional Review Steps
- [ ] Verify that the multidev instructions pass
- [ ] Note: Can't really test this in our current storybook implementation

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
