### PR TITLE
#1036 :: View Block - Make view items with teaser images off aligned flush with page content

### DIFF
--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -12,6 +12,16 @@ $break-card-collection-max: tokens.$break-m - 0.05;
 $break-card-collection-list-image-max: tokens.$break-s - 0.05;
 $break-single-card-collection-max: tokens.$break-xl - 0.05;
 
+// Mixin for list items without images - removes indentation
+@mixin list-no-image-flush {
+  [data-collection-type='list'] [data-component-has-image='false'] & {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+    max-width: 100%;
+  }
+}
+
 .reference-card {
   @include atoms.clickable-component-heading-link;
   @include atoms.clickable-component-image;
@@ -380,14 +390,6 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     flex: 1 1 100%;
   }
 
-  // When there's no image in list view, content should be flush left (all breakpoints)
-  [data-collection-type='list'] [data-component-has-image='false'] & {
-    flex: 1 0 100%;
-    margin-inline-start: 0;
-    margin-inline-end: 0;
-    max-width: 100%;
-  }
-
   // vertically center content when profile source.
   [data-collection-type='single'][data-collection-featured='false'][data-collection-source='profile']
     & {
@@ -407,13 +409,7 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
       max-width: 50%;
     }
 
-    // When there's no image in list view, content should be flush left
-    [data-collection-type='list'] [data-component-has-image='false'] & {
-      flex: 1 0 100%;
-      margin-inline-start: 0;
-      margin-inline-end: 0;
-      max-width: 100%;
-    }
+    @include list-no-image-flush;
   }
 
   @media (min-width: tokens.$break-s) and (max-width: $break-card-collection-max) {
@@ -427,13 +423,7 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
       flex: 1 0 66%;
     }
 
-    // When there's no image in list view, content should be flush left
-    [data-collection-type='list'] [data-component-has-image='false'] & {
-      flex: 1 0 100%;
-      margin-inline-start: 0;
-      margin-inline-end: 0;
-      max-width: 100%;
-    }
+    @include list-no-image-flush;
   }
 
   @media (min-width: tokens.$break-m) {
@@ -443,13 +433,7 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
       margin-inline-end: auto;
     }
 
-    // When there's no image in list view, content should be flush left
-    [data-collection-type='list'] [data-component-has-image='false'] & {
-      flex: 1 0 100%;
-      margin-inline-start: 0;
-      margin-inline-end: 0;
-      max-width: 100%;
-    }
+    @include list-no-image-flush;
   }
 
   @media (min-width: tokens.$break-mobile) {
@@ -459,13 +443,7 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
       margin-inline-end: auto;
     }
 
-    // When there's no image in list view, content should be flush left
-    [data-collection-type='list'] [data-component-has-image='false'] & {
-      flex: 1 0 100%;
-      margin-inline-start: 0;
-      margin-inline-end: 0;
-      max-width: 100%;
-    }
+    @include list-no-image-flush;
 
     [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='false']
       & {

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -380,6 +380,14 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     flex: 1 1 100%;
   }
 
+  // When there's no image in list view, content should be flush left (all breakpoints)
+  [data-collection-type='list'] [data-component-has-image='false'] & {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+    max-width: 100%;
+  }
+
   // vertically center content when profile source.
   [data-collection-type='single'][data-collection-featured='false'][data-collection-source='profile']
     & {
@@ -398,6 +406,14 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     [data-collection-type='list'][data-collection-source='profile'] & {
       max-width: 50%;
     }
+
+    // When there's no image in list view, content should be flush left
+    [data-collection-type='list'] [data-component-has-image='false'] & {
+      flex: 1 0 100%;
+      margin-inline-start: 0;
+      margin-inline-end: 0;
+      max-width: 100%;
+    }
   }
 
   @media (min-width: tokens.$break-s) and (max-width: $break-card-collection-max) {
@@ -410,6 +426,14 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     [data-collection-type='list'][data-collection-featured='false'] & {
       flex: 1 0 66%;
     }
+
+    // When there's no image in list view, content should be flush left
+    [data-collection-type='list'] [data-component-has-image='false'] & {
+      flex: 1 0 100%;
+      margin-inline-start: 0;
+      margin-inline-end: 0;
+      max-width: 100%;
+    }
   }
 
   @media (min-width: tokens.$break-m) {
@@ -418,6 +442,14 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
       margin-inline-start: auto;
       margin-inline-end: auto;
     }
+
+    // When there's no image in list view, content should be flush left
+    [data-collection-type='list'] [data-component-has-image='false'] & {
+      flex: 1 0 100%;
+      margin-inline-start: 0;
+      margin-inline-end: 0;
+      max-width: 100%;
+    }
   }
 
   @media (min-width: tokens.$break-mobile) {
@@ -425,6 +457,14 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
       flex: 0 1 71%;
       margin-inline-start: auto;
       margin-inline-end: auto;
+    }
+
+    // When there's no image in list view, content should be flush left
+    [data-collection-type='list'] [data-component-has-image='false'] & {
+      flex: 1 0 100%;
+      margin-inline-start: 0;
+      margin-inline-end: 0;
+      max-width: 100%;
     }
 
     [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='false']


### PR DESCRIPTION
## [#1036: View Block - Make view items with teaser images off aligned flush with page content](https://github.com/yalesites-org/YaleSites-Internal/issues/1036)

### Description of work
- Update SCSS to allow content to be flush when there is no image

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Create a page with a view in the list style. Test with and without images. With images should look the same as it does currently. Without images it should be flush to the left.

Demo PR: https://github.com/yalesites-org/yalesites-project/pull/1189