### PR TITLE
1016 :: Add Heading Field to Link List Group

### DIFF
--- a/components/02-molecules/link-grid/_yds-link-grid.scss
+++ b/components/02-molecules/link-grid/_yds-link-grid.scss
@@ -115,6 +115,17 @@ $component-link-grid-themes: map.deep-get(tokens.$tokens, 'component-themes');
   margin-bottom: var(--size-spacing-7);
   padding: var(--size-spacing-4) 0;
 
+  // If column contains a heading, remove top padding
+  &:has(.link-group__heading) {
+    padding-top: 0;
+  }
+
+  // Style link-group headings when used inside link-grid columns
+  .link-group__heading {
+    // Match bottom padding to list item bottom margin
+    padding-bottom: var(--size-spacing-6);
+  }
+
   // medium = two columns
   @media (min-width: tokens.$break-m) {
     flex: 1 1 50%;

--- a/components/02-molecules/link-grid/link-grid.yml
+++ b/components/02-molecules/link-grid/link-grid.yml
@@ -1,4 +1,5 @@
 link_grid__heading: 'This is a link grid'
+link_grid__heading_one: 'HEADING FOR LINK GROUP ONE'
 link_grid__links_one:
   - link_grid__link__url: '#'
     link_grid__link__content: 'This is a link'
@@ -8,6 +9,7 @@ link_grid__links_one:
     link_grid__link__content: 'This is a very long link that will wrap lines'
   - link_grid__link__url: 'https://google.com/download.pdf'
     link_grid__link__content: 'Link #4'
+link_grid__heading_two: 'HEADING FOR LINK GROUP TWO'
 link_grid__links_two:
   - link_grid__link__url: '#'
     link_grid__link__content: 'This is a link in the second column'
@@ -21,6 +23,7 @@ link_grid__links_two:
     link_grid__link__content: 'Link #5 column 2'
   - link_grid__link__url: '#'
     link_grid__link__content: 'Link #6 column 2'
+link_grid__heading_three: ''
 link_grid__links_three:
   - link_grid__link__url: '#'
     link_grid__link__content: 'This is a link in the third column'
@@ -30,6 +33,7 @@ link_grid__links_three:
     link_grid__link__content: 'This is a very long link that will wrap lines'
   - link_grid__link__url: '#'
     link_grid__link__content: 'Link #4 column #3'
+link_grid__heading_four: ''
 link_grid__links_four:
   - link_grid__link__url: '#'
     link_grid__link__content: 'This is a link in the fourth column'

--- a/components/02-molecules/link-grid/yds-link-grid.twig
+++ b/components/02-molecules/link-grid/yds-link-grid.twig
@@ -2,6 +2,10 @@
  # Available Variables:
  # - link_grid__theme (default is `one`, set as dial on component)
  # - link_grid__width (default is `site`, not currently set as dial on component)
+ # - link_grid__heading_one (optional heading for first column)
+ # - link_grid__heading_two (optional heading for second column)
+ # - link_grid__heading_three (optional heading for third column)
+ # - link_grid__heading_four (optional heading for fourth column)
  #
  # Available Blocks
  # - link_grid__links_one
@@ -32,6 +36,13 @@
   {% endif %}
   {% if link_grid__links_one %}
     <ul {{ bem('links-column', ['one'], link_grid__base_class) }}>
+      {% if link_grid__heading_one %}
+        {% include "@atoms/typography/headings/yds-heading.twig" with {
+          heading__level: '2',
+          heading__blockname: 'link-group',
+          heading: link_grid__heading_one,
+        } %}
+      {% endif %}
       {% block link_grid__links_one %}
         {% for link in link_grid__links_one %}
           {% include "@molecules/link-grid/_yds-link-grid--links.twig" %}
@@ -41,6 +52,13 @@
   {% endif %}
   {% if link_grid__links_two %}
     <ul {{ bem('links-column', ['two'], link_grid__base_class) }}>
+      {% if link_grid__heading_two %}
+        {% include "@atoms/typography/headings/yds-heading.twig" with {
+          heading__level: '2',
+          heading__blockname: 'link-group',
+          heading: link_grid__heading_two,
+        } %}
+      {% endif %}
       {% block link_grid__links_two %}
         {% for link in link_grid__links_two %}
           {% include "@molecules/link-grid/_yds-link-grid--links.twig" %}
@@ -50,6 +68,13 @@
   {% endif %}
   {% if link_grid__links_three %}
     <ul {{ bem('links-column', ['three'], link_grid__base_class) }}>
+      {% if link_grid__heading_three %}
+        {% include "@atoms/typography/headings/yds-heading.twig" with {
+          heading__level: '2',
+          heading__blockname: 'link-group',
+          heading: link_grid__heading_three,
+        } %}
+      {% endif %}
       {% block link_grid__links_three %}
         {% for link in link_grid__links_three %}
           {% include "@molecules/link-grid/_yds-link-grid--links.twig" %}
@@ -59,6 +84,13 @@
   {% endif %}
   {% if link_grid__links_four %}
     <ul {{ bem('links-column', ['four'], link_grid__base_class) }}>
+      {% if link_grid__heading_four %}
+        {% include "@atoms/typography/headings/yds-heading.twig" with {
+          heading__level: '2',
+          heading__blockname: 'link-group',
+          heading: link_grid__heading_four,
+        } %}
+      {% endif %}
       {% block link_grid__links_four %}
         {% for link in link_grid__links_four %}
           {% include "@molecules/link-grid/_yds-link-grid--links.twig" %}


### PR DESCRIPTION
## [1016: Add Heading Field to Link List Group](https://github.com/yalesites-org/YaleSites-Internal/issues/1016)

### Description of work
- Adds style for link list headings
- Adds headings to link list and link grid in Storybook

### Testing Link(s)
- [ ] Link group: https://deploy-preview-610--dev-component-library-twig.netlify.app/?path=/story/molecules-link-group--link-group
- [ ] Link grid: https://deploy-preview-610--dev-component-library-twig.netlify.app/?path=/story/molecules-link-grid--link-grid

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements

Platform PR: https://github.com/yalesites-org/yalesites-project/pull/1196
Atomic PR: https://github.com/yalesites-org/atomic/pull/432
