### PR TITLE
#1178: Enhance Storybook Color Page with Copyable Color Values (HEX, RGB, CMYK, Pantone)

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,6 +8,9 @@ module.exports = {
     '../images', 
     '../fonts'
   ],
+  core: {
+    disableTelemetry: true,
+  },
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-links',

--- a/components/00-tokens/colors/cl-colors.scss
+++ b/components/00-tokens/colors/cl-colors.scss
@@ -1,3 +1,7 @@
+// Success green used for the copy-button check icon. No Yale token equivalent —
+// defined here so there is one place to update it if the value ever changes.
+$cl-colors-copy-success: #16a34a;
+
 // Card grid — scoped under .cl-colors so it doesn't affect color-global-themes.twig,
 // which also uses .cl-colors__list and .cl-colors__item but without a .cl-colors wrapper.
 .cl-colors {
@@ -11,7 +15,7 @@
   }
 
   .cl-colors__item {
-    background: #fff;
+    background: var(--color-basic-white);
     border: 1px solid #e5e7eb;
     box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
     overflow: hidden;
@@ -107,7 +111,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid #00356b;
+      outline: 2px solid var(--color-blue-yale);
       outline-offset: 2px;
     }
 
@@ -121,12 +125,12 @@
     }
 
     &--copied {
-      color: #16a34a;
+      color: $cl-colors-copy-success;
 
       // Keep green during hover — the base &:hover rule has equal specificity
       // but appears earlier in source, so this later rule wins the cascade.
       &:hover {
-        color: #16a34a;
+        color: $cl-colors-copy-success;
       }
 
       .cl-colors__icon-copy {

--- a/components/00-tokens/colors/cl-colors.scss
+++ b/components/00-tokens/colors/cl-colors.scss
@@ -16,7 +16,7 @@ $cl-colors-copy-success: #16a34a;
 
   .cl-colors__item {
     background: var(--color-basic-white);
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--color-gray-200);
     box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
     overflow: hidden;
     transition: box-shadow 0.2s ease;
@@ -38,7 +38,7 @@ $cl-colors-copy-success: #16a34a;
   .cl-colors__name {
     font-size: 0.95rem;
     font-weight: 600;
-    color: #1a1a1a;
+    color: var(--color-gray-900);
     margin: 0 0 0.25rem;
   }
 
@@ -46,10 +46,10 @@ $cl-colors-copy-success: #16a34a;
     display: block;
     font-size: 0.7rem;
     font-family: monospace;
-    color: #6b6b6b;
+    color: var(--color-gray-500);
     margin-bottom: 0.75rem;
     padding-bottom: 0.75rem;
-    border-bottom: 1px solid #f0f0f0;
+    border-bottom: 1px solid var(--color-gray-100);
   }
 
   // Each value-row: label on its own full-width line, value + copy button below.
@@ -66,7 +66,7 @@ $cl-colors-copy-success: #16a34a;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: #6b6b6b;
+    color: var(--color-gray-500);
     width: 100%;
     margin-bottom: 0.1rem;
   }
