### PR TITLE
538: Fix Views Category Tags Display

### DIFF
--- a/components/01-atoms/lists/_yds-list.scss
+++ b/components/01-atoms/lists/_yds-list.scss
@@ -69,7 +69,3 @@ ol {
   margin-top: var(--size-spacing-4);
   text-transform: capitalize;
 }
-
-.taxonomy-list__item--more {
-  text-transform: none;
-}

--- a/components/01-atoms/lists/taxonomy/yds-tags-list.twig
+++ b/components/01-atoms/lists/taxonomy/yds-tags-list.twig
@@ -1,6 +1,5 @@
-{% set visible_items = visible_items|default(3) %}
 <ul {{ bem('taxonomy-list', ['tags'], '') }}>
-  {% for item in items|slice(0, visible_items) %}
+  {% for item in items %}
     <li {{ bem('item', [], 'taxonomy-list') }}>
       {% block list_item %}
         {{ item.content }}
@@ -8,9 +7,4 @@
     </li>
     <li aria-hidden="true" {{ bem('divider', [], 'taxonomy-list') }}>{{ '|' }}</li>
   {% endfor %}
-  {% if items|length > visible_items %}
-    <li {{ bem('item', ['more'], 'taxonomy-list') }}>
-      <a href="{{ url }}">{{ '+' }}{{ items|length - visible_items }}{{ " more"|t }}</a>
-    </li>
-  {% endif %}
 </ul>

--- a/components/02-molecules/banner/video-banner.mdx
+++ b/components/02-molecules/banner/video-banner.mdx
@@ -26,9 +26,22 @@ Use the controls panel below to experiment with the component's properties in re
 
 ### Twig-Only Props
 
