### PR TITLE
YSP-1159: RC: Resource Video size too small. Make size of Video block

### DIFF
--- a/components/02-molecules/meta/resource-meta/_yds-resource-meta.scss
+++ b/components/02-molecules/meta/resource-meta/_yds-resource-meta.scss
@@ -11,6 +11,12 @@
       grid-template-columns: 1fr auto;
     }
   }
+
+  // Allow video resources to expand to full container width
+  // Default justify-content: start constrains grid to minimum width needed
+  [data-component-resource-type='video'] & {
+    justify-content: stretch;
+  }
 }
 
 .resource-meta__page-title {
@@ -19,6 +25,12 @@
 
 .resource-meta__media {
   width: max-content;
+
+  // Allow video containers to expand within the grid
+  // max-content constrains videos to minimum size, auto allows expansion
+  [data-component-resource-type='video'] & {
+    width: auto;
+  }
 }
 
 .resource-meta__image {

--- a/components/02-molecules/meta/resource-meta/yds-resource-meta.twig
+++ b/components/02-molecules/meta/resource-meta/yds-resource-meta.twig
@@ -90,13 +90,11 @@
           </div>
         {% endif %}
       {% elseif resource_meta__resource_type == 'video' %}
-        <div {{ bem('inner', [], resource_meta__base_class) }}>
-          {% block resource_meta__video %}
-            {% include "@atoms/videos/video-embed/yds-video-embed.twig" with {
-              video_embed__content: video_embed__content__1,
-            } %}
-          {% endblock %}
-        </div>
+        {% block resource_meta__video %}
+          {% include "@atoms/videos/video-embed/yds-video-embed.twig" with {
+            video_embed__content: video_embed__content__1,
+          } %}
+        {% endblock %}
       {% endif %}
     </div>
   {% endif %}


### PR DESCRIPTION
## [YSP-1159: RC: Resource Video size too small. Make size of Video block](https://yaleits.atlassian.net/browse/YSP-1159)

### Description of work
- Update grid and width styles to allow videos to expand to the full container width

### Testing Link(s)
- [ ] Navigate to the [Resource Story](https://deploy-preview-570--dev-component-library-twig.netlify.app/?path=/story/molecules-meta--resource)
- [ ] Navigate to the [Drupal multidev](https://github.com/yalesites-org/yalesites-project/pull/1087) to test this in Drupal

### Functional Review Steps
- [ ] Verify the video now spans the full width of the space

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
