### PR TITLE
1225: RC: Publication Resource Cleanup V2

### DIFF
--- a/components/02-molecules/meta/publication-meta/yds-publication-detail.twig
+++ b/components/02-molecules/meta/publication-meta/yds-publication-detail.twig
@@ -77,10 +77,6 @@
             </div>
           {% endif %}
           {% if publication_detail__download_url %}
-            {# Download icon is added by lib/ys_link's download-link
-               decorator (file extension → fa-circle-down) — adding one
-               here in the CTA content double-stamps the arrow. Pass label
-               only and let ys_link decorate. #}
             <div {{ bem('download', [], publication_detail__base_class) }}>
               {% include "@atoms/controls/cta/yds-cta.twig" with {
                 cta__content: publication_detail__download_label|default('Download'),
@@ -88,6 +84,8 @@
                 cta__component_theme: 'one',
                 cta__attributes: {
                   'aria-label': publication_detail__download_aria_label,
+                  'download': '',
+                  'data-link-type': 'download',
                 },
               } %}
             </div>


### PR DESCRIPTION
## [1225: RC: Publication Resource Cleanup V2](https://github.com/yalesites-org/YaleSites-Internal/issues/1225)

### Description of work
- Add `data-link-type="download"` and `download` attributes to publication detail download CTA so LinkPurpose decorates it with the download icon
- Remove outdated ys_link comment (platform uses LinkPurpose)
- Other work completed in: yalesites-org/yalesites-project#1263, yalesites-org/atomic#457

### Functional testing steps:
- [ ] Visit a Resource page with a downloadable file
- [ ] Verify the download CTA shows the fa-circle-down icon
- [ ] Verify the download attribute is present on the link element

References yalesites-org/YaleSites-Internal#1225