### PR TITLE
Release Update: 1125: Site name when using nav position right is breaking too early

### DIFF
--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -395,13 +395,6 @@ $site-name-as-logo-height-sm: 6.25rem; // 100px
       letter-spacing: 0.075em;
     }
   }
-
-  // if right alignment, limit the branding width
-  @media (min-width: tokens.$break-mobile) {
-    [data-site-header-nav-position='right'] & {
-      max-width: 36.5%;
-    }
-  }
 }
 
 .site-header__collection-nav-branding {


### PR DESCRIPTION
## [Release Update: 1125: Site name when using nav position right is breaking too early](https://github.com/yalesites-org/YaleSites-Internal/issues/1125)

### Description of work
- Fixes site name wrapping too early when nav position is set to right

Closes https://github.com/yalesites-org/YaleSites-Internal/issues/1125

### Testing Link(s)
- [ ] Navigate to [the multidev PR site](https://github.com/yalesites-org/yalesites-project/pull/1219)

### Functional Review Steps
- [ ] Set nav position to "right" and verify site name displays without premature wrapping
- [ ] Make the site name very long with spaces
- [ ] Verify nav position left and center are unaffected

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
