### PR TITLE
YSP-1020: Grand Hero: New Design Option for shorter banner

### DIFF
--- a/components/02-molecules/banner/banner.stories.js
+++ b/components/02-molecules/banner/banner.stories.js
@@ -144,7 +144,7 @@ GrandHeroBanner.argTypes = {
   size: {
     name: 'Content Size',
     type: 'select',
-    options: ['reduced', 'full'],
+    options: ['reduced', 'full', 'mini'],
   },
   withVideo: {
     name: 'With Video',

--- a/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
+++ b/components/02-molecules/banner/grand-hero/_yds-grand-hero.scss
@@ -30,6 +30,10 @@ $break-grand-hero-banner: tokens.$break-m;
     min-height: 28rem;
   }
 
+  &[data-grand-hero-size='mini'] {
+    min-height: 14rem;
+  }
+
   &[data-grand-hero-size='full'] {
     min-height: calc(95vh - var(--site-header-height));
   }


### PR DESCRIPTION
## [YSP-1020: Grand Hero: New Design Option for shorter banner](https://yaleits.atlassian.net/browse/YSP-1020)

### Description of work

- Adds mini size option for grand hero banner component with 14rem minimum height
- Provides new design variation for shorter banner implementation

### Testing Link(s)

- [ ] Navigate to the https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/molecules-banner--grand-hero to test mini size option

### Functional Review Steps

- [ ] Verify mini size grand hero banner displays with correct 14rem height
- [ ] Test that mini size styling applies when data-grand-hero-size='mini' attribute is used
- [ ] Confirm existing small and full size options continue to work as expected

### Design Review

- [ ] Verify the mini banner height matches the https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771
- [ ] Confirm the mini size provides appropriate visual hierarchy for shorter content

### Accessibility Review

- [ ] Verify the component meets Accessibility requirements
- [ ] Ensure mini size maintains proper focus management and screen reader compatibility