### PR TITLE
1188: Refactor text-copy-button to support extensible copy feedback UI

### DIFF
--- a/components/01-atoms/controls/text-copy-button/yds-text-copy-button.js
+++ b/components/01-atoms/controls/text-copy-button/yds-text-copy-button.js
@@ -1,35 +1,119 @@
+/**
+ * @file yds-text-copy-button.js
+ *
+ * Copies the text inside `.pre-text__text` to the clipboard when a
+ * `.text-copy-button__button` is clicked. After a successful copy the behavior
+ * fires a `text-copy-button:copied` CustomEvent that bubbles up the DOM,
+ * allowing consumers to swap in their own feedback UI.
+ *
+ * ## Overriding the default feedback
+ *
+ * The default feedback replaces the button's text content with
+ * "Copied to clipboard", then reverts to "(Copy)" after 1.2 s. To replace
+ * this with custom UI (e.g. an icon swap), listen for the event and call
+ * `event.preventDefault()`:
+ *
+ * @example
+ * document.addEventListener('text-copy-button:copied', (e) => {
+ *   // Scope to a specific context if needed:
+ *   if (!e.detail.button.closest('.my-component')) return;
+ *
+ *   // Prevent the default "(Copy)" → "Copied to clipboard" text swap.
+ *   e.preventDefault();
+ *
+ *   // Provide custom feedback — e.g. toggle a CSS modifier for an icon swap.
+ *   const btn = e.detail.button;
+ *   btn.classList.add('my-component__copy-btn--copied');
+ *   setTimeout(() => btn.classList.remove('my-component__copy-btn--copied'), 1200);
+ * });
+ *
+ * ## Event detail
+ *
+ * @property {string}      detail.text   - The plain text that was copied.
+ * @property {HTMLElement} detail.button - The button element that was clicked.
+ *
+ * ## Screen reader announcements
+ *
+ * Regardless of whether the default feedback is suppressed, a `role="status"`
+ * live region always announces "Copied [text] to clipboard" to assistive
+ * technology (WCAG 4.1.3 Status Messages, Level AA).
+ */
 Drupal.behaviors.textCopyButton = {
   attach(context) {
-    // Add click event listener for clicking the text
-    const elems = context.querySelectorAll('.text-copy-button__button');
-    elems.forEach((elem) => {
-      elem.addEventListener(
-        'click',
-        (event) => {
-          // Only fire if the target has id copy
-          if (!event.target.matches('.text-copy-button__button')) return;
+    // Only bind buttons that haven't been initialized (idempotency guard).
+    // Drupal.attachBehaviors() is called on every AJAX request and every
+    // Storybook render — without this guard, listeners stack.
+    const elems = context.querySelectorAll(
+      '.text-copy-button__button:not([data-text-copy-init])',
+    );
 
-          if (!navigator.clipboard) {
-            // Clipboard API not available
-            return;
-          }
-          const text = event.target.parentNode
-            .querySelector('.pre-text__text')
-            .textContent.trim();
-          try {
-            navigator.clipboard.writeText(text);
-            const triggerValue = elem;
-            triggerValue.innerHTML = 'Copied to clipboard';
-            setTimeout(() => {
-              triggerValue.innerHTML = '(Copy)';
-            }, 1200);
-          } catch (error) {
-            const triggerValue = elem;
-            triggerValue.innerHTML = '(error)';
-          }
-        },
-        false,
-      );
+    elems.forEach((elem) => {
+      elem.setAttribute('data-text-copy-init', '');
+
+      elem.addEventListener('click', (event) => {
+        const btn = event.target.closest('.text-copy-button__button');
+        if (!btn || !navigator.clipboard) return;
+
+        // Use closest() rather than parentNode so this works regardless of
+        // whether the button contains nested elements (text, SVG icons, etc.).
+        const wrapper = btn.closest('.text-copy-button');
+        if (!wrapper) return;
+
+        const source = wrapper.querySelector('.pre-text__text');
+        if (!source) return;
+
+        const text = source.textContent.trim();
+
+        navigator.clipboard
+          .writeText(text)
+          .then(() => {
+            // Dispatch a cancelable event. Consumers can call preventDefault()
+            // to suppress the default text feedback and provide their own UI.
+            const copyEvent = new CustomEvent('text-copy-button:copied', {
+              bubbles: true,
+              cancelable: true,
+              detail: { text, button: btn },
+            });
+            const useDefault = btn.dispatchEvent(copyEvent);
+
+            // Announce copy result to screen readers (WCAG 4.1.3 Status Messages).
+            Drupal.behaviors.textCopyButton.announce(
+              `Copied ${text} to clipboard`,
+            );
+
+            if (useDefault) {
+              // Default text feedback — unchanged from original behavior.
+              btn.textContent = 'Copied to clipboard';
+              setTimeout(() => {
+                btn.textContent = '(Copy)';
+              }, 1200);
+            }
+          })
+          .catch(() => {
+            btn.textContent = '(error)';
+          });
+      });
     });
+  },
+
+  /**
+   * Announces a message to screen readers via a shared aria-live region.
+   * The region is created on first call and reused thereafter.
+   *
+   * @param {string} message - Plain text to announce.
+   */
+  announce(message) {
+    let region = document.querySelector('.text-copy-button__status');
+    if (!region) {
+      region = document.createElement('div');
+      region.className = 'text-copy-button__status visually-hidden';
+      region.setAttribute('role', 'status');
+      region.setAttribute('aria-live', 'polite');
+      document.body.appendChild(region);
+    }
+    region.textContent = message;
+    setTimeout(() => {
+      region.textContent = '';
+    }, 1200);
   },
 };

--- a/components/01-atoms/controls/text-copy-button/yds-text-copy-button.js
+++ b/components/01-atoms/controls/text-copy-button/yds-text-copy-button.js
@@ -31,12 +31,6 @@
  *
  * @property {string}      detail.text   - The plain text that was copied.
  * @property {HTMLElement} detail.button - The button element that was clicked.
- *
- * ## Screen reader announcements
- *
- * Regardless of whether the default feedback is suppressed, a `role="status"`
- * live region always announces "Copied [text] to clipboard" to assistive
- * technology (WCAG 4.1.3 Status Messages, Level AA).
  */
 Drupal.behaviors.textCopyButton = {
   attach(context) {
@@ -76,17 +70,11 @@ Drupal.behaviors.textCopyButton = {
             });
             const useDefault = btn.dispatchEvent(copyEvent);
 
-            // Announce copy result to screen readers (WCAG 4.1.3 Status Messages).
-            Drupal.behaviors.textCopyButton.announce(
-              `Copied ${text} to clipboard`,
-            );
-
             if (useDefault) {
-              // Default text feedback — unchanged from original behavior.
               btn.textContent = 'Copied to clipboard';
               setTimeout(() => {
                 btn.textContent = '(Copy)';
-              }, 1200);
+              }, 1700);
             }
           })
           .catch(() => {
@@ -94,26 +82,5 @@ Drupal.behaviors.textCopyButton = {
           });
       });
     });
