### PR TITLE
YSP-822: Add Event Time to Event Display Modes

### DIFF
--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -57,8 +57,13 @@ format__day__long = Thursday, December 3, 2024
   'format__day__long__start': 'l, F j, Y' ~ em_dash,
   'format__month_year': 'F Y',
   'format__year_only': 'Y',
+  'format__date_and_time__start': 'F j, Y g:i a' ~ em_dash,
+  'format__date_and_time': 'g:i a',
+  'format__date_time_multiple_days__start': 'D M j, Y g:i a' ~ em_dash,
+  'format__date_time_multiple_days': 'D M j, Y g:i a',
 } %}
 
+{# easy to name configurations that utilize the above formats _start and regular variants #}
 {% set format_defaults = {
   "time": "format__time",
   "date": "format__date",
@@ -67,10 +72,13 @@ format__day__long = Thursday, December 3, 2024
   "day__full": "format__day__full",
   "year_only": "format__year_only",
   "month_year": "format__month_year",
+  "same_day_diff_time": "format__date_and_time",
+  "date_time_multiple_days": "format__date_time_multiple_days",
 } %}
 
 {% set used_format = date_time__format_override|default(format_defaults[date_time__format]) %}
 
+{# Combine start and end date/time into one variable for output #}
 {% if same_start_and_end %}
   {% set date_time = date_time__start|date(formats[used_format]) %}
 {% else %}


### PR DESCRIPTION
## [YSP-822: Add Event Time to Event Display Modes](https://yaleits.atlassian.net/browse/YSP-822)

### Description of work
- Add time formats that support same day with different times, and multiple days with times for view displays
- Other work completed in https://github.com/yalesites-org/atomic/pull/409

### Testing Link(s)
- Date work can really only be tested in Drupal at this time: https://github.com/yalesites-org/yalesites-project/pull/1101

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
