### PR TITLE
897 :: Color Slot Preview Enhancement

### DIFF
--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -32,13 +32,18 @@ const ProgressPlugin = new webpack.ProgressPlugin();
 
 const CopyWebpackPlugin = new _CopyWebpackPlugin([
   {
-  from: './fonts',
-  to: './fonts',
+    from: './fonts',
+    to: './fonts',
   },
   {
     from: './images/patterns',
     to: './images/patterns',
-  }
+  },
+  {
+    from: './node_modules/@yalesites-org/tokens/build/json/tokens.json',
+    to: './tokens.json',
+    noErrorOnMissing: true,
+  },
 ]);
 
 module.exports = {


### PR DESCRIPTION
### Description of work
- Adds a static page to display all token color names, swatches, hex codes, values and other data: https://pr-1174-yalesites-platform.pantheonsite.io/admin/yalesites/themes/color-tokens
- Adds a new color picker widget based on the background colors for the theme with color names and hex codes, applies the widget to all block_content types that originally had the theme picker

### Functional testing steps:
- [ ] Add a block to a page that has the theme picker (accordion, callouts, spotlights, facts...)
- [ ] Verify that you see theme options that include a circle with the color plus color name and hex code
- [ ] Verify that you can select a theme option and the component appears as expected with that theme applied
- [ ] Verify you see the [color-tokens page](https://pr-1174-yalesites-platform.pantheonsite.io/admin/yalesites/themes/color-tokens)

Notes: I needed to add the tokens.json file to the built theme (dist) in order to be able to get those values non-locally. Any updates to the tokens.json file will be reflected in the color tokens page and the color picker widget

Platform PR: https://github.com/yalesites-org/yalesites-project/pull/1174