@@ -75,7 +75,7 @@ $cl-colors-copy-success: #16a34a;
   .cl-colors__value {
     font-size: 0.8rem;
     font-family: monospace;
-    color: #374151;
+    color: var(--color-gray-700);
     flex: 1;
     background: transparent;
     border: none;
@@ -100,14 +100,14 @@ $cl-colors-copy-success: #16a34a;
     cursor: pointer;
     padding: 0.25rem;
     border-radius: 0.25rem;
-    color: #9ca3af;
+    color: var(--color-gray-400);
     transition: color 0.15s ease, background-color 0.15s ease;
     line-height: 0;
     flex-shrink: 0;
 
     &:hover {
-      background-color: #f3f4f6;
-      color: #4b5563;
+      background-color: var(--color-gray-100);
+      color: var(--color-gray-600);
     }
 
     &:focus-visible {

--- a/components/00-tokens/colors/cl-colors.scss
+++ b/components/00-tokens/colors/cl-colors.scss
@@ -1,34 +1,143 @@
-.cl-colors__list {
-  display: flex;
-  flex-wrap: wrap;
-  margin: 0 0 var(--size-spacing-7);
-  padding: 0;
-}
+// Card grid — scoped under .cl-colors so it doesn't affect color-global-themes.twig,
+// which also uses .cl-colors__list and .cl-colors__item but without a .cl-colors wrapper.
+.cl-colors {
+  .cl-colors__list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1.5rem;
+    margin: 0 0 var(--size-spacing-7);
+    padding: 0;
+    list-style: none;
+  }
 
-.cl-colors__item {
-  list-style: none;
-  padding: var(--size-spacing-5) var(--size-spacing-7);
-  flex: 1 1 20%;
-  min-width: 150px;
-  min-height: 150px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 0.25rem;
-}
+  .cl-colors__item {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+    overflow: hidden;
+    transition: box-shadow 0.2s ease;
 
-.cl-colors__title {
-  background: hsl(0deg 0% 100% / 80%);
-  padding: 0.5rem;
-}
+    &:hover {
+      box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+    }
+  }
 
-.cl-colors__hex {
-  background: hsl(0deg 0% 100% / 80%);
-  padding: 0.25rem 0.5rem;
-  font-size: 0.8em;
-  font-family: monospace;
-  letter-spacing: 0.05em;
+  .cl-colors__swatch {
+    width: 100%;
+    height: 140px;
+  }
+
+  .cl-colors__info {
+    padding: 1rem 1.25rem 1.25rem;
+  }
+
+  .cl-colors__name {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #1a1a1a;
+    margin: 0 0 0.25rem;
+  }
+
+  .cl-colors__var {
+    display: block;
+    font-size: 0.7rem;
+    font-family: monospace;
+    color: #6b6b6b;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid #f0f0f0;
+  }
+
+  // Each value-row: label on its own full-width line, value + copy button below.
+  .cl-colors__value-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 0.35rem 0;
+    gap: 0 0.5rem;
+  }
+
+  .cl-colors__label {
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #6b6b6b;
+    width: 100%;
+    margin-bottom: 0.1rem;
+  }
+
+  // Reset <code> element browser defaults; display as plain inline text.
+  .cl-colors__value {
+    font-size: 0.8rem;
+    font-family: monospace;
+    color: #374151;
+    flex: 1;
+    background: transparent;
+    border: none;
+    padding: 0;
+  }
+
+  // Visually hidden but readable by screen readers; provides the button's accessible name.
+  // JS updates textContent on copy — same mechanism as text-copy-button's default announcement.
+  .cl-colors__copy-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .cl-colors__copy-btn {
+    appearance: none;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+    color: #9ca3af;
+    transition: color 0.15s ease, background-color 0.15s ease;
+    line-height: 0;
+    flex-shrink: 0;
+
+    &:hover {
+      background-color: #f3f4f6;
+      color: #4b5563;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #00356b;
+      outline-offset: 2px;
+    }
+
+    // Default icon states — must precede &--copied so source order gives --copied priority.
+    .cl-colors__icon-copy {
+      display: block;
+    }
+
+    .cl-colors__icon-check {
+      display: none;
+    }
+
+    &--copied {
+      color: #16a34a;
+
+      // Keep green during hover — the base &:hover rule has equal specificity
+      // but appears earlier in source, so this later rule wins the cascade.
+      &:hover {
+        color: #16a34a;
+      }
+
+      .cl-colors__icon-copy {
+        display: none;
+      }
+
+      .cl-colors__icon-check {
+        display: block;
+      }
+    }
+  }
 }
 
 [data-global-theme] {

--- a/components/00-tokens/colors/color-data.yml
+++ b/components/00-tokens/colors/color-data.yml
@@ -1,0 +1,187 @@
+# Supplemental color metadata for the Storybook Colors page.
+# Hex and RGB values are computed from design tokens automatically.
+# OPAC should verify/correct CMYK values (these are programmatic approximations)
+# and fill in Pantone values when available.
+blue:
+  yale:
+    name: "Yale Blue"
+    cmyk: "100, 50, 0, 58"
+    pantone: "--"
+  medium:
+    name: "Medium Blue"
+    cmyk: "79, 44, 0, 25"
+    pantone: "--"
+  light:
+    name: "Light Blue"
+    cmyk: "62, 34, 0, 0"
+    pantone: "--"
+  horizon:
+    name: "Horizon Blue"
+    cmyk: "64, 32, 0, 33"
+    pantone: "--"
+  shale:
+    name: "Shale Blue"
+    cmyk: "33, 10, 0, 31"
+    pantone: "--"
+  pewter:
+    name: "Pewter Blue"
+    cmyk: "10, 0, 0, 21"
+    pantone: "--"
+  royal:
+    name: "Royal Blue"
+    cmyk: "64, 44, 0, 41"
+    pantone: "--"
+  slate:
+    name: "Slate Blue"
+    cmyk: "25, 3, 0, 64"
+    pantone: "--"
+  oceanic:
+    name: "Oceanic Blue"
+    cmyk: "53, 0, 5, 56"
+    pantone: "--"
+  soft-oceanic:
+    name: "Soft Oceanic Blue"
+    cmyk: "8, 0, 1, 3"
+    pantone: "--"
+  soft:
+    name: "Soft Blue"
+    cmyk: "6, 2, 0, 3"
+    pantone: "--"
+  deep-teal:
+    name: "Deep Teal Blue"
+    cmyk: "42, 21, 0, 67"
+    pantone: "--"
+  mint:
+    name: "Mint Blue"
+    cmyk: "34, 0, 4, 18"
+    pantone: "--"
+  ocean:
+    name: "Ocean Blue"
+    cmyk: "54, 0, 4, 56"
+    pantone: "--"
+
+green:
+  basil:
+    name: "Basil Green"
+    cmyk: "15, 0, 23, 59"
+    pantone: "--"
+  ground:
+    name: "Ground Green"
+    cmyk: "8, 0, 17, 38"
+    pantone: "--"
+  fog:
+    name: "Fog Green"
+    cmyk: "0, 1, 10, 13"
+    pantone: "--"
+  pine:
+    name: "Pine Green"
+    cmyk: "27, 0, 14, 78"
+    pantone: "--"
+
+orange:
+  peach:
+    name: "Peach"
+    cmyk: "0, 22, 55, 16"
+    pantone: "--"
+  coral:
+    name: "Coral"
+    cmyk: "0, 61, 68, 0"
+    pantone: "--"
+
+yellow:
+  umbrella:
+    name: "Umbrella"
+    cmyk: "0, 13, 46, 11"
+    pantone: "--"
+  yale-gold:
+    name: "Yale Gold"
+    cmyk: "0, 16, 64, 0"
+    pantone: "--"
+
+basic:
+  white:
+    name: "White"
+    cmyk: "0, 0, 0, 0"
+    pantone: "--"
+  black:
+    name: "Black"
+    cmyk: "0, 0, 0, 100"
+    pantone: "--"
+  brown-gray:
+    name: "Brown Gray"
+    cmyk: "0, 7, 13, 53"
+    pantone: "--"
+
+gray:
+  100:
+    name: "Gray 100"
+    cmyk: "0, 0, 0, 3"
+    pantone: "--"
+  200:
+    name: "Gray 200"
+    cmyk: "0, 0, 0, 15"
+    pantone: "--"
+  300:
+    name: "Gray 300"
+    cmyk: "0, 0, 0, 27"
+    pantone: "--"
+  400:
+    name: "Gray 400"
+    cmyk: "0, 0, 0, 39"
+    pantone: "--"
+  500:
+    name: "Gray 500"
+    cmyk: "0, 0, 0, 54"
+    pantone: "--"
+  600:
+    name: "Gray 600"
+    cmyk: "0, 0, 0, 63"
+    pantone: "--"
+  700:
+    name: "Gray 700"
+    cmyk: "0, 0, 0, 71"
+    pantone: "--"
+  800:
+    name: "Gray 800"
+    cmyk: "0, 0, 0, 87"
+    pantone: "--"
+  900:
+    name: "Gray 900"
+    cmyk: "0, 0, 0, 89"
+    pantone: "--"
+  hale:
+    name: "Gray Hale"
+    cmyk: "22, 13, 0, 66"
+    pantone: "--"
+
+brown:
+  sand:
+    name: "Sand"
+    cmyk: "0, 8, 16, 24"
+    pantone: "--"
+  mushroom:
+    name: "Mushroom"
+    cmyk: "0, 5, 12, 43"
+    pantone: "--"
+
+purple:
+  visited:
+    name: "Visited"
+    cmyk: "48, 70, 0, 43"
+    pantone: "--"
+  visited-hover:
+    name: "Visited Hover"
+    cmyk: "48, 71, 0, 24"
+    pantone: "--"
+  visited-light:
+    name: "Visited Light"
+    cmyk: "10, 15, 0, 3"
+    pantone: "--"
+  visited-light-hover:
+    name: "Visited Light Hover"
+    cmyk: "15, 22, 0, 2"
+    pantone: "--"
+  plum:
+    name: "Plum"
+    cmyk: "15, 23, 0, 57"
+    pantone: "--"

--- a/components/00-tokens/colors/color-data.yml
+++ b/components/00-tokens/colors/color-data.yml
@@ -4,184 +4,184 @@
 # and fill in Pantone values when available.
 blue:
   yale:
-    name: "Yale Blue"
-    cmyk: "100, 50, 0, 58"
-    pantone: "--"
+    name: 'Yale Blue'
+    cmyk: '100, 50, 0, 58'
+    pantone: '--'
   medium:
-    name: "Medium Blue"
-    cmyk: "79, 44, 0, 25"
-    pantone: "--"
+    name: 'Medium Blue'
+    cmyk: '79, 44, 0, 25'
+    pantone: '--'
   light:
-    name: "Light Blue"
-    cmyk: "62, 34, 0, 0"
-    pantone: "--"
+    name: 'Light Blue'
+    cmyk: '62, 34, 0, 0'
+    pantone: '--'
   horizon:
-    name: "Horizon Blue"
-    cmyk: "64, 32, 0, 33"
-    pantone: "--"
+    name: 'Horizon Blue'
+    cmyk: '64, 32, 0, 33'
+    pantone: '--'
   shale:
-    name: "Shale Blue"
-    cmyk: "33, 10, 0, 31"
-    pantone: "--"
+    name: 'Shale Blue'
+    cmyk: '33, 10, 0, 31'
+    pantone: '--'
   pewter:
-    name: "Pewter Blue"
-    cmyk: "10, 0, 0, 21"
-    pantone: "--"
+    name: 'Pewter Blue'
+    cmyk: '10, 0, 0, 21'
+    pantone: '--'
   royal:
-    name: "Royal Blue"
-    cmyk: "64, 44, 0, 41"
-    pantone: "--"
+    name: 'Royal Blue'
+    cmyk: '64, 44, 0, 41'
+    pantone: '--'
   slate:
-    name: "Slate Blue"
-    cmyk: "25, 3, 0, 64"
-    pantone: "--"
+    name: 'Slate Blue'
+    cmyk: '25, 3, 0, 64'
+    pantone: '--'
   oceanic:
-    name: "Oceanic Blue"
-    cmyk: "53, 0, 5, 56"
-    pantone: "--"
+    name: 'Oceanic Blue'
+    cmyk: '53, 0, 5, 56'
+    pantone: '--'
   soft-oceanic:
-    name: "Soft Oceanic Blue"
-    cmyk: "8, 0, 1, 3"
-    pantone: "--"
+    name: 'Soft Oceanic Blue'
+    cmyk: '8, 0, 1, 3'
+    pantone: '--'
   soft:
-    name: "Soft Blue"
-    cmyk: "6, 2, 0, 3"
-    pantone: "--"
+    name: 'Soft Blue'
+    cmyk: '6, 2, 0, 3'
+    pantone: '--'
   deep-teal:
-    name: "Deep Teal Blue"
-    cmyk: "42, 21, 0, 67"
-    pantone: "--"
+    name: 'Deep Teal Blue'
+    cmyk: '42, 21, 0, 67'
+    pantone: '--'
   mint:
-    name: "Mint Blue"
-    cmyk: "34, 0, 4, 18"
-    pantone: "--"
+    name: 'Mint Blue'
+    cmyk: '34, 0, 4, 18'
+    pantone: '--'
   ocean:
-    name: "Ocean Blue"
-    cmyk: "54, 0, 4, 56"
-    pantone: "--"
+    name: 'Ocean Blue'
+    cmyk: '54, 0, 4, 56'
+    pantone: '--'
 
 green:
   basil:
-    name: "Basil Green"
-    cmyk: "15, 0, 23, 59"
-    pantone: "--"
+    name: 'Basil Green'
+    cmyk: '15, 0, 23, 59'
+    pantone: '--'
   ground:
-    name: "Ground Green"
-    cmyk: "8, 0, 17, 38"
-    pantone: "--"
+    name: 'Ground Green'
+    cmyk: '8, 0, 17, 38'
+    pantone: '--'
   fog:
-    name: "Fog Green"
-    cmyk: "0, 1, 10, 13"
-    pantone: "--"
+    name: 'Fog Green'
+    cmyk: '0, 1, 10, 13'
+    pantone: '--'
   pine:
-    name: "Pine Green"
-    cmyk: "27, 0, 14, 78"
-    pantone: "--"
+    name: 'Pine Green'
+    cmyk: '27, 0, 14, 78'
+    pantone: '--'
 
 orange:
   peach:
-    name: "Peach"
-    cmyk: "0, 22, 55, 16"
-    pantone: "--"
+    name: 'Peach'
+    cmyk: '0, 22, 55, 16'
+    pantone: '--'
   coral:
-    name: "Coral"
-    cmyk: "0, 61, 68, 0"
-    pantone: "--"
+    name: 'Coral'
+    cmyk: '0, 61, 68, 0'
+    pantone: '--'
 
 yellow:
   umbrella:
-    name: "Umbrella"
-    cmyk: "0, 13, 46, 11"
-    pantone: "--"
+    name: 'Umbrella'
+    cmyk: '0, 13, 46, 11'
+    pantone: '--'
   yale-gold:
-    name: "Yale Gold"
-    cmyk: "0, 16, 64, 0"
-    pantone: "--"
+    name: 'Yale Gold'
+    cmyk: '0, 16, 64, 0'
+    pantone: '--'
 
 basic:
   white:
-    name: "White"
-    cmyk: "0, 0, 0, 0"
-    pantone: "--"
+    name: 'White'
+    cmyk: '0, 0, 0, 0'
+    pantone: '--'
   black:
-    name: "Black"
-    cmyk: "0, 0, 0, 100"
-    pantone: "--"
+    name: 'Black'
+    cmyk: '0, 0, 0, 100'
+    pantone: '--'
   brown-gray:
-    name: "Brown Gray"
-    cmyk: "0, 7, 13, 53"
-    pantone: "--"
+    name: 'Brown Gray'
+    cmyk: '0, 7, 13, 53'
+    pantone: '--'
 
 gray:
   100:
-    name: "Gray 100"
-    cmyk: "0, 0, 0, 3"
-    pantone: "--"
+    name: 'Gray 100'
+    cmyk: '0, 0, 0, 3'
+    pantone: '--'
   200:
-    name: "Gray 200"
-    cmyk: "0, 0, 0, 15"
-    pantone: "--"
+    name: 'Gray 200'
+    cmyk: '0, 0, 0, 15'
+    pantone: '--'
   300:
-    name: "Gray 300"
-    cmyk: "0, 0, 0, 27"
-    pantone: "--"
+    name: 'Gray 300'
+    cmyk: '0, 0, 0, 27'
+    pantone: '--'
   400:
-    name: "Gray 400"
-    cmyk: "0, 0, 0, 39"
-    pantone: "--"
+    name: 'Gray 400'
+    cmyk: '0, 0, 0, 39'
+    pantone: '--'
   500:
-    name: "Gray 500"
-    cmyk: "0, 0, 0, 54"
-    pantone: "--"
+    name: 'Gray 500'
+    cmyk: '0, 0, 0, 54'
+    pantone: '--'
   600:
-    name: "Gray 600"
-    cmyk: "0, 0, 0, 63"
-    pantone: "--"
+    name: 'Gray 600'
+    cmyk: '0, 0, 0, 63'
+    pantone: '--'
   700:
-    name: "Gray 700"
-    cmyk: "0, 0, 0, 71"
-    pantone: "--"
+    name: 'Gray 700'
+    cmyk: '0, 0, 0, 71'
+    pantone: '--'
   800:
-    name: "Gray 800"
-    cmyk: "0, 0, 0, 87"
-    pantone: "--"
+    name: 'Gray 800'
+    cmyk: '0, 0, 0, 87'
+    pantone: '--'
   900:
-    name: "Gray 900"
-    cmyk: "0, 0, 0, 89"
-    pantone: "--"
+    name: 'Gray 900'
+    cmyk: '0, 0, 0, 89'
+    pantone: '--'
   hale:
-    name: "Gray Hale"
-    cmyk: "22, 13, 0, 66"
-    pantone: "--"
+    name: 'Gray Hale'
+    cmyk: '22, 13, 0, 66'
+    pantone: '--'
 
 brown:
   sand:
-    name: "Sand"
-    cmyk: "0, 8, 16, 24"
-    pantone: "--"
+    name: 'Sand'
+    cmyk: '0, 8, 16, 24'
+    pantone: '--'
   mushroom:
-    name: "Mushroom"
-    cmyk: "0, 5, 12, 43"
-    pantone: "--"
+    name: 'Mushroom'
+    cmyk: '0, 5, 12, 43'
+    pantone: '--'
 
 purple:
   visited:
-    name: "Visited"
-    cmyk: "48, 70, 0, 43"
-    pantone: "--"
+    name: 'Visited'
+    cmyk: '48, 70, 0, 43'
+    pantone: '--'
   visited-hover:
-    name: "Visited Hover"
-    cmyk: "48, 71, 0, 24"
-    pantone: "--"
+    name: 'Visited Hover'
+    cmyk: '48, 71, 0, 24'
+    pantone: '--'
   visited-light:
-    name: "Visited Light"
-    cmyk: "10, 15, 0, 3"
-    pantone: "--"
+    name: 'Visited Light'
+    cmyk: '10, 15, 0, 3'
+    pantone: '--'
   visited-light-hover:
-    name: "Visited Light Hover"
-    cmyk: "15, 22, 0, 2"
-    pantone: "--"
+    name: 'Visited Light Hover'
+    cmyk: '15, 22, 0, 2'
+    pantone: '--'
   plum:
-    name: "Plum"
-    cmyk: "15, 23, 0, 57"
-    pantone: "--"
+    name: 'Plum'
+    cmyk: '15, 23, 0, 57'
+    pantone: '--'

--- a/components/00-tokens/colors/colors.stories.js
+++ b/components/00-tokens/colors/colors.stories.js
@@ -82,13 +82,41 @@ const colorGroups = [
   'purple',
 ];
 
-const colorsData = {
-  colors: Object.fromEntries(
-    colorGroups
-      .filter((g) => tokens.color[g])
-      .map((g) => [g, mergeColorData(tokens.color[g], colorMeta[g])]),
-  ),
-};
+const hiddenColors = [
+  'purple.visited',
+  'purple.visited-hover',
+  'purple.visited-light',
+  'purple.visited-light-hover',
+];
+
+function getAvailableGroups() {
+  return colorGroups.filter((g) => tokens.color[g]);
+}
+
+function isVisibleColor(group, key) {
+  return !hiddenColors.includes(`${group}.${key}`);
+}
+
+function filterHiddenColors(group, mergedColors) {
+  const allColors = Object.entries(mergedColors);
+  const visibleColors = allColors.filter(([key]) => isVisibleColor(group, key));
+  return Object.fromEntries(visibleColors);
+}
+
+function isNonEmptyGroup([, colors]) {
+  return Object.keys(colors).length > 0;
+}
+
+function buildVisibleColorGroups() {
+  const groups = getAvailableGroups().map((g) => [
+    g,
+    filterHiddenColors(g, mergeColorData(tokens.color[g], colorMeta[g])),
+  ]);
+
+  return Object.fromEntries(groups.filter(isNonEmptyGroup));
+}
+
+const colorsData = { colors: buildVisibleColorGroups() };
 
 // Shared live region for copy announcements. aria-live="polite" (without
 // aria-atomic) announces to VoiceOver on all activation methods — CTRL+OPT+Space,

--- a/components/00-tokens/colors/colors.stories.js
+++ b/components/00-tokens/colors/colors.stories.js
@@ -1,5 +1,7 @@
 import tokens from '@yalesites-org/tokens/build/json/tokens.json';
 import getGlobalThemes from './color-global-themes';
+import colorMeta from './color-data.yml';
+import '../../01-atoms/controls/text-copy-button/yds-text-copy-button';
 
 import colorsTwig from './colors.twig';
 import colorComponentThemeTwig from './color-component-theme-pairings.twig';
@@ -21,7 +23,7 @@ import { exampleSiteNameImageSvg } from '../../_storybook/theme-constants';
 import tabData from '../../02-molecules/tabs/tabs.yml';
 import bannerData from '../../02-molecules/banner/banner.yml';
 
-function hslToHex(hslStr) {
+function hslToComponents(hslStr) {
   const match = hslStr.match(
     /hsl\((\d+(?:\.\d+)?),\s*(\d+(?:\.\d+)?)%,\s*(\d+(?:\.\d+)?)%\)/,
   );
@@ -33,32 +35,108 @@ function hslToHex(hslStr) {
   const f = (n) => {
     const k = (n + h / 30) % 12;
     const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-    return Math.round(255 * color)
-      .toString(16)
-      .padStart(2, '0');
+    return Math.round(255 * color);
   };
-  return `#${f(0)}${f(8)}${f(4)}`;
+  return { r: f(0), g: f(8), b: f(4) };
 }
 
-function addHex(colorGroup) {
+function hslToHex(hslStr) {
+  const rgb = hslToComponents(hslStr);
+  if (!rgb) return null;
+  const toHex = (n) => n.toString(16).padStart(2, '0');
+  return `#${toHex(rgb.r)}${toHex(rgb.g)}${toHex(rgb.b)}`;
+}
+
+function hslToRgb(hslStr) {
+  const rgb = hslToComponents(hslStr);
+  if (!rgb) return null;
+  return `${rgb.r}, ${rgb.g}, ${rgb.b}`;
+}
+
+function mergeColorData(tokenGroup, metaGroup = {}) {
   return Object.fromEntries(
-    Object.entries(colorGroup).map(([name, value]) => [
-      name,
-      { value, hex: hslToHex(value) },
-    ]),
+    Object.entries(tokenGroup).map(([key, hslValue]) => {
+      const meta = metaGroup[key] || {};
+      return [
+        key,
+        {
+          name: meta.name || key,
+          hex: hslToHex(hslValue),
+          rgb: hslToRgb(hslValue),
+          cmyk: meta.cmyk || '--',
+          pantone: meta.pantone || '--',
+        },
+      ];
+    }),
   );
 }
 
+const colorGroups = [
+  'blue',
+  'green',
+  'orange',
+  'yellow',
+  'basic',
+  'gray',
+  'brown',
+  'purple',
+];
+
 const colorsData = {
-  colors: {
-    blue: addHex(tokens.color.blue),
-    green: addHex(tokens.color.green),
-    orange: addHex(tokens.color.orange),
-    yellow: addHex(tokens.color.yellow),
-    basic: addHex(tokens.color.basic),
-    gray: addHex(tokens.color.gray),
-  },
+  colors: Object.fromEntries(
+    colorGroups
+      .filter((g) => tokens.color[g])
+      .map((g) => [g, mergeColorData(tokens.color[g], colorMeta[g])]),
+  ),
 };
+
+// Shared live region for copy announcements. aria-live="polite" (without
+// aria-atomic) announces to VoiceOver on all activation methods — CTRL+OPT+Space,
+// Enter, and mouse click — regardless of where the VO cursor is. Intentionally
+// NOT role="status" (which implies aria-atomic="true"): aria-atomic causes
+// VoiceOver to treat clearing the region as a full update, shifting its virtual
+// cursor and auto-reading forward. Without aria-atomic, an empty-string update
+// has no content and VoiceOver ignores it, so clearing is safe.
+// Created eagerly so VoiceOver registers it before the first copy — lazy creation
+// causes the first announcement to be missed.
+// ID guard prevents duplicates on Storybook HMR re-evaluation.
+let clColorsAnnouncer = document.getElementById('cl-colors-copy-announcer');
+if (!clColorsAnnouncer) {
+  clColorsAnnouncer = document.createElement('div');
+  clColorsAnnouncer.id = 'cl-colors-copy-announcer';
+  clColorsAnnouncer.setAttribute('aria-live', 'polite');
+  Object.assign(clColorsAnnouncer.style, {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    overflow: 'hidden',
+    clip: 'rect(0,0,0,0)',
+    whiteSpace: 'nowrap',
+  });
+  document.body.appendChild(clColorsAnnouncer);
+}
+
+// Guard prevents stacking duplicate listeners on HMR re-evaluation.
+// Stored as a data attribute on the announcer element to avoid ESLint
+// no-underscore-dangle restrictions on custom document properties.
+if (!clColorsAnnouncer.dataset.listenerAttached) {
+  clColorsAnnouncer.dataset.listenerAttached = 'true';
+  document.addEventListener('text-copy-button:copied', (e) => {
+    if (!e.detail.button.closest('.cl-colors')) return;
+    e.preventDefault();
+    const btn = e.detail.button;
+
+    clColorsAnnouncer.textContent = 'Copied!';
+
+    btn.classList.add('cl-colors__copy-btn--copied');
+    setTimeout(() => {
+      btn.classList.remove('cl-colors__copy-btn--copied');
+      // Safe to clear without aria-atomic — empty update has no content for
+      // VoiceOver to announce or navigate to.
+      clColorsAnnouncer.textContent = '';
+    }, 1700);
+  });
+}
 
 const colorComponentThemeData = { themes: tokens['component-themes'] };
 const colorBasicThemeData = { themes: tokens['basic-themes'] };

--- a/components/00-tokens/colors/colors.stories.js
+++ b/components/00-tokens/colors/colors.stories.js
@@ -116,9 +116,10 @@ if (!clColorsAnnouncer) {
   document.body.appendChild(clColorsAnnouncer);
 }
 
-// Guard prevents stacking duplicate listeners on HMR re-evaluation.
-// Stored as a data attribute on the announcer element to avoid ESLint
-// no-underscore-dangle restrictions on custom document properties.
+// Guard prevents stacking duplicate listeners on Storybook HMR re-evaluation.
+// A module-level variable would reset on HMR while the DOM node persists, so
+// the flag lives on the announcer element — which survives re-evaluation with
+// its ID intact — rather than in a module-level variable.
 if (!clColorsAnnouncer.dataset.listenerAttached) {
   clColorsAnnouncer.dataset.listenerAttached = 'true';
   document.addEventListener('text-copy-button:copied', (e) => {
@@ -128,8 +129,12 @@ if (!clColorsAnnouncer.dataset.listenerAttached) {
 
     clColorsAnnouncer.textContent = 'Copied!';
 
+    // Clear any in-flight timeout on this button before starting a new one.
+    // Without this, rapid clicks accumulate timeouts that remove --copied at
+    // staggered times, leaving the button in the wrong visual state.
+    clearTimeout(Number(btn.dataset.copyTimeout));
     btn.classList.add('cl-colors__copy-btn--copied');
-    setTimeout(() => {
+    btn.dataset.copyTimeout = setTimeout(() => {
       btn.classList.remove('cl-colors__copy-btn--copied');
       // Safe to clear without aria-atomic — empty update has no content for
       // VoiceOver to announce or navigate to.

--- a/components/00-tokens/colors/colors.twig
+++ b/components/00-tokens/colors/colors.twig
@@ -49,9 +49,7 @@
                   <svg class="cl-colors__icon-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
                     <polyline points="20 6 9 17 4 12"></polyline>
                   </svg>
-                  {# Visually-hidden label: screen readers read this as the button name.
-                     JS updates its textContent on copy — same mechanism as text-copy-button's
-                     default textContent swap, which is the reliable cross-SR announcement. #}
+                  {# Visually-hidden label read by screen readers as the button's accessible name. #}
                   <span {{ bem('copy-label', [], colors__base_class) }}>Copy {{ label }} {{ val }}</span>
                 </button>
               </div>

--- a/components/00-tokens/colors/colors.twig
+++ b/components/00-tokens/colors/colors.twig
@@ -6,29 +6,59 @@
       <div class="text">
         <h1>All available color options are outlined here.</h1>
         <p>Each color is defined in the tokens repository: <code>atomic/node_modules/@yalesites-org/tokens/tokens/figma-export/tokens.json</code>.</p>
+        <p>CMYK values are approximate. Pantone values are pending OPAC review. Click any value to copy it to your clipboard.</p>
       </div>
     </div>
   </div>
 </div>
 
-{% for color, colorset in _context.colors %}
+{% for group, colorset in _context.colors %}
   <div {{ bem(colors__base_class) }}>
-    <h2>{{ color }}</h2>
-    <ul {{ bem('list', [], colors__base_class) }} data-theme="">
-      {% if colorset is iterable %}
-        {% for nested_color, nested_value in colorset %}
-          <li {{ bem("item", [], colors__base_class) }} style="background: var(--color-{{color}}-{{ nested_color }});">
-            <span {{ bem("title", [], colors__base_class) }}>--color-{{ color }}-{{ nested_color }}</span>
-            {% if nested_value.hex %}
-              <span {{ bem("hex", [], colors__base_class) }}>{{ nested_value.hex }}</span>
-            {% endif %}
-          </li>
-        {% endfor %}
-      {% else %}
-        <li {{ bem("item", [], colors__base_class) }} style="background: var(--color-{{color}});">
-          <span {{ bem("title", [], colors__base_class) }}>--color-{{ color }}</span>
+    <h2>{{ group|capitalize }}</h2>
+    <ul {{ bem('list', [], colors__base_class) }}>
+      {% for key, color in colorset %}
+        <li {{ bem('item', [], colors__base_class) }}>
+          <div {{ bem('swatch', [], colors__base_class) }} style="background: var(--color-{{ group }}-{{ key }});"></div>
+          <div {{ bem('info', [], colors__base_class) }}>
+            <h3 {{ bem('name', [], colors__base_class) }}>{{ color.name }}</h3>
+            <span {{ bem('var', [], colors__base_class) }}>--color-{{ group }}-{{ key }}</span>
+
+            {% set value_rows = {
+              'HEX': color.hex,
+              'RGB': color.rgb,
+              'CMYK': color.cmyk,
+              'PANTONE': color.pantone
+            } %}
+
+            {% for label, val in value_rows %}
+              {# text-copy-button class satisfies yds-text-copy-button.js wrapper lookup #}
+              <div {{ bem('value-row', [], colors__base_class, ['text-copy-button']) }}>
+                <span {{ bem('label', [], colors__base_class) }}>{{ label }}</span>
+                {# pre-text__text class is required by yds-text-copy-button.js to read the copy value #}
+                <code class="cl-colors__value pre-text__text">{{ val }}</code>
+                <button
+                  class="cl-colors__copy-btn text-copy-button__button"
+                  type="button"
+                >
+                  {# Copy icon (shown by default) #}
+                  <svg class="cl-colors__icon-copy" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                  </svg>
+                  {# Check icon (shown when copied, toggled by JS via --copied modifier) #}
+                  <svg class="cl-colors__icon-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                  </svg>
+                  {# Visually-hidden label: screen readers read this as the button name.
+                     JS updates its textContent on copy — same mechanism as text-copy-button's
+                     default textContent swap, which is the reliable cross-SR announcement. #}
+                  <span {{ bem('copy-label', [], colors__base_class) }}>Copy {{ label }} {{ val }}</span>
+                </button>
+              </div>
+            {% endfor %}
+          </div>
         </li>
-      {% endif %}
+      {% endfor %}
     </ul>
   </div>
 {% endfor %}

--- a/components/00-tokens/colors/colors.twig
+++ b/components/00-tokens/colors/colors.twig
@@ -31,27 +31,29 @@
             } %}
 
             {% for label, val in value_rows %}
-              {# text-copy-button class satisfies yds-text-copy-button.js wrapper lookup #}
-              <div {{ bem('value-row', [], colors__base_class, ['text-copy-button']) }}>
+              {% set is_placeholder = val == '--' %}
+              <div {{ bem('value-row', [], colors__base_class, is_placeholder ? [] : ['text-copy-button']) }}>
                 <span {{ bem('label', [], colors__base_class) }}>{{ label }}</span>
                 {# pre-text__text class is required by yds-text-copy-button.js to read the copy value #}
-                <code class="cl-colors__value pre-text__text">{{ val }}</code>
-                <button
-                  class="cl-colors__copy-btn text-copy-button__button"
-                  type="button"
-                >
-                  {# Copy icon (shown by default) #}
-                  <svg class="cl-colors__icon-copy" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-                  </svg>
-                  {# Check icon (shown when copied, toggled by JS via --copied modifier) #}
-                  <svg class="cl-colors__icon-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-                    <polyline points="20 6 9 17 4 12"></polyline>
-                  </svg>
-                  {# Visually-hidden label read by screen readers as the button's accessible name. #}
-                  <span {{ bem('copy-label', [], colors__base_class) }}>Copy {{ label }} {{ val }}</span>
-                </button>
+                <code class="cl-colors__value{{ is_placeholder ? '' : ' pre-text__text' }}">{{ val }}</code>
+                {% if not is_placeholder %}
+                  <button
+                    class="cl-colors__copy-btn text-copy-button__button"
+                    type="button"
+                  >
+                    {# Copy icon (shown by default) #}
+                    <svg class="cl-colors__icon-copy" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                    </svg>
+                    {# Check icon (shown when copied, toggled by JS via --copied modifier) #}
+                    <svg class="cl-colors__icon-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                      <polyline points="20 6 9 17 4 12"></polyline>
+                    </svg>
+                    {# Visually-hidden label read by screen readers as the button's accessible name. #}
+                    <span {{ bem('copy-label', [], colors__base_class) }}>Copy {{ label }} {{ val }}</span>
+                  </button>
+                {% endif %}
               </div>
             {% endfor %}
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5355,8 +5355,9 @@
       }
     },
     "node_modules/@yalesites-org/tokens": {
-      "version": "1.37.0",
-      "resolved": "git+ssh://git@github.com/yalesites-org/tokens.git#3ecf5e7067433870a5825e5deb9ac7c2e795d777"
+      "version": "1.38.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/tokens/1.38.0/e2a6c35f845ad40637800f079d09b9f50791d658",
+      "integrity": "sha512-lSRqu0vTfhDJqwI+i3Gh26IbYKRoYWSt/eyL1W6oNhxKU8hWCf5psc9SS4upmFJUUt4HNhoJhigdY8sLpzyCmg=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",


### PR DESCRIPTION
## [#1178: Enhance Storybook Color Page with Copyable Color Values (HEX, RGB, CMYK, Pantone)](https://github.com/yalesites-org/YaleSites-Internal/issues/1178)

### Description of work
- Redesigns the Tokens/Colors Storybook page with rich color cards showing HEX, RGB, CMYK, and Pantone values
- Adds click-to-copy functionality for each color value with icon-swap visual feedback
- Adds supplemental `color-data.yml` for CMYK, Pantone, and display names; HEX and RGB are computed automatically from design tokens
- Implements accessible VoiceOver announcements via `aria-live="polite"` region, working on Enter, click, and CTRL+OPT+Space
- Replaces hardcoded hex values with CSS custom properties (`--color-basic-white`, `--color-blue-yale`) and introduces `$cl-colors-copy-success` SCSS variable for the check-icon green

Closes https://github.com/yalesites-org/YaleSites-Internal/issues/1178

### Testing Link(s)
- [ ] Navigate to the [Colors Story](https://deploy-preview-633--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--colors)

### Functional Review Steps
- [ ] Verify color cards render with swatch, name, CSS variable, and all four value rows (HEX, RGB, CMYK, PANTONE)
- [ ] Click a value to copy — confirm clipboard content is correct and check icon appears
- [ ] Tab to a copy button and activate with Enter — confirm copy works and VoiceOver announces "Copied!"
- [ ] Verify the **Tokens > Color Global Themes** story still renders correctly (scoping regression check)

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify VoiceOver announces "Copied!" on click, Enter, and CTRL+OPT+Space
- [ ] Verify focus rings are visible on copy buttons
- [ ] Verify color label contrast passes WCAG AA (4.5:1)