-  },
-
-  /**
-   * Announces a message to screen readers via a shared aria-live region.
-   * The region is created on first call and reused thereafter.
-   *
-   * @param {string} message - Plain text to announce.
-   */
-  announce(message) {
-    let region = document.querySelector('.text-copy-button__status');
-    if (!region) {
-      region = document.createElement('div');
-      region.className = 'text-copy-button__status visually-hidden';
-      region.setAttribute('role', 'status');
-      region.setAttribute('aria-live', 'polite');
-      document.body.appendChild(region);
-    }
-    region.textContent = message;
-    setTimeout(() => {
-      region.textContent = '';
-    }, 1200);
   },
 };

--- a/components/01-atoms/controls/text-copy-button/yds-text-copy-button.twig
+++ b/components/01-atoms/controls/text-copy-button/yds-text-copy-button.twig
@@ -25,7 +25,7 @@
 		</span>
 	{% endif %}
 
-	<button {{ bem('button', [], text_copy_button__base_class) }}>
+	<button {{ bem('button', [], text_copy_button__base_class) }}{% if text_copy_button__pre_text %} aria-label="Copy {{ text_copy_button__pre_text }}"{% endif %}>
 		{% block text_copy_button__content %}
 			{{- text_copy_button__content -}}
 		{% endblock %}

--- a/components/01-atoms/controls/text-copy-button/yds-text-copy-button.twig
+++ b/components/01-atoms/controls/text-copy-button/yds-text-copy-button.twig
@@ -25,7 +25,7 @@
 		</span>
 	{% endif %}
 
