### PR TITLE
1235: RC2 Bug: Inconsistent numeral style in Event multi-date display

### DIFF
--- a/.storybook/_drupal.js
+++ b/.storybook/_drupal.js
@@ -12,12 +12,40 @@ window.Drupal = { behaviors: {} };
   Drupal.attachBehaviors = function (context, settings) {
     context = context || document;
     settings = settings || drupalSettings;
+
+    // Guard against duplicate attachment within the same render cycle.
+    // Without this, multiple useEffect calls in Storybook Docs view attach
+    // duplicate event listeners, causing toggles to fire twice and appear broken.
+    if (context._drupalBehaviorsAttached) return;
+    context._drupalBehaviorsAttached = true;
+
     const behaviors = Drupal.behaviors;
 
     Object.keys(behaviors).forEach(function (i) {
       if (typeof behaviors[i].attach === 'function') {
         try {
           behaviors[i].attach(context, settings);
+        } catch (e) {
+          Drupal.throwError(e);
+        }
+      }
+    });
+  };
+
+  Drupal.detachBehaviors = function (context, settings, trigger) {
+    context = context || document;
+    settings = settings || drupalSettings;
+    trigger = trigger || 'unload';
+
+    // Clear the attachment guard so behaviors re-attach on the next render.
+    delete context._drupalBehaviorsAttached;
+
+    const behaviors = Drupal.behaviors;
+
+    Object.keys(behaviors).forEach(function (i) {
+      if (typeof behaviors[i].detach === 'function') {
+        try {
+          behaviors[i].detach(context, settings, trigger);
         } catch (e) {
           Drupal.throwError(e);
         }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -26,11 +26,15 @@ import '../lib/link-treatment/link-treatment.scss';
 export const decorators = [
   (StoryFn, context) => {
     useEffect(() => {
-      Drupal.attachBehaviors();
-
       // Update body attributes for theme + heading typography
       document.body.setAttribute('data-global-theme', context.globals.globalTheme);
       document.body.setAttribute('data-font-pairing', context.globals.headingTypography || 'yalenew');
+
+      Drupal.attachBehaviors(document);
+
+      return () => {
+        Drupal.detachBehaviors(document);
+      };
     }, [context]);
 
     return StoryFn(context);

--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -109,6 +109,6 @@ format__day__long = Thursday, December 3, 2024
   class: bem('date-time', date_time__modifiers),
 } %}
 
-<time {{ add_attributes(date_time__attribuites) }}>{{ date_time|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}</time>
+<time {{ add_attributes(date_time__attribuites) }}>{{ date_time }}</time>
 
 {% endapply %}

--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -112,7 +112,7 @@ format__day__long = Thursday, December 3, 2024
 {% endif %}
 
 {# Add attributes #}
-{% set date_time__modifiers = (used_format == 'format__all_day' or used_format == 'format__localist_all_day') ? ['all-day'] : [] %}
+{% set date_time__modifiers = used_format == 'format__all_day' ? ['all-day'] : [] %}
 {% set date_time__attribuites = {
   datetime: date_time__start|date(formats['format__iso']),
   class: bem('date-time', date_time__modifiers),

--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -61,6 +61,8 @@ format__day__long = Thursday, December 3, 2024
   'format__date_and_time': 'g:i a',
   'format__date_time_multiple_days__start': 'D M j, Y g:i a' ~ em_dash,
   'format__date_time_multiple_days': 'D M j, Y g:i a',
+  'format__localist_same_day__start': 'D M j, Y g:i a' ~ em_dash,
+  'format__localist_same_day': 'g:i a',
 } %}
 
 {# easy to name configurations that utilize the above formats _start and regular variants #}
@@ -74,6 +76,7 @@ format__day__long = Thursday, December 3, 2024
   "month_year": "format__month_year",
   "same_day_diff_time": "format__date_and_time",
   "date_time_multiple_days": "format__date_time_multiple_days",
+  "localist_same_day": "format__localist_same_day",
 } %}
 
 {% set used_format = date_time__format_override|default(format_defaults[date_time__format]) %}
@@ -106,6 +109,6 @@ format__day__long = Thursday, December 3, 2024
   class: bem('date-time', date_time__modifiers),
 } %}
 
-<time {{ add_attributes(date_time__attribuites) }}>{{ date_time }}</time>
+<time {{ add_attributes(date_time__attribuites) }}>{{ date_time|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}</time>
 
 {% endapply %}

--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -77,12 +77,21 @@ format__day__long = Thursday, December 3, 2024
   "same_day_diff_time": "format__date_and_time",
   "date_time_multiple_days": "format__date_time_multiple_days",
   "localist_same_day": "format__localist_same_day",
+  "localist_all_day": "format__localist_all_day",
 } %}
 
 {% set used_format = date_time__format_override|default(format_defaults[date_time__format]) %}
 
 {# Combine start and end date/time into one variable for output #}
-{% if used_format == 'format__all_day' %}
+{% if used_format == 'format__localist_all_day' %}
+  {% set start_date_formatted = date_time__start|date(formats['format__day__full']) %}
+  {% set end_date_formatted = date_time__end|date(formats['format__day__full']) %}
+  {% if start_date_formatted == end_date_formatted %}
+    {% set date_time = start_date_formatted ~ ' All day' %}
+  {% else %}
+    {% set date_time = start_date_formatted ~ em_dash ~ end_date_formatted ~ ' All day' %}
+  {% endif %}
+{% elseif used_format == 'format__all_day' %}
   {# For all day events, show the date (without time) followed by "All day" #}
   {# Check if start and end dates are the same day (not just same timestamp) #}
   {# Use format__date__start which includes em dash - keep it for both single and multi-day #}
@@ -103,7 +112,7 @@ format__day__long = Thursday, December 3, 2024
 {% endif %}
 
 {# Add attributes #}
-{% set date_time__modifiers = used_format == 'format__all_day' ? ['all-day'] : [] %}
+{% set date_time__modifiers = (used_format == 'format__all_day' or used_format == 'format__localist_all_day') ? ['all-day'] : [] %}
 {% set date_time__attribuites = {
   datetime: date_time__start|date(formats['format__iso']),
   class: bem('date-time', date_time__modifiers),

--- a/components/02-molecules/meta/event-meta/event-localist--past-only.yml
+++ b/components/02-molecules/meta/event-meta/event-localist--past-only.yml
@@ -6,13 +6,13 @@ event_dates:
     original_start: 1714739400
     original_end: 1714743000
     is_past_event: true
+    is_all_day: false
   - formatted_start_date: Saturday, May 4th, 2024
     formatted_end_date: Saturday, May 4th, 2024
-    formatted_start_time: 8:30 am EDT
-    formatted_end_time: 9:30 am EDT
-    original_start: 1714825800
-    original_end: 1714829400
+    original_start: 1714795200
+    original_end: 1714881540
     is_past_event: true
+    is_all_day: true
   - formatted_start_date: Sunday, May 5th, 2024
     formatted_end_date: Sunday, May 5th, 2024
     formatted_start_time: 8:30 am EDT
@@ -20,6 +20,7 @@ event_dates:
     original_start: 1714912200
     original_end: 1714915800
     is_past_event: true
+    is_all_day: false
 ticket_cost: $40 pre registration, $60 at the door
 ticket_url: https://www.yale.edu
 event_meta__cta_primary__content: Event Name Website

--- a/components/02-molecules/meta/event-meta/event-localist.yml
+++ b/components/02-molecules/meta/event-meta/event-localist.yml
@@ -6,13 +6,13 @@ event_dates:
     original_start: 1714739400
     original_end: 1714743000
     is_past_event: true
+    is_all_day: false
   - formatted_start_date: Saturday, May 4th, 2024
     formatted_end_date: Saturday, May 4th, 2024
-    formatted_start_time: 8:30 am EDT
-    formatted_end_time: 9:30 am EDT
-    original_start: 1714825800
-    original_end: 1714829400
+    original_start: 1714795200
+    original_end: 1714881540
     is_past_event: true
+    is_all_day: true
   - formatted_start_date: Sunday, May 5th, 2024
     formatted_end_date: Sunday, May 5th, 2024
     formatted_start_time: 8:30 am EDT
@@ -20,6 +20,7 @@ event_dates:
     original_start: 1714912200
     original_end: 1714915800
     is_past_event: true
+    is_all_day: false
   - formatted_start_date: Sunday, May 10th, 2030
     formatted_end_date: Sunday, May 10th, 2030
     formatted_start_time: 8:30 am EDT

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -207,12 +207,16 @@
           {% elseif event_featured_date.formatted_start_date == event_featured_date.formatted_end_date %}
           {#Replace am to a.m. and pm to p.m.#}
 
-            {{ event_featured_date.original_start|date('D M j, Y') }}
-            {{ event_featured_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}{{ em_dash }}{{ event_featured_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+            <time class="date-time" datetime="{{ event_featured_date.original_start|date('c') }}">
+              {{ event_featured_date.original_start|date('D M j, Y') }}
+              {{ event_featured_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}{{ em_dash }}{{ event_featured_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+            </time>
           {% else %}
-            {{ event_featured_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-            {{ em_dash }}
-            {{ event_featured_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+            <time class="date-time" datetime="{{ event_featured_date.original_start|date('c') }}">
+              {{ event_featured_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+              {{ em_dash }}
+              {{ event_featured_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+            </time>
           {% endif %}
           </div>
         </div>
@@ -259,12 +263,16 @@
                         date_time__format_override: 'format__all_day',
                       } %}
                     {% elseif event_date.formatted_start_date == event_date.formatted_end_date %}
-                      {{ event_date.original_start|date('D M j, Y') }}
-                      {{ event_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}{{ em_dash }}{{- event_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}
+                      <time class="date-time" datetime="{{ event_date.original_start|date('c') }}">
+                        {{ event_date.original_start|date('D M j, Y') }}
+                        {{ event_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}{{ em_dash }}{{- event_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}
+                      </time>
                     {% else %}
-                      {{ event_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-                      {{ em_dash }}
-                      {{ event_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+                      <time class="date-time" datetime="{{ event_date.original_start|date('c') }}">
+                        {{ event_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+                        {{ em_dash }}
+                        {{ event_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+                      </time>
                     {% endif %}
                   </li>
                 {% endfor %}
@@ -296,12 +304,16 @@
                         date_time__format_override: 'format__all_day',
                       } %}
                     {% elseif event_date.formatted_start_date == event_date.formatted_end_date %}
-                      {{ event_date.original_start|date('D M j, Y') }}
-                      {{ event_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}{{ em_dash }}{{- event_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}
+                      <time class="date-time" datetime="{{ event_date.original_start|date('c') }}">
+                        {{ event_date.original_start|date('D M j, Y') }}
+                        {{ event_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}{{ em_dash }}{{- event_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}
+                      </time>
                     {% else %}
-                      {{ event_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-                      {{ em_dash }}
-                      {{ event_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+                      <time class="date-time" datetime="{{ event_date.original_start|date('c') }}">
+                        {{ event_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+                        {{ em_dash }}
+                        {{ event_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
+                      </time>
                     {% endif %}
                   </li>
                 {% endfor %}

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -202,7 +202,7 @@
             {% include "@atoms/date-time/yds-date-time.twig" with {
               date_time__start: event_featured_date.original_start,
               date_time__end: event_featured_date.original_end,
-              date_time__format_override: 'format__all_day',
+              date_time__format: 'localist_all_day',
             } %}
           {% elseif event_featured_date.formatted_start_date == event_featured_date.formatted_end_date %}
             {% include "@atoms/date-time/yds-date-time.twig" with {
@@ -259,7 +259,7 @@
                       {% include "@atoms/date-time/yds-date-time.twig" with {
                         date_time__start: event_date.original_start,
                         date_time__end: event_date.original_end,
-                        date_time__format_override: 'format__all_day',
+                        date_time__format: 'localist_all_day',
                       } %}
                     {% elseif event_date.formatted_start_date == event_date.formatted_end_date %}
                       {% include "@atoms/date-time/yds-date-time.twig" with {
@@ -301,7 +301,7 @@
                       {% include "@atoms/date-time/yds-date-time.twig" with {
                         date_time__start: event_date.original_start,
                         date_time__end: event_date.original_end,
-                        date_time__format_override: 'format__all_day',
+                        date_time__format: 'localist_all_day',
                       } %}
                     {% elseif event_date.formatted_start_date == event_date.formatted_end_date %}
                       {% include "@atoms/date-time/yds-date-time.twig" with {

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -205,18 +205,17 @@
               date_time__format_override: 'format__all_day',
             } %}
           {% elseif event_featured_date.formatted_start_date == event_featured_date.formatted_end_date %}
-          {#Replace am to a.m. and pm to p.m.#}
-
-            <time class="date-time" datetime="{{ event_featured_date.original_start|date('c') }}">
-              {{ event_featured_date.original_start|date('D M j, Y') }}
-              {{ event_featured_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}{{ em_dash }}{{ event_featured_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-            </time>
+            {% include "@atoms/date-time/yds-date-time.twig" with {
+              date_time__start: event_featured_date.original_start,
+              date_time__end: event_featured_date.original_end,
+              date_time__format: 'localist_same_day',
+            } %}
           {% else %}
-            <time class="date-time" datetime="{{ event_featured_date.original_start|date('c') }}">
-              {{ event_featured_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-              {{ em_dash }}
-              {{ event_featured_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-            </time>
+            {% include "@atoms/date-time/yds-date-time.twig" with {
+              date_time__start: event_featured_date.original_start,
+              date_time__end: event_featured_date.original_end,
+              date_time__format: 'date_time_multiple_days',
+            } %}
           {% endif %}
           </div>
         </div>
@@ -263,16 +262,17 @@
                         date_time__format_override: 'format__all_day',
                       } %}
                     {% elseif event_date.formatted_start_date == event_date.formatted_end_date %}
-                      <time class="date-time" datetime="{{ event_date.original_start|date('c') }}">
-                        {{ event_date.original_start|date('D M j, Y') }}
-                        {{ event_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}{{ em_dash }}{{- event_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}
-                      </time>
+                      {% include "@atoms/date-time/yds-date-time.twig" with {
+                        date_time__start: event_date.original_start,
+                        date_time__end: event_date.original_end,
+                        date_time__format: 'localist_same_day',
+                      } %}
                     {% else %}
-                      <time class="date-time" datetime="{{ event_date.original_start|date('c') }}">
-                        {{ event_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-                        {{ em_dash }}
-                        {{ event_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-                      </time>
+                      {% include "@atoms/date-time/yds-date-time.twig" with {
+                        date_time__start: event_date.original_start,
+                        date_time__end: event_date.original_end,
+                        date_time__format: 'date_time_multiple_days',
+                      } %}
                     {% endif %}
                   </li>
                 {% endfor %}
@@ -304,16 +304,17 @@
                         date_time__format_override: 'format__all_day',
                       } %}
                     {% elseif event_date.formatted_start_date == event_date.formatted_end_date %}
-                      <time class="date-time" datetime="{{ event_date.original_start|date('c') }}">
-                        {{ event_date.original_start|date('D M j, Y') }}
-                        {{ event_date.original_start|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}{{ em_dash }}{{- event_date.original_end|date('g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) -}}
-                      </time>
+                      {% include "@atoms/date-time/yds-date-time.twig" with {
+                        date_time__start: event_date.original_start,
+                        date_time__end: event_date.original_end,
+                        date_time__format: 'localist_same_day',
+                      } %}
                     {% else %}
-                      <time class="date-time" datetime="{{ event_date.original_start|date('c') }}">
-                        {{ event_date.original_start|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-                        {{ em_dash }}
-                        {{ event_date.original_end|date('D M j, Y g:i a')|replace({'am': 'a.m.', 'pm': 'p.m.'}) }}
-                      </time>
+                      {% include "@atoms/date-time/yds-date-time.twig" with {
+                        date_time__start: event_date.original_start,
+                        date_time__end: event_date.original_end,
+                        date_time__format: 'date_time_multiple_days',
+                      } %}
                     {% endif %}
                   </li>
                 {% endfor %}

--- a/components/02-molecules/meta/event-meta/yds-event-meta.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta.twig
@@ -72,8 +72,7 @@
 
           {# Time #}
           <div {{ bem('time', [], event_meta__base_class) }}>
-            {{ event_meta__time|replace({'am': 'a.m.', 'pm': 'p.m.'}) }} {# 8:30 pm- to 8:30 p.m.- #} 
-            {#Replace am to a.m. and pm to p.m.#}
+            {{ event_meta__time }}
           </div>
         </div>
         {# Event Details #}

--- a/components/02-molecules/meta/meta.stories.js
+++ b/components/02-molecules/meta/meta.stories.js
@@ -71,7 +71,7 @@ export const Event = ({
     if (!allDay) {
       return {
         ...date,
-        is_all_day: false,
+        is_all_day: date.is_all_day ?? false,
       };
     }
     // For all-day, set times to midnight (start) and 23:59 (end)
@@ -94,7 +94,7 @@ export const Event = ({
     if (!allDay) {
       return {
         ...selectedData.event_featured_date,
-        is_all_day: false,
+        is_all_day: selectedData.event_featured_date.is_all_day ?? false,
       };
     }
     const startDate = new Date(


### PR DESCRIPTION
## [1235: RC2 Bug: Inconsistent numeral style in Event multi-date display](https://github.com/yalesites-org/YaleSites-Internal/issues/1235)

### Description of work
- Routed all event date outputs through the `yds-date-time.twig` atom (previously rendered as inline Twig date filters), so the atom's `<time class="date-time">` wrapper and `body-oldstyle-nums` mixin apply consistently across all date types
- Added `localist_same_day` and `localist_all_day` formats to `yds-date-time.twig` to support the full range of event date display cases (named for Storybook context, but apply to any event source)
- Added weekday abbreviation to all-day event dates to match timed event format ("Wed May 20, 2026 All day")
- Removed `a.m./p.m.` period substitution in favor of natural lowercase `am/pm` for consistency across all event formats
- Fixed `localist_all_day` to inherit base `.date-time` small-caps styling by removing the `--all-day` modifier that was suppressing it

### Functional testing steps:
- [ ] Open the [event meta docs](https://deploy-preview-642--dev-component-library-twig.netlify.app/iframe.html?viewMode=docs&id=molecules-meta--docs&globals=#event-meta)
- [ ] Verify all date types (all-day, same-day timed, multi-day timed) display consistent numeral style
- [ ] Verify all-day event dates show a weekday abbreviation (e.g. "Wed May 20, 2026 All day")
- [ ] Verify timed event dates show lowercase `am/pm` without periods
- [ ] Check all three date contexts: featured date, upcoming dates list, past dates list
- [ ] Verify font pairing (YaleNew vs Mallory) applies correctly to all date types in Storybook
- [ ] Test in Drupal multidev via yalesites-org/yalesites-project#1266

References yalesites-org/YaleSites-Internal#1235