### PR TITLE
Bump tokens to 1.37.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5355,9 +5355,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.36.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.36.0/bec7ac4f82ab8c61d4f7539d6fc1f4c9f0ccadda",
-      "integrity": "sha512-Smjy/TzR8z+wjDbWdSBIWNkhrZBV/1ku5P2EK5GX+GhGH3smxVRCjpT/JOj19FGsRNq/Dw2zavk6dq26YxyJKw=="
+      "version": "1.37.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.37.0/8af2a002d29d64873024c565407aba6404fcf30a",
+      "integrity": "sha512-zYtyuOdVZod7lBhOn32RWXHb7C22ZxujCHCAOFkRqFsYL+KnViE6w4dR6r5uspunLhlIkg0Skktn/gvEyWfb1Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",


### PR DESCRIPTION
## Bump tokens to 1.37.0

### Description of work
- Adds latest tokens version to component library twig

[See it in action here](https://deploy-preview-619--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--colors)