### PR TITLE
YSP-926: Views: Card grid stroke outline

### DIFF
--- a/components/02-molecules/cards/custom-card/_yds-custom-card.scss
+++ b/components/02-molecules/cards/custom-card/_yds-custom-card.scss
@@ -148,3 +148,11 @@ $global-card-themes: map.deep-get(tokens.$tokens, 'global-themes');
     }
   }
 }
+
+// For images linked, add borders around them
+// except the bottom border.
+.custom-card__image-link {
+  border-top: var(--card-border);
+  border-left: var(--card-border);
+  border-right: var(--card-border);
+}


### PR DESCRIPTION
## [YSP-926: Views: Card grid stroke outline](https://yaleits.atlassian.net/browse/YSP-926)

### Description of work
- Added top, left, and right borders to `.custom-card__image-link`
- Other work completed in https://github.com/yalesites-org/yalesites-project/pull/1100

### Testing Link(s)
- [ ] Navigate to the [Custom Card Collection Story](https://deploy-preview-576--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection-custom-card-collection--custom-card-collection)
- [ ] Navigate to the [Custom Card Story](https://deploy-preview-576--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--custom-card)

### Functional Review Steps
- [ ] Verify that it looks unchanged (since we can't have a transparent image right now)
- [ ] Visit the [Drupal multidev](https://github.com/yalesites-org/yalesites-project/pull/1100) to test more

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