-	<button {{ bem('button', [], text_copy_button__base_class) }}{% if text_copy_button__pre_text %} aria-label="Copy {{ text_copy_button__pre_text }}"{% endif %}>
+	<button {{ bem('button', [], text_copy_button__base_class) }}>
 		{% block text_copy_button__content %}
 			{{- text_copy_button__content -}}
 		{% endblock %}


### PR DESCRIPTION
## [#1188: Refactor text-copy-button to support extensible copy feedback UI](https://github.com/yalesites-org/YaleSites-Internal/issues/1188)

Closes yalesites-org/YaleSites-Internal#1188

### Description of work
- Introduces a cancelable `text-copy-button:copied` CustomEvent dispatched on every successful copy, allowing consumers to call `event.preventDefault()` and provide their own feedback UI (e.g. icon swap) without modifying this atom
- Adds idempotency guard via `:not([data-text-copy-init])` to prevent duplicate listeners when `Drupal.attachBehaviors()` is called repeatedly
- Replaces fragile `parentNode` traversal with `closest()` so clicks on nested elements (SVG icons, spans) resolve correctly
- Replaces `innerHTML` with `textContent` for plain string assignments
- Increases the copy confirmation timeout from 1200 ms to 1700 ms (see Accessibility notes below)

### Screen reader announcement approach

Several approaches were evaluated for announcing copy success across all screen reader and browser combinations:

- **`aria-live` regions** (`role="status"`, `role="log"`, `role="alert"`) — silently dropped by VoiceOver in Chromium regardless of `aria-live` value or how the region is constructed
- **Focused off-screen elements** — the project's `.visually-hidden` class uses `clip: rect(1px,1px,1px,1px)` which causes VoiceOver + Chrome to treat the element as inaccessible, even when focused
- **`aria-label` on the button** — overrides the accessible name entirely, so changing `textContent` to "Copied to clipboard" is never reached by screen readers; VoiceOver always reads the static `aria-label` value instead

The only mechanism that works consistently across VoiceOver (Safari and Chrome), NVDA, and JAWS is relying on the **focused button's own text content change**. Clicking a `<button>` moves focus to it per spec, so when `textContent` becomes `'Copied to clipboard'` the new accessible name is announced immediately without a separate announcement element or live region.

The `aria-label` added in a prior iteration has been removed for the same reason.

The revert timeout is set to 1700 ms rather than the original 1200 ms to give screen readers enough time to finish announcing "Copied to clipboard" before the button text reverts to "(Copy)". At 1200 ms the utterance was consistently cut off mid-read; 1700 ms provides a comfortable buffer at normal speech rates.

### Testing Link(s)
- [ ] Navigate to the [Text Copy Button Story](https://deploy-preview-632--dev-component-library-twig.netlify.app/?path=/docs/atoms-controls--docs#text-copy-button)
- [ ] Navigate to the multidev at https://github.com/yalesites-org/yalesites-project/pull/1243

### Functional Review Steps
- [ ] Click "(Copy)" — button shows "Copied to clipboard", reverts to "(Copy)" after 1.7 s
- [ ] Verify clipboard contains the expected text
- [ ] Click multiple times rapidly — no erratic behavior (idempotency guard working)
- [ ] In browser console, add a listener with `e.preventDefault()` — button text should not change when copy is clicked
- [ ] Visit the Drupal multidev and test profile creation that has the copy button

### Design Review
- [ ] Verify the component appearance is unchanged from before this refactor

### Accessibility Review
- [ ] With VoiceOver + Chrome: activate copy button via Space/Enter — VoiceOver announces "Copied to clipboard"
- [ ] With VoiceOver + Safari: same test — VoiceOver announces "Copied to clipboard"
- [ ] Click copy multiple times in succession — announcement fires each time
- [ ] Run axe in the a11y addon — no new violations

### Notes
- [ ] To play with the copy event in Storybook, add this to the console and then click:
     ```js
     document.addEventListener('text-copy-button:copied', (e) => {
       console.log('Event fired:', e.detail.text);
     });
     ```
- [ ] To play with overriding the text swap, add this to the console and then click:
     ```js
     document.addEventListener('text-copy-button:copied', (e) => {
       e.preventDefault();
       console.log('Default prevented — no text swap should happen');
     });
     ```