### PR TITLE
#1140 :: Support Portrait Images in Resource Category View Block

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -90,6 +90,7 @@ export const parameters = {
         'Atoms',
         'Molecules',
         'Organisms',
+        ['Card Collection', ['Docs', 'Visreg', '*']],
         'Page Layouts',
         'Page Examples',
         ['Overview', '*'],

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -253,6 +253,27 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
       }
     }
 
+    // Resource portrait grid.
+    [data-collection-type='grid'][data-collection-source='resource-portrait']
+      & {
+      aspect-ratio: 5/8;
+
+      // Safari 14 fix for aspect-ratio
+      @supports not (aspect-ratio: 5 / 8) {
+        &::before {
+          float: left;
+          padding-top: 160%;
+          content: '';
+        }
+
+        &::after {
+          display: block;
+          content: '';
+          clear: both;
+        }
+      }
+    }
+
     // Profile list non-featured
     [data-collection-source='profile'][data-collection-type='list'][data-collection-featured='false']
       & {
@@ -267,7 +288,8 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
   }
 
   // Resource thumbnail show top of the PDF file
-  [data-collection-source='resource'] & {
+  [data-collection-source='resource'] &,
+  [data-collection-source='resource-portrait'] & {
     overflow: hidden;
   }
 

--- a/components/02-molecules/cards/reference-card/_yds-reference-card.scss
+++ b/components/02-molecules/cards/reference-card/_yds-reference-card.scss
@@ -254,8 +254,7 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
     }
 
     // Resource portrait grid.
