### PR TITLE
#1232 :: Bug: Site-Wide Alert – link hover color fails accessibility in Emergency variant

### DIFF
--- a/components/02-molecules/alert/_yds-alert.scss
+++ b/components/02-molecules/alert/_yds-alert.scss
@@ -151,6 +151,15 @@ $alert-fade-speed: var(--animation-speed-slow);
   }
 }
 
+// Emergency: `atoms.link` sets `--color-link-hover` from global `--color-slot-two`
+// (e.g. Yale blue). On the red emergency background that pairing is ~2.3:1 —
+// below WCAG 2.1 AA for normal text. Pin hover (and visited-hover) to the
+// alert text token so contrast matches body copy (~5.2:1 with white on red).
+.alert[data-alert-type='emergency'] .alert__link {
+  --color-link-hover: var(--color-alert-text);
+  --color-link-visited-hover: var(--color-alert-text);
+}
+
 .alert__toggle {
   @include atoms.button-reset;
 


### PR DESCRIPTION
## [#1232: Bug: Site-Wide Alert – link hover color fails accessibility in Emergency variant](https://github.com/yalesites-org/YaleSites-Internal/issues/1232)

### Description of work
- Update style for emergency alert link

### Testing Link(s)
- [ ] Navigate to the [Alert component](https://deploy-preview-644--dev-component-library-twig.netlify.app/?path=/story/molecules-site-alert-visreg--visreg)

Verify the hover in the emergency alert looks as expected.

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
