### PR TITLE
#292 ::  Add Third Font Style Option to Site Settings: Yale Old-Style Numerals / Mallory

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -68,6 +68,7 @@ export const globalTypes = {
       items: [
         { value: 'yalenew', title: 'Headings: YaleNew' },
         { value: 'mallory', title: 'Headings: Mallory' },
+        { value: 'yalenew-oldstyle', title: 'Headings: Yale Old-Style Numerals' },
       ],
       showName: true,
       dynamicTitle: true,

--- a/components/00-introduction/introduction.stories.js
+++ b/components/00-introduction/introduction.stories.js
@@ -167,7 +167,7 @@ const introductionHTML = `
                   },
                   {
                     list__item__content:
-                      '<strong>Typography: Heading Fonts:</strong> Toggle between YaleNew and Mallory heading font pairings',
+                      '<strong>Typography: Heading Fonts:</strong> Switch between YaleNew, Mallory, and Yale Old-Style Numerals heading font pairings',
                   },
                 ],
               })}

--- a/components/00-tokens/typography/_typography.scss
+++ b/components/00-tokens/typography/_typography.scss
@@ -163,6 +163,7 @@ code {
 
 @mixin heading($level, $style: null) {
   body[data-font-pairing='yalenew'] &,
+  body[data-font-pairing='yalenew-oldstyle'] &,
   body:not([data-font-pairing]) & {
     @if $level == 'h1' {
       @include h1-yale-new;

--- a/components/00-tokens/typography/heading-styles.twig
+++ b/components/00-tokens/typography/heading-styles.twig
@@ -4,7 +4,7 @@
 <p>Heading styles all include a <code>font</code> attribute, but some also include the <code>letter-spacing</code> and/or <code>text-transform</code> attributes. So, in order to keep implementation consistent, all typography definitions across the codebase must implement the relevant sass mixin and not mix or omit parts of any typography style.</p>
 
 <div style="padding: 1rem 1.25rem; background: #f0f0f0; border: 1px solid #ccc; border-left: 4px solid #0053A0; margin: 1.5rem 0;">
-  <strong>Heading Font Global Switch:</strong> You can swap between <strong>YaleNew</strong> and <strong>Mallory</strong> heading fonts globally using the <strong>Typography: Heading Fonts</strong> control in the Storybook toolbar. This is a site-wide change — all component headings will respect whichever choice is made, mirroring how the font selection works in our Drupal instance.
+  <strong>Heading Font Global Switch:</strong> You can swap between <strong>YaleNew</strong>, <strong>Mallory</strong>, and <strong>Yale Old-Style Numerals</strong> heading fonts globally using the <strong>Typography: Heading Fonts</strong> control in the Storybook toolbar. This is a site-wide change — all component headings will respect whichever choice is made, mirroring how the font selection works in our Drupal instance.
 </div>
 
 <ul {{ bem(type__base_class) }}>

--- a/components/03-organisms/site-header/_yds-site-header.scss
+++ b/components/03-organisms/site-header/_yds-site-header.scss
@@ -371,6 +371,10 @@ $site-name-as-logo-height-sm: 6.25rem; // 100px
   color: var(--color-site-header-site-branding);
   text-decoration: none;
 
+  body[data-font-pairing='yalenew-oldstyle'] & {
+    font-variant-numeric: oldstyle-nums;
+  }
+
   &--desktop {
     [data-collection-nav-position='in_header'] & {
       font-family: var(--font-families-mallory);
@@ -406,6 +410,10 @@ $site-name-as-logo-height-sm: 6.25rem; // 100px
   text-decoration: none;
   letter-spacing: -0.02em;
   margin-top: 0.25em;
+
+  body[data-font-pairing='yalenew-oldstyle'] & {
+    font-variant-numeric: oldstyle-nums;
+  }
 
   &--mobile {
     font-size: var(--font-size-29);


### PR DESCRIPTION

## [#292: Add Third Font Style Option to Site Settings: Yale Old-Style Numerals / Mallory](https://github.com/yalesites-org/YaleSites-Internal/issues/292)

### Description of work
- Adds old-style option to typography and header settings
- Adds preview option for old-style to Storybook

### Testing Link(s)
- [ ] Navigate to the [Component Story](https://deploy-preview-XX--dev-component-library-twig.netlify.app/?path=/story/tokens-breakpoints--breakpoints)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