-    [data-collection-type='grid'][data-collection-source='resource-portrait']
-      & {
+    .card-collection--resource-portrait[data-collection-type='grid'] & {
       aspect-ratio: 5/8;
 
       // Safari 14 fix for aspect-ratio
@@ -289,7 +288,7 @@ $break-single-card-collection-max: tokens.$break-xl - 0.05;
 
   // Resource thumbnail show top of the PDF file
   [data-collection-source='resource'] &,
-  [data-collection-source='resource-portrait'] & {
+  .card-collection--resource-portrait & {
     overflow: hidden;
   }
 

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -307,14 +307,19 @@ export const ResourceCard = ({
   showEyebrow,
   showTags,
   overlayText,
+  portrait,
 }) => `
-<div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
+<div class='card-collection${
+  portrait ? ' card-collection--resource-portrait' : ''
+}' data-component-width='site'${
+  portrait ? " data-collection-source='resource'" : ''
+} data-collection-type='${collectionType}' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
       ${referenceCardTwig({
         card_collection__source_type: 'resource',
         card_collection__type: collectionType,
-        ...imageData.responsive_images['3x2'],
+        ...imageData.responsive_images[portrait ? '1x1.6' : '3x2'],
         reference_card__date: date,
         reference_card__eyebrow: eyebrow,
         reference_card__heading: heading,
@@ -336,6 +341,7 @@ export const ResourceCard = ({
 `;
 const resourceCardArgs = {
   showCategories: true,
+  portrait: false,
   date: referenceResourceData.reference_card__date,
 };
 ResourceCard.argTypes = addTableDefaults(
@@ -344,64 +350,12 @@ ResourceCard.argTypes = addTableDefaults(
       name: 'Date',
       type: 'string',
     },
+    portrait: {
+      name: 'Portrait',
+      type: 'boolean',
+    },
   },
   resourceCardArgs,
 );
 
 ResourceCard.args = resourceCardArgs;
-
-export const ResourcePortraitCard = ({
-  date,
-  eyebrow,
-  heading,
-  snippet,
-  collectionType,
-  featured,
-  withImage,
-  showCategories,
-  showEyebrow,
-  showTags,
-  overlayText,
-}) => `
-<div class='card-collection card-collection--resource-portrait' data-component-width='site' data-collection-source='resource' data-collection-type='${collectionType}' data-collection-featured="${featured}">
-  <div class='card-collection__inner'>
-    <ul class='card-collection__cards'>
-      ${referenceCardTwig({
-        card_collection__source_type: 'resource',
-        card_collection__type: collectionType,
-        ...imageData.responsive_images['1x1.6'],
-        reference_card__date: date,
-        reference_card__eyebrow: eyebrow,
-        reference_card__heading: heading,
-        reference_card__snippet: snippet,
-        reference_card__featured: featured ? 'true' : 'false',
-        reference_card__image: withImage ? 'true' : 'false',
-        reference_card__url: referenceResourceData.reference_card__url,
-        show_categories: showCategories,
-        show_eyebrow: showEyebrow,
-        show_tags: showTags,
-        reference_card__categories:
-          referenceResourceData.reference_card__categories,
-        reference_card__tags: referenceResourceData.reference_card__tags,
-        reference_card__overlay: overlayText,
-      })}
-    </ul>
-  </div>
-</div>
-`;
-const resourcePortraitCardArgs = {
-  showCategories: true,
-  featured: false,
-  date: referenceResourceData.reference_card__date,
-};
-ResourcePortraitCard.argTypes = addTableDefaults(
-  {
-    date: {
-      name: 'Date',
-      type: 'string',
-    },
-  },
-  resourcePortraitCardArgs,
-);
-
-ResourcePortraitCard.args = resourcePortraitCardArgs;

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -349,3 +349,59 @@ ResourceCard.argTypes = addTableDefaults(
 );
 
 ResourceCard.args = resourceCardArgs;
+
+export const ResourcePortraitCard = ({
+  date,
+  eyebrow,
+  heading,
+  snippet,
+  collectionType,
+  featured,
+  withImage,
+  showCategories,
+  showEyebrow,
+  showTags,
+  overlayText,
+}) => `
+<div class='card-collection card-collection--resource-portrait' data-component-width='site' data-collection-source='resource' data-collection-type='${collectionType}' data-collection-featured="${featured}">
+  <div class='card-collection__inner'>
+    <ul class='card-collection__cards'>
+      ${referenceCardTwig({
+        card_collection__source_type: 'resource',
+        card_collection__type: collectionType,
+        ...imageData.responsive_images['1x1.6'],
+        reference_card__date: date,
+        reference_card__eyebrow: eyebrow,
+        reference_card__heading: heading,
+        reference_card__snippet: snippet,
+        reference_card__featured: featured ? 'true' : 'false',
+        reference_card__image: withImage ? 'true' : 'false',
+        reference_card__url: referenceResourceData.reference_card__url,
+        show_categories: showCategories,
+        show_eyebrow: showEyebrow,
+        show_tags: showTags,
+        reference_card__categories:
+          referenceResourceData.reference_card__categories,
+        reference_card__tags: referenceResourceData.reference_card__tags,
+        reference_card__overlay: overlayText,
+      })}
+    </ul>
+  </div>
+</div>
+`;
+const resourcePortraitCardArgs = {
+  showCategories: true,
+  featured: false,
+  date: referenceResourceData.reference_card__date,
+};
+ResourcePortraitCard.argTypes = addTableDefaults(
+  {
+    date: {
+      name: 'Date',
+      type: 'string',
+    },
+  },
+  resourcePortraitCardArgs,
+);
+
+ResourcePortraitCard.args = resourcePortraitCardArgs;

--- a/components/03-organisms/card-collection/card-collection.mdx
+++ b/components/03-organisms/card-collection/card-collection.mdx
@@ -9,12 +9,44 @@ import componentProps from './card-collection-props.yml';
 
 The card collection component displays multiple cards in a flexible grid or list layout. It supports various card types including posts, events, profiles, resources, and directory listings. Card collections can be configured with different layout modes, featured positioning, and image display options to create organized, scannable content groupings across the site.
 
-## Interactive Preview
+## Card Type Variants
 
-Use the controls panel below to experiment with the card collection's properties in real-time.
+The card collection supports the following card types. Each section below is fully interactive — use the controls panel to experiment with layout, featured mode, and image options.
+
+### Post Cards
+
+Standard content cards for blog posts, news, or general content. Supports 3x2 images, headlines, excerpts, and publication date.
 
 <Canvas of={CardCollectionStories.PostCardCollection} />
 <Controls of={CardCollectionStories.PostCardCollection} />
+
+### Event Cards
+
+Specialized cards for events with date, format (online/in-person), and CTAs. Supports 3x2 images.
+
+<Canvas of={CardCollectionStories.EventCardCollection} />
+<Controls of={CardCollectionStories.EventCardCollection} />
+
+### Profile Cards
+
+People-focused cards with headshots, names, titles, and affiliations. Uses 1x1 images.
+
+<Canvas of={CardCollectionStories.ProfileCardCollection} />
+<Controls of={CardCollectionStories.ProfileCardCollection} />
+
+### Directory Listing Cards
+
+Compact profile cards for directory views. Uses the `profile-directory` layout type.
+
+<Canvas of={CardCollectionStories.DirectoryListingCardCollection} />
+<Controls of={CardCollectionStories.DirectoryListingCardCollection} />
+
+### Resource Cards
+
+Cards for downloadable resources, documents, or external links. Supports icons, file types, and overlay labels like "Pinned". Toggle the **Portrait** control to switch to the portrait display mode, which renders images at a 1:1.6 ratio.
+
+<Canvas of={CardCollectionStories.ResourceCardCollection} />
+<Controls of={CardCollectionStories.ResourceCardCollection} />
 
 ## Properties
 
@@ -26,39 +58,48 @@ Use the controls panel below to experiment with the card collection's properties
 
 {twigPropsTable(componentProps, 'optional')}
 
-## Card Type Variants
+### Property Compatibility by Card Type
 
-The card collection supports five distinct card types, each optimized for different content types:
+Not all properties apply to every card type. The controls panel in each section above reflects this automatically.
 
-<Canvas of={CardCollectionStories.PostCardCollection} />
-
-### Post Cards
-
-Standard content cards displaying blog posts, news articles, or general content. Supports 3x2 aspect ratio images, headlines, excerpts, and metadata like publication date.
-
-<Canvas of={CardCollectionStories.EventCardCollection} />
-
-### Event Cards
-
-Specialized cards for events displaying date, time, format (online/in-person), location, and event details. Supports 3x2 aspect ratio images.
-
-<Canvas of={CardCollectionStories.ProfileCardCollection} />
-
-### Profile Cards
-
-People-focused cards displaying headshots, names, titles, and affiliations. Uses 1x1 aspect ratio images optimized for portrait photography.
-
-<Canvas of={CardCollectionStories.DirectoryListingCardCollection} />
-
-### Directory Listing Cards
-
-Compact profile cards designed for directory views. Uses the <code>profile-directory</code> layout type for efficient display of multiple people.
-
-<Canvas of={CardCollectionStories.ResourceCardCollection} />
-
-### Resource Cards
-
-Cards for downloadable resources, documents, or external links. Supports icons, file types, and overlay labels like "Pinned".
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Post</th>
+      <th>Event</th>
+      <th>Profile</th>
+      <th>Directory</th>
+      <th>Resource</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Heading</td>
+      <td>Y</td><td>Y</td><td>Y</td><td>Y</td><td>Y</td>
+    </tr>
+    <tr>
+      <td>Collection Type</td>
+      <td>Y</td><td>Y</td><td>Y</td><td>—</td><td>Y</td>
+    </tr>
+    <tr>
+      <td>Featured</td>
+      <td>Y</td><td>Y</td><td>Y</td><td>Y</td><td>Y</td>
+    </tr>
+    <tr>
+      <td>With Images</td>
+      <td>Y</td><td>Y</td><td>Y</td><td>—</td><td>Y</td>
+    </tr>
+    <tr>
+      <td>Overlay</td>
+      <td>Y</td><td>—</td><td>—</td><td>—</td><td>Y</td>
+    </tr>
+    <tr>
+      <td>Portrait</td>
+      <td>—</td><td>—</td><td>—</td><td>—</td><td>Y</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Collection Layouts
 

--- a/components/03-organisms/card-collection/card-collection.mdx
+++ b/components/03-organisms/card-collection/card-collection.mdx
@@ -76,27 +76,51 @@ Not all properties apply to every card type. The controls panel in each section 
   <tbody>
     <tr>
       <td>Heading</td>
-      <td>Y</td><td>Y</td><td>Y</td><td>Y</td><td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
     </tr>
     <tr>
       <td>Collection Type</td>
-      <td>Y</td><td>Y</td><td>Y</td><td>—</td><td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>—</td>
+      <td>Y</td>
     </tr>
     <tr>
       <td>Featured</td>
-      <td>Y</td><td>Y</td><td>Y</td><td>Y</td><td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
     </tr>
     <tr>
       <td>With Images</td>
-      <td>Y</td><td>Y</td><td>Y</td><td>—</td><td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>Y</td>
+      <td>—</td>
+      <td>Y</td>
     </tr>
     <tr>
       <td>Overlay</td>
-      <td>Y</td><td>—</td><td>—</td><td>—</td><td>Y</td>
+      <td>Y</td>
+      <td>—</td>
+      <td>—</td>
+      <td>—</td>
+      <td>Y</td>
     </tr>
     <tr>
       <td>Portrait</td>
-      <td>—</td><td>—</td><td>—</td><td>—</td><td>Y</td>
+      <td>—</td>
+      <td>—</td>
+      <td>—</td>
+      <td>—</td>
+      <td>Y</td>
     </tr>
   </tbody>
 </table>

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -152,6 +152,3 @@ export const ResourcePortraitCardCollection = ({
 ResourcePortraitCardCollection.args = {
   featured: false,
 };
-ResourcePortraitCardCollection.args = {
-  featured: false,
-};

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -152,3 +152,6 @@ export const ResourcePortraitCardCollection = ({
 ResourcePortraitCardCollection.args = {
   featured: false,
 };
+ResourcePortraitCardCollection.args = {
+  featured: false,
+};

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -126,3 +126,29 @@ export const ResourceCardCollection = ({
     ...imageData.responsive_images['3x2'],
   });
 };
+
+export const ResourcePortraitCardCollection = ({
+  heading,
+  collectionType,
+  featured,
+  withImages,
+  withOverlay,
+}) => {
+  const items = featured ? [1, 2, 3] : [1, 2, 3, 4];
+
+  return cardCollectionTwig({
+    card_collection__source_type: 'resource',
+    card_collection__modifiers: ['resource-portrait'],
+    card_collection__type: collectionType,
+    card_collection__heading: heading,
+    card_collection__featured: featured ? 'true' : 'false',
+    card_collection__with_images: withImages ? 'true' : 'false',
+    card_collection__cards: items,
+    reference_card__overlay: withOverlay ? 'Pinned' : '',
+    ...resourceCardData,
+    ...imageData.responsive_images['1x1.6'],
+  });
+};
+ResourcePortraitCardCollection.args = {
+  featured: false,
+};

--- a/components/03-organisms/card-collection/card-collection.stories.js
+++ b/components/03-organisms/card-collection/card-collection.stories.js
@@ -8,6 +8,7 @@ import resourceCardData from '../../02-molecules/cards/reference-card/examples/r
 import imageData from '../../01-atoms/images/image/image.yml';
 import componentProps from './card-collection-props.yml';
 import { toArgTypes, toArgs } from '../../_storybook/component-props';
+import { addTableDefaults } from '../../_storybook/add-table-defaults';
 
 /**
  * Storybook Definition.
@@ -65,6 +66,10 @@ export const EventCardCollection = ({
   });
 };
 
+EventCardCollection.argTypes = {
+  withOverlay: { table: { disable: true } },
+};
+
 export const ProfileCardCollection = ({
   heading,
   collectionType,
@@ -83,6 +88,10 @@ export const ProfileCardCollection = ({
     ...profileCardData,
     ...imageData.responsive_images['1x1'],
   });
+};
+
+ProfileCardCollection.argTypes = {
+  withOverlay: { table: { disable: true } },
 };
 
 export const DirectoryListingCardCollection = ({
@@ -105,17 +114,25 @@ export const DirectoryListingCardCollection = ({
   });
 };
 
+DirectoryListingCardCollection.argTypes = {
+  collectionType: { table: { disable: true } },
+  withImages: { table: { disable: true } },
+  withOverlay: { table: { disable: true } },
+};
+
 export const ResourceCardCollection = ({
   heading,
   collectionType,
   featured,
   withImages,
   withOverlay,
+  portrait,
 }) => {
   const items = featured ? [1, 2, 3] : [1, 2, 3, 4];
 
   return cardCollectionTwig({
     card_collection__source_type: 'resource',
+    card_collection__modifiers: portrait ? ['resource-portrait'] : [],
     card_collection__type: collectionType,
     card_collection__heading: heading,
     card_collection__featured: featured ? 'true' : 'false',
@@ -123,32 +140,19 @@ export const ResourceCardCollection = ({
     card_collection__cards: items,
     reference_card__overlay: withOverlay ? 'Pinned' : '',
     ...resourceCardData,
-    ...imageData.responsive_images['3x2'],
+    ...imageData.responsive_images[portrait ? '1x1.6' : '3x2'],
   });
 };
-
-export const ResourcePortraitCardCollection = ({
-  heading,
-  collectionType,
-  featured,
-  withImages,
-  withOverlay,
-}) => {
-  const items = featured ? [1, 2, 3] : [1, 2, 3, 4];
-
-  return cardCollectionTwig({
-    card_collection__source_type: 'resource',
-    card_collection__modifiers: ['resource-portrait'],
-    card_collection__type: collectionType,
-    card_collection__heading: heading,
-    card_collection__featured: featured ? 'true' : 'false',
-    card_collection__with_images: withImages ? 'true' : 'false',
-    card_collection__cards: items,
-    reference_card__overlay: withOverlay ? 'Pinned' : '',
-    ...resourceCardData,
-    ...imageData.responsive_images['1x1.6'],
-  });
+const resourceCardCollectionArgs = {
+  portrait: false,
 };
-ResourcePortraitCardCollection.args = {
-  featured: false,
-};
+ResourceCardCollection.argTypes = addTableDefaults(
+  {
+    portrait: {
+      name: 'Portrait',
+      type: 'boolean',
+    },
+  },
+  resourceCardCollectionArgs,
+);
+ResourceCardCollection.args = resourceCardCollectionArgs;

--- a/components/03-organisms/card-collection/card-collection.visreg.stories.js
+++ b/components/03-organisms/card-collection/card-collection.visreg.stories.js
@@ -83,6 +83,19 @@ export const Visreg = () => {
       ...imageData.responsive_images['3x2'],
     })}
 
+    <h3>Resource Portrait Cards</h3>
+    ${cardCollectionTwig({
+      card_collection__source_type: 'resource',
+      card_collection__modifiers: ['resource-portrait'],
+      card_collection__type: collectionType,
+      card_collection__heading: 'Resource Portrait Card Collection',
+      card_collection__featured: 'false',
+      card_collection__with_images: withImages ? 'true' : 'false',
+      card_collection__cards: [1, 2, 3, 4],
+      ...resourceCardData,
+      ...imageData.responsive_images['1x1.6'],
+    })}
+
     <h3>Directory Listing Cards</h3>
     ${cardCollectionTwig({
       card_collection__source_type: 'directory-listing',


### PR DESCRIPTION
## [#1140: Support Portrait Images in Resource Category View Block](https://github.com/yalesites-org/YaleSites-Internal/issues/1140)

### Description of work
- SCSS updates for resource portrait view mode
- Added a Storybook preview of the cards and card collection: https://deploy-preview-628--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--resource-portrait-card-collection

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-628--dev-component-library-twig.netlify.app/?path=/story/organisms-card-collection--resource-portrait-card-collection)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