-| Property                | Type   | Description                                                                                                                                   |
-| ----------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `video_banner__content` | string | Required. HTML embed string for the video (e.g., from Drupal's video embed field). Provided by the CMS; not an interactive Storybook control. |
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>video_banner__content</code></td>
+      <td><code>string</code></td>
+      <td>Required. HTML embed string for the video (e.g., from Drupal's video embed field). Provided by the CMS; not an interactive Storybook control.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Technical Specifications
 

--- a/components/02-molecules/banner/video-banner.mdx
+++ b/components/02-molecules/banner/video-banner.mdx
@@ -36,9 +36,16 @@ Use the controls panel below to experiment with the component's properties in re
   </thead>
   <tbody>
     <tr>
-      <td><code>video_banner__content</code></td>
-      <td><code>string</code></td>
-      <td>Required. HTML embed string for the video (e.g., from Drupal's video embed field). Provided by the CMS; not an interactive Storybook control.</td>
+      <td>
+        <code>video_banner__content</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+        Required. HTML embed string for the video (e.g., from Drupal's video
+        embed field). Provided by the CMS; not an interactive Storybook control.
+      </td>
     </tr>
   </tbody>
 </table>

--- a/components/02-molecules/cards/custom-card/custom-card.mdx
+++ b/components/02-molecules/cards/custom-card/custom-card.mdx
@@ -38,9 +38,16 @@ Use the controls panel below to experiment with the custom card's properties in 
   </thead>
   <tbody>
     <tr>
-      <td><code>custom_card__url</code></td>
-      <td><code>string</code></td>
-      <td>Required. URL for the card heading link. Provided by the CMS; not an interactive Storybook control.</td>
+      <td>
+        <code>custom_card__url</code>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+      <td>
+        Required. URL for the card heading link. Provided by the CMS; not an
+        interactive Storybook control.
+      </td>
     </tr>
   </tbody>
 </table>

--- a/components/02-molecules/cards/custom-card/custom-card.mdx
+++ b/components/02-molecules/cards/custom-card/custom-card.mdx
@@ -28,9 +28,22 @@ Use the controls panel below to experiment with the custom card's properties in 
 
 ### Twig-Only Props
 
-| Property           | Type   | Description                                                                                         |
-| ------------------ | ------ | --------------------------------------------------------------------------------------------------- |
-| `custom_card__url` | string | Required. URL for the card heading link. Provided by the CMS; not an interactive Storybook control. |
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>custom_card__url</code></td>
+      <td><code>string</code></td>
+      <td>Required. URL for the card heading link. Provided by the CMS; not an interactive Storybook control.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Component Variations
 

--- a/components/02-molecules/cards/reference-card/event/_yds-calendar-cell-event.twig
+++ b/components/02-molecules/cards/reference-card/event/_yds-calendar-cell-event.twig
@@ -12,7 +12,6 @@
   <time>{{ time }}</time>
   {% embed "@atoms/lists/taxonomy/yds-tags-list.twig" with {
     items: type,
-    visible_items: 2,
     url: url,
   } %}
 

--- a/components/02-molecules/cards/reference-card/event/_yds-calendar-cell-event.twig
+++ b/components/02-molecules/cards/reference-card/event/_yds-calendar-cell-event.twig
@@ -12,7 +12,6 @@
   <time>{{ time }}</time>
   {% embed "@atoms/lists/taxonomy/yds-tags-list.twig" with {
     items: type,
-    url: url,
   } %}
 
     {% block list_item %}

--- a/components/02-molecules/cards/reference-card/examples/event-card.yml
+++ b/components/02-molecules/cards/reference-card/examples/event-card.yml
@@ -4,3 +4,9 @@ reference_card__url: 'https://google.com/download.pdf'
 reference_card__date: 2022-03-30 13:00
 reference_card__format: 'Online'
 multi_day_event: true
+reference_card__tags:
+  - content: Public Event
+  - content: Campus Event
+  - content: Exhibitions
+  - content: Family Programs
+  - content: Readings

--- a/components/02-molecules/cards/reference-card/yds-reference-card.twig
+++ b/components/02-molecules/cards/reference-card/yds-reference-card.twig
@@ -94,7 +94,6 @@
       {% block reference_card__tags %}
         {% include "@atoms/lists/taxonomy/yds-tags-list.twig" with {
           items: reference_card__tags,
-          url: reference_card__url,
         } %}
       {% endblock %}
     {% endif %}

--- a/components/03-organisms/calendar/calendar.yml
+++ b/components/03-organisms/calendar/calendar.yml
@@ -229,6 +229,9 @@
         type:
           - 'Public Event'
           - 'Community Event'
+          - 'Campus Event'
+          - 'Lecture'
+          - 'Workshop'
         description: 'Lin Zhong, professor of computer science, has been named a fellow of the Association for Computing Machinery (ACM).'
       - category: 'computer science'
         title: 'Music in Schools Initiative - Morse Summer Music Academy'

--- a/components/03-organisms/calendar/calendar.yml
+++ b/components/03-organisms/calendar/calendar.yml
@@ -124,6 +124,10 @@
         time: 09:00am to 9:45am
         type:
           - 'Public Event'
+          - 'Community Event'
+          - 'Campus Event'
+          - 'Lecture'
+          - 'Workshop'
         optional_link__content: 'Optional link'
         optional_link__url: '/'
   - date:


### PR DESCRIPTION
## [#538: Fix Views Category Tags Display](https://github.com/yalesites-org/YaleSites-Internal/issues/538)

### Description of work
- Removes the `visible_items` limit and `+N more` link from `yds-tags-list.twig` so all tags display inline regardless of quantity
- Removes the now-unused `.taxonomy-list__item--more` SCSS rule
- Removes the `visible_items: 2` parameter from the calendar cell event embed

### Testing Link(s)
- [ ] [Tags List story](https://deploy-preview-635--dev-component-library-twig.netlify.app/?path=/story/atoms-lists--tags-list)
- [ ] [Post Card story](https://deploy-preview-635--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--post-card)
- [ ] [Event Card story](https://deploy-preview-635--dev-component-library-twig.netlify.app/?path=/story/molecules-cards--event-card)
- [ ] [Calendar story](https://deploy-preview-635--dev-component-library-twig.netlify.app/?path=/story/organisms-calendar--calendar)
- [ ] [Drupal Multidev](https://github.com/yalesites-org/yalesites-project/pull/1249)

### Functional Review Steps
- [ ] In the **Tags List story**, verify all 5 tags display inline: Public Event | Campus Event | Exhibitions | Family Programs | Readings — with no "+2 more" link
- [ ] In the **Post Card story**, open the Controls panel and enable **Show Tags**, then verify all 5 tags display inline: Public Event | Campus Event | Exhibitions | Family Programs | Readings — with no "+2 more" link
- [ ] In the **Event Card story**, open the Controls panel and enable **Show Tags**, then verify all 5 tags display inline: Public Event | Campus Event | Exhibitions | Family Programs | Readings — with no "+2 more" link
- [ ] In the **Calendar story**, find the June 18 "Yale Pathways to Science Summer Scholars 2024" event (the only event that day) and verify all 5 types display inline: Public Event | Community Event | Campus Event | Lecture | Workshop — with no "+3 more" link
- [ ] Test functionality in the [Drupal Multidev](https://github.com/yalesites-org/yalesites-project/pull/1249)

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements

Closes yalesites-org/YaleSites-Internal#538