### PR TITLE
RC: Microsite header style not the same as parent site header

### DIFF
--- a/components/03-organisms/site-header/yds-site-header.twig
+++ b/components/03-organisms/site-header/yds-site-header.twig
@@ -112,6 +112,7 @@
           link__base_class: 'collection-microsite-branding',
           link__modifiers: [modifiers],
           link__blockname: base_class,
+          link__style: 'no-underline',
         } %}
       {% endif %}
     </div>


### PR DESCRIPTION
## [1115: RC: microsite header style not the same as parent site header](https://github.com/yalesites-org/YaleSites-Internal/issues/1115)

### Description of work
- Fixes microsite branding link underline styling in site header
- Adds `no-underline` style to collection microsite branding link

Closes https://github.com/yalesites-org/YaleSites-Internal/issues/1115

#### Related PRs:
- Atomic: https://github.com/yalesites-org/atomic/pull/437

### Testing Link(s)
- [ ] Navigate to the multidev: https://github.com/yalesites-org/yalesites-project/pull/1205

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
