### PR TITLE
YSP-1143: RC: Force download for download CTA button

### DIFF
--- a/components/02-molecules/meta/resource-meta/yds-resource-meta.twig
+++ b/components/02-molecules/meta/resource-meta/yds-resource-meta.twig
@@ -83,6 +83,7 @@
               cta__component_theme: cta__component_theme|default('one'),
               cta__attributes: {
                 'aria-label': resource_meta__download_aria_label,
+                'download': '',
               }
             } %}
           </div>


### PR DESCRIPTION
## [YSP-1143: RC: Force download for download CTA button](https://yaleits.atlassian.net/browse/YSP-1143)

### Description of work
- Adds an empty 'download' attribute to the resource download CTA link for better browser handling of file downloads and improved accessibility.

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
