### PR TITLE
1101: getAssetPath Twig function missing in Storybook

### DIFF
--- a/.storybook/setupTwig.js
+++ b/.storybook/setupTwig.js
@@ -3,6 +3,7 @@ const twigDrupal = require('twig-drupal-filters');
 const twigBEM = require('bem-twig-extension');
 const twigAddAttributes = require('add-attributes-twig-extension');
 const twigUrl = require('./twig-url');
+const twigAssetPath = require('./twig-asset-path');
 
 module.exports.namespaces = {
   atoms: resolve(__dirname, '../', 'components/01-atoms'),
@@ -25,5 +26,6 @@ module.exports.setupTwig = function setupTwig(twig) {
   twigBEM(twig);
   twigAddAttributes(twig);
   twigUrl(twig);
+  twigAssetPath(twig);
   return twig;
 };

--- a/.storybook/twig-asset-path.js
+++ b/.storybook/twig-asset-path.js
@@ -1,0 +1,44 @@
+/**
+ * Custom Twig function to get versioned asset paths from webpack manifest.
+ *
+ * This is the Storybook (JavaScript) equivalent of the Drupal PHP function
+ * in CoreTwigExtension.php.
+ */
+const path = require('path');
+const fs = require('fs');
+
+module.exports = function twigAssetPath(twigInstance) {
+  /**
+   * Get the versioned asset path from the webpack manifest.
+   *
+   * @param {string} assetName - The original asset filename (e.g., 'icons.svg')
+   * @param {string} directory - Optional directory path (used in Drupal, ignored in Storybook)
+   * @returns {string} The versioned asset path, or original filename if not found
+   */
+  const getAssetPath = (assetName, directory = null) => {
+    try {
+      // In Storybook context, always load from dist/manifest.json
+      // The directory parameter is only used in Drupal context, so we ignore it here
+      const manifestPath = path.join(__dirname, '..', 'dist', 'manifest.json');
+
+      if (fs.existsSync(manifestPath)) {
+        const manifestContent = fs.readFileSync(manifestPath, 'utf8');
+        const manifest = JSON.parse(manifestContent);
+
+        // Return versioned filename if found in manifest
+        if (manifest[assetName]) {
+          return manifest[assetName];
+        }
+      }
+    } catch (error) {
+      // Fail gracefully - log warning but don't break rendering
+      console.warn(`getAssetPath: Could not load manifest or find "${assetName}":`, error.message);
+    }
+
+    // Fallback to original filename (matches Drupal behavior)
+    return assetName;
+  };
+
+  // Register the function with Twig
+  twigInstance.extendFunction('getAssetPath', getAssetPath);
+};


### PR DESCRIPTION
## [1101: getAssetPath Twig function missing in Storybook](https://github.com/yalesites-org/YaleSites-Internal/issues/1101)

### Description of work
- Adds getAssetPath Twig function for Storybook
- Fixes "Unknown getAssetPath function" error in component stories
- Implements JavaScript equivalent of Drupal's CoreTwigExtension function

Closes yalesites-org/YaleSites-Internal#1101

### Testing Link(s)
- [ ] Navigate to the [Textfields Examples Story](https://deploy-preview-612--dev-component-library-twig.netlify.app/?path=/story/atoms-forms--textfields-examples)
- [ ] Navigate to the [Icon Story](https://deploy-preview-612--dev-component-library-twig.netlify.app/?path=/story/atoms-images--icons)
- [ ] Navigate to the [Utility Nav Story](https://deploy-preview-612--dev-component-library-twig.netlify.app/?path=/story/organisms-menu-utility-nav--utility-nav-examples)

### Functional Review Steps
- [ ] Verify no Twig errors appear when viewing stories that use icons
- [ ] Verify icons load correctly in all component stories
- [ ] Inspect browser DevTools to confirm versioned filename (e.g., icons.35df26b6.svg) is used
- [ ] Check browser console for no warnings related to getAssetPath function

### Design Review
- [ ] Verify icons display correctly with no visual regressions

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
