### PR TITLE
#1239 :: Split Storybook color page into web colors and print colors pages

### DIFF
--- a/components/00-tokens/colors/cl-colors.scss
+++ b/components/00-tokens/colors/cl-colors.scss
@@ -144,6 +144,56 @@ $cl-colors-copy-success: #16a34a;
   }
 }
 
+// Intro placeholder shown until PM adds contextual copy.
+.cl-colors__intro-placeholder {
+  color: var(--color-gray-500);
+  font-style: italic;
+}
+
+// Pyramid tier wrapper for the print colors page.
+.cl-colors-tier {
+  margin-bottom: var(--size-spacing-8);
+
+  &--yale-blue {
+    // Yale Blue tier has extra visual weight at the top of the pyramid.
+    padding-bottom: var(--size-spacing-6);
+    border-bottom: 3px solid var(--color-gray-200);
+    margin-bottom: var(--size-spacing-9);
+  }
+}
+
+.cl-colors-tier__heading {
+  margin-bottom: var(--size-spacing-5);
+}
+
+// Combined web+print single-page layout.
+.cl-colors-combined {
+  &__intro {
+    margin-bottom: var(--size-spacing-8);
+  }
+
+  &__section {
+    padding-top: var(--size-spacing-8);
+    border-top: 3px solid var(--color-gray-300);
+    margin-bottom: var(--size-spacing-10);
+
+    &:first-of-type {
+      border-top: none;
+      padding-top: 0;
+    }
+  }
+
+  &__section-heading {
+    margin-bottom: var(--size-spacing-4);
+  }
+
+  &__section-intro {
+    margin-bottom: var(--size-spacing-6);
+    color: var(--color-gray-500);
+    font-style: italic;
+  }
+}
+
 [data-global-theme] {
   .global-theme-title {
     position: sticky;

--- a/components/00-tokens/colors/colors.stories.js
+++ b/components/00-tokens/colors/colors.stories.js
@@ -1,9 +1,12 @@
 import tokens from '@yalesites-org/tokens/build/json/tokens.json';
 import getGlobalThemes from './color-global-themes';
 import colorMeta from './color-data.yml';
+import printColorsMeta from './print-colors.yml';
 import '../../01-atoms/controls/text-copy-button/yds-text-copy-button';
 
 import colorsTwig from './colors.twig';
+import webColorsTwig from './web-colors.twig';
+import printColorsTwig from './print-colors.twig';
 import colorComponentThemeTwig from './color-component-theme-pairings.twig';
 import colorGlobalThemeTwig from './color-global-themes.twig';
 import colorGlobalThemePairingTwig from './color-global-theme-pairings.twig';
@@ -209,6 +212,49 @@ export default {
 };
 
 export const Colors = () => colorsTwig(colorsData);
+
+// ---------------------------------------------------------------------------
+// Web Colors — HEX values only (for digital use).
+// ---------------------------------------------------------------------------
+export const WebColors = () => webColorsTwig(colorsData);
+WebColors.storyName = 'Web Colors';
+
+// ---------------------------------------------------------------------------
+// Print Colors — PMS + CMYK values (for print vendors). Pyramid hierarchy.
+// HEX drives swatches only and is never shown to users.
+// ---------------------------------------------------------------------------
+const printData = { print_colors: printColorsMeta };
+
+export const PrintColors = () => printColorsTwig(printData);
+PrintColors.storyName = 'Print Colors';
+
+// ---------------------------------------------------------------------------
+// Web + Print Colors — single page with both sections for comparison.
+// Composed in JS so each template is included without Twig cross-file paths.
+// ---------------------------------------------------------------------------
+export const WebAndPrintColors = () => `
+  <div class="cl-colors-combined">
+    <div class="cl-colors-combined__intro text-field" data-component-alignment="left" data-component-width="max">
+      <div class="text-field__inner">
+        <div class="text">
+          <h1>Yale Brand Colors</h1>
+          <p class="cl-colors__intro-placeholder"><em>[Contextual copy — to be added by PM.]</em></p>
+        </div>
+      </div>
+    </div>
+    <section class="cl-colors-combined__section">
+      <h2 class="cl-colors-combined__section-heading">Web Colors</h2>
+      <p class="cl-colors-combined__section-intro"><em>[Contextual copy — to be added by PM.]</em></p>
+      ${webColorsTwig({ ...colorsData, is_subsection: true })}
+    </section>
+    <section class="cl-colors-combined__section">
+      <h2 class="cl-colors-combined__section-heading">Print Colors</h2>
+      <p class="cl-colors-combined__section-intro"><em>[Contextual copy — to be added by PM.]</em></p>
+      ${printColorsTwig({ ...printData, is_subsection: true })}
+    </section>
+  </div>
+`;
+WebAndPrintColors.storyName = 'Web + Print Colors';
 
 export const ComponentColorSlots = () => `
   <div style="max-width: 1200px; margin: 40px auto; padding: 20px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">

--- a/components/00-tokens/colors/print-colors.twig
+++ b/components/00-tokens/colors/print-colors.twig
@@ -38,6 +38,7 @@
 {# Yale Blue — sits alone at the top of the pyramid #}
 <section class="cl-colors-tier cl-colors-tier--yale-blue">
   <{{ tier_heading_level }} class="cl-colors-tier__heading">{{ print_colors.yale_blue.label }}</{{ tier_heading_level }}>
+  <div {{ bem(colors__base_class) }}>
   <ul {{ bem('list', [], colors__base_class) }}>
     {% for key, color in print_colors.yale_blue.colors %}
       <li {{ bem('item', [], colors__base_class) }}>
@@ -73,11 +74,13 @@
       </li>
     {% endfor %}
   </ul>
+  </div>
 </section>
 
 {# Core Colors — blues + Warm Gray #}
 <section class="cl-colors-tier cl-colors-tier--core">
   <{{ tier_heading_level }} class="cl-colors-tier__heading">{{ print_colors.core.label }}</{{ tier_heading_level }}>
+  <div {{ bem(colors__base_class) }}>
   <ul {{ bem('list', [], colors__base_class) }}>
     {% for key, color in print_colors.core.colors %}
       <li {{ bem('item', [], colors__base_class) }}>
@@ -112,12 +115,14 @@
       </li>
     {% endfor %}
   </ul>
+  </div>
 </section>
 
 {# Color families — Red, Yellow, Green, Orange, Purple, Cyan/Teal, Gray #}
 {% for family_key, family in print_colors.families %}
   <section class="cl-colors-tier cl-colors-tier--{{ family_key }}">
     <{{ tier_heading_level }} class="cl-colors-tier__heading">{{ family.label }}</{{ tier_heading_level }}>
+    <div {{ bem(colors__base_class) }}>
     <ul {{ bem('list', [], colors__base_class) }}>
       {% for key, color in family.colors %}
         <li {{ bem('item', [], colors__base_class) }}>
@@ -152,5 +157,6 @@
         </li>
       {% endfor %}
     </ul>
+    </div>
   </section>
 {% endfor %}

--- a/components/00-tokens/colors/print-colors.twig
+++ b/components/00-tokens/colors/print-colors.twig
@@ -1,0 +1,156 @@
+{% set colors__base_class = "cl-colors" %}
+
+{#
+  Print color values (PMS + CMYK) are for use with professional print vendors.
+  Yale's brand colors look different in print than on screen — this is expected.
+  HEX values are used internally to render swatches only and are never displayed
+  to users on this page.
+#}
+
+{% if not is_subsection %}
+  <div {{ bem('wrap', [], colors__base_class) }}>
+    <div class="text-field" data-component-alignment="left" data-component-width="max">
+      <div class="text-field__inner">
+        <div class="text">
+          <h1>Print Colors</h1>
+          {% if print_colors__intro %}
+            {{ print_colors__intro }}
+          {% else %}
+            <p class="cl-colors__intro-placeholder"><em>[Contextual copy — to be added by PM.]</em></p>
+          {% endif %}
+          <p>PMS and CMYK values are shown for use with professional print vendors. Yale's brand colors look different in print than on screen — this is expected and intentional. Click any value to copy it to your clipboard.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}
+
+{% set tier_heading_level = is_subsection ? 'h3' : 'h2' %}
+{% set card_name_level = is_subsection ? 'h4' : 'h3' %}
+
+{#
+  Macro-style reusable card block. Rendered inline for each tier to avoid
+  cross-file Twig include path complexity in the Storybook environment.
+  Each card shows PMS and CMYK (coated + uncoated) with copy buttons.
+  HEX drives the swatch style attribute only — it is never rendered as text.
+#}
+
+{# Yale Blue — sits alone at the top of the pyramid #}
+<section class="cl-colors-tier cl-colors-tier--yale-blue">
+  <{{ tier_heading_level }} class="cl-colors-tier__heading">{{ print_colors.yale_blue.label }}</{{ tier_heading_level }}>
+  <ul {{ bem('list', [], colors__base_class) }}>
+    {% for key, color in print_colors.yale_blue.colors %}
+      <li {{ bem('item', [], colors__base_class) }}>
+        <div {{ bem('swatch', [], colors__base_class) }} style="background: {{ color.hex }};"></div>
+        <div {{ bem('info', [], colors__base_class) }}>
+          <{{ card_name_level }} {{ bem('name', [], colors__base_class) }}>{{ color.name }}</{{ card_name_level }}>
+          {% set print_rows = {
+            'PMS': color.pms,
+            'CMYK (Coated)': color.cmyk_coated,
+            'CMYK (Uncoated)': color.cmyk_uncoated
+          } %}
+          {% for label, val in print_rows %}
+            <div {{ bem('value-row', [], colors__base_class, ['text-copy-button']) }}>
+              <span {{ bem('label', [], colors__base_class) }}>{{ label }}</span>
+              {# pre-text__text class is required by yds-text-copy-button.js to read the copy value #}
+              <code class="cl-colors__value pre-text__text">{{ val }}</code>
+              <button
+                class="cl-colors__copy-btn text-copy-button__button"
+                type="button"
+              >
+                <svg class="cl-colors__icon-copy" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                </svg>
+                <svg class="cl-colors__icon-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>
+                <span {{ bem('copy-label', [], colors__base_class) }}>Copy {{ label }} {{ val }}</span>
+              </button>
+            </div>
+          {% endfor %}
+        </div>
+      </li>
+    {% endfor %}
+  </ul>
+</section>
+
+{# Core Colors — blues + Warm Gray #}
+<section class="cl-colors-tier cl-colors-tier--core">
+  <{{ tier_heading_level }} class="cl-colors-tier__heading">{{ print_colors.core.label }}</{{ tier_heading_level }}>
+  <ul {{ bem('list', [], colors__base_class) }}>
+    {% for key, color in print_colors.core.colors %}
+      <li {{ bem('item', [], colors__base_class) }}>
+        <div {{ bem('swatch', [], colors__base_class) }} style="background: {{ color.hex }};"></div>
+        <div {{ bem('info', [], colors__base_class) }}>
+          <{{ card_name_level }} {{ bem('name', [], colors__base_class) }}>{{ color.name }}</{{ card_name_level }}>
+          {% set print_rows = {
+            'PMS': color.pms,
+            'CMYK (Coated)': color.cmyk_coated,
+            'CMYK (Uncoated)': color.cmyk_uncoated
+          } %}
+          {% for label, val in print_rows %}
+            <div {{ bem('value-row', [], colors__base_class, ['text-copy-button']) }}>
+              <span {{ bem('label', [], colors__base_class) }}>{{ label }}</span>
+              <code class="cl-colors__value pre-text__text">{{ val }}</code>
+              <button
+                class="cl-colors__copy-btn text-copy-button__button"
+                type="button"
+              >
+                <svg class="cl-colors__icon-copy" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                </svg>
+                <svg class="cl-colors__icon-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>
+                <span {{ bem('copy-label', [], colors__base_class) }}>Copy {{ label }} {{ val }}</span>
+              </button>
+            </div>
+          {% endfor %}
+        </div>
+      </li>
+    {% endfor %}
+  </ul>
+</section>
+
+{# Color families — Red, Yellow, Green, Orange, Purple, Cyan/Teal, Gray #}
+{% for family_key, family in print_colors.families %}
+  <section class="cl-colors-tier cl-colors-tier--{{ family_key }}">
+    <{{ tier_heading_level }} class="cl-colors-tier__heading">{{ family.label }}</{{ tier_heading_level }}>
+    <ul {{ bem('list', [], colors__base_class) }}>
+      {% for key, color in family.colors %}
+        <li {{ bem('item', [], colors__base_class) }}>
+          <div {{ bem('swatch', [], colors__base_class) }} style="background: {{ color.hex }};"></div>
+          <div {{ bem('info', [], colors__base_class) }}>
+            <{{ card_name_level }} {{ bem('name', [], colors__base_class) }}>{{ color.name }}</{{ card_name_level }}>
+            {% set print_rows = {
+              'PMS': color.pms,
+              'CMYK (Coated)': color.cmyk_coated,
+              'CMYK (Uncoated)': color.cmyk_uncoated
+            } %}
+            {% for label, val in print_rows %}
+              <div {{ bem('value-row', [], colors__base_class, ['text-copy-button']) }}>
+                <span {{ bem('label', [], colors__base_class) }}>{{ label }}</span>
+                <code class="cl-colors__value pre-text__text">{{ val }}</code>
+                <button
+                  class="cl-colors__copy-btn text-copy-button__button"
+                  type="button"
+                >
+                  <svg class="cl-colors__icon-copy" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                  </svg>
+                  <svg class="cl-colors__icon-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                  </svg>
+                  <span {{ bem('copy-label', [], colors__base_class) }}>Copy {{ label }} {{ val }}</span>
+                </button>
+              </div>
+            {% endfor %}
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endfor %}

--- a/components/00-tokens/colors/print-colors.yml
+++ b/components/00-tokens/colors/print-colors.yml
@@ -1,0 +1,233 @@
+# Print color specifications.
+#
+# Source: color-specs_2025-05-10.pdf, provided by OPAC (2025-05-10).
+#
+# IMPORTANT: `hex` is used ONLY to render the on-screen swatch. It must never be
+# displayed to users on the print page — print displays PMS and CMYK only.
+# Yale's brand colors render differently in print than on screen, so these HEX
+# values are approximations of the printed result for swatch purposes.
+#
+# Structure mirrors the print "pyramid" hierarchy:
+#   yale_blue  -> sits alone at the top
+#   core       -> the blues directly below Yale Blue, plus Warm Gray
+#   families   -> the remaining accent colors grouped by family
+#
+# Combined coated/uncoated PMS cells (e.g. "PMS 660 C / PMS 279 U") are kept as a
+# single string so the C (coated) / U (uncoated) distinction shows as authored.
+
+yale_blue:
+  label: 'Yale Blue'
+  colors:
+    yale-blue:
+      name: 'Yale Blue'
+      hex: '#00356b'
+      pms: 'PMS 648 C / PMS 295 U'
+      cmyk_coated: '100, 75, 8, 40'
+      cmyk_uncoated: '100, 75, 5, 35'
+
+core:
+  label: 'Core Colors'
+  colors:
+    blue:
+      name: 'Blue'
+      hex: '#4681C2'
+      pms: 'PMS 660 C / PMS 279 U'
+      cmyk_coated: '74, 44, 0, 0'
+      cmyk_uncoated: '70, 39, 0, 0'
+    blue-light:
+      name: 'Blue (light)'
+      hex: '#78A7D8'
+      pms: 'PMS 645'
+      cmyk_coated: '51, 23, 0, 1'
+      cmyk_uncoated: '52, 24, 0, 1'
+    blue-lighter:
+      name: 'Blue (lighter)'
+      hex: '#A7CFEE'
+      pms: 'PMS 277'
+      cmyk_coated: '32, 8, 0, 0'
+      cmyk_uncoated: '31, 8, 0, 0'
+    warm-gray:
+      name: 'Warm Gray'
+      hex: '#968B83'
+      pms: 'PMS Warm Gray 7'
+      cmyk_coated: '43, 41, 45, 4'
+      cmyk_uncoated: '33, 31, 33, 17'
+
+families:
+  red:
+    label: 'Red'
+    colors:
+      red:
+        name: 'Red'
+        hex: '#ED1C2E'
+        pms: 'PMS 485'
+        cmyk_coated: '0, 99, 89, 0'
+        cmyk_uncoated: '0, 85, 100, 0'
+      red-light:
+        name: 'Red (light)'
+        hex: '#EF4637'
+        pms: 'PMS 179'
+        cmyk_coated: '0, 88, 85, 0'
+        cmyk_uncoated: '0, 83, 100, 0'
+      red-dark:
+        name: 'Red (dark)'
+        hex: '#C11E30'
+        pms: 'PMS 1805'
+        cmyk_coated: '0, 97, 78, 22'
+        cmyk_uncoated: '2, 89, 76, 18'
+      red-darker:
+        name: 'Red (darker)'
+        hex: '#85081F'
+        pms: 'PMS 1815'
+        cmyk_coated: '2, 97, 72, 52'
+        cmyk_uncoated: '9, 86, 74, 38'
+
+  yellow:
+    label: 'Yellow'
+    colors:
+      yellow:
+        name: 'Yellow'
+        hex: '#FCE020'
+        pms: 'PMS 107'
+        cmyk_coated: '3, 7, 96, 0'
+        cmyk_uncoated: '0, 0, 89, 0'
+      yellow-light:
+        name: 'Yellow (light)'
+        hex: '#FDF49B'
+        pms: 'PMS 601'
+        cmyk_coated: '2, 0, 49, 0'
+        cmyk_uncoated: '0, 0, 53, 0'
+      gold:
+        name: 'Gold'
+        hex: '#FDB515'
+        pms: 'PMS 130 C / PMS 129 U'
+        cmyk_coated: '0, 32, 100, 0'
+        cmyk_uncoated: '0, 25, 100, 0'
+      gold-dark:
+        name: 'Gold (dark)'
+        hex: '#E19717'
+        pms: 'PMS 131'
+        cmyk_coated: '0, 39, 100, 11'
+        cmyk_uncoated: '0, 42, 100, 16'
+
+  green:
+    label: 'Green'
+    colors:
+      green:
+        name: 'Green'
+        hex: '#00AA52'
+        pms: 'PMS 347'
+        cmyk_coated: '92, 0, 97, 0'
+        cmyk_uncoated: '90, 0, 95, 0'
+      green-light:
+        name: 'Green (light)'
+        hex: '#CCE4B2'
+        pms: 'PMS 580'
+        cmyk_coated: '21, 0, 38, 0'
+        cmyk_uncoated: '17, 0, 35, 0'
+      green-dark:
+        name: 'Green (dark)'
+        hex: '#475826'
+        pms: 'PMS 574'
+        cmyk_coated: '49, 22, 85, 58'
+        cmyk_uncoated: '47, 25, 79, 42'
+
+  orange:
+    label: 'Orange'
+    colors:
+      orange:
+        name: 'Orange'
+        hex: '#F89644'
+        pms: 'PMS 6017'
+        cmyk_coated: '0, 49, 82, 0'
+        cmyk_uncoated: '0, 52, 86, 0'
+      orange-light:
+        name: 'Orange (light)'
+        hex: '#FFEBC2'
+        pms: 'PMS 7506'
+        cmyk_coated: '0, 7, 26, 0'
+        cmyk_uncoated: '0, 6, 28, 0'
+      orange-dark:
+        name: 'Orange (dark)'
+        hex: '#F15623'
+        pms: 'PMS 1665'
+        cmyk_coated: '0, 82, 100, 0'
+        cmyk_uncoated: '0, 72, 100, 0'
+      orange-darker:
+        name: 'Orange (darker)'
+        hex: '#D3551D'
+        pms: 'PMS 1525'
+        cmyk_coated: '0, 77, 100, 14'
+        cmyk_uncoated: '0, 66, 100, 15'
+
+  purple:
+    label: 'Purple'
+    colors:
+      purple:
+        name: 'Purple'
+        hex: '#88177A'
+        pms: 'PMS 249'
+        cmyk_coated: '43, 100, 0, 17'
+        cmyk_uncoated: '43, 92, 8, 20'
+      purple-dark:
+        name: 'Purple (dark)'
+        hex: '#5E0257'
+        pms: 'PMS 7652'
+        cmyk_coated: '48, 99, 3, 46'
+        cmyk_uncoated: '52, 88, 15, 35'
+
+  cyan:
+    label: 'Cyan/Teal'
+    colors:
+      cyan:
+        name: 'Cyan'
+        hex: '#006BA4'
+        pms: 'PMS 3015'
+        cmyk_coated: '100, 32, 0, 25'
+        cmyk_uncoated: '100, 42, 0, 21'
+      cyan-bright:
+        name: 'Cyan (bright)'
+        hex: '#00B3F0'
+        pms: 'PMS 2202'
+        cmyk_coated: '91, 0, 0, 0'
+        cmyk_uncoated: '90, 0, 0, 0'
+      cyan-light:
+        name: 'Cyan (light)'
+        hex: '#7AD1EF'
+        pms: 'PMS 2197'
+        cmyk_coated: '47, 0, 3, 0'
+        cmyk_uncoated: '50, 0, 2, 0'
+      teal:
+        name: 'Teal'
+        hex: '#00ACC6'
+        pms: 'PMS 2229'
+        cmyk_coated: '100, 0, 24, 0'
+        cmyk_uncoated: '100, 0, 22, 0'
+      teal-dark:
+        name: 'Teal (dark)'
+        hex: '#008AA0'
+        pms: 'PMS 2231'
+        cmyk_coated: '100, 0, 23, 25'
+        cmyk_uncoated: '100, 8, 22, 19'
+
+  gray:
+    label: 'Gray'
+    colors:
+      gray-dark:
+        name: 'Gray (dark)'
+        hex: '#53595F'
+        pms: 'PMS 425'
+        cmyk_coated: '63, 51, 45, 33'
+        cmyk_uncoated: '46, 35, 32, 28'
+      gray-medium:
+        name: 'Gray (medium)'
+        hex: '#6A625C'
+        pms: 'PMS 405'
+        cmyk_coated: '49, 47, 51, 32'
+        cmyk_uncoated: '43, 41, 45, 37'
+      gray-light:
+        name: 'Gray (light)'
+        hex: '#CBC8C4'
+        pms: 'PMS 400'
+        cmyk_coated: '20, 17, 19, 0'
+        cmyk_uncoated: '17, 16, 20, 1'

--- a/components/00-tokens/colors/web-colors.twig
+++ b/components/00-tokens/colors/web-colors.twig
@@ -1,0 +1,59 @@
+{% set colors__base_class = "cl-colors" %}
+
+{% if not is_subsection %}
+  <div {{ bem('wrap', [], colors__base_class) }}>
+    <div class="text-field" data-component-alignment="left" data-component-width="max">
+      <div class="text-field__inner">
+        <div class="text">
+          <h1>Web Colors</h1>
+          {% if web_colors__intro %}
+            {{ web_colors__intro }}
+          {% else %}
+            <p class="cl-colors__intro-placeholder"><em>[Contextual copy — to be added by PM.]</em></p>
+          {% endif %}
+          <p>HEX values are shown for use in digital applications. Click any value to copy it to your clipboard.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}
+
+{% set group_heading_level = is_subsection ? 'h3' : 'h2' %}
+{% set card_name_level = is_subsection ? 'h4' : 'h3' %}
+
+{% for group, colorset in _context.colors %}
+  <div {{ bem(colors__base_class) }}>
+    <{{ group_heading_level }}>{{ group|capitalize }}</{{ group_heading_level }}>
+    <ul {{ bem('list', [], colors__base_class) }}>
+      {% for key, color in colorset %}
+        <li {{ bem('item', [], colors__base_class) }}>
+          <div {{ bem('swatch', [], colors__base_class) }} style="background: var(--color-{{ group }}-{{ key }});"></div>
+          <div {{ bem('info', [], colors__base_class) }}>
+            <{{ card_name_level }} {{ bem('name', [], colors__base_class) }}>{{ color.name }}</{{ card_name_level }}>
+            <span {{ bem('var', [], colors__base_class) }}>--color-{{ group }}-{{ key }}</span>
+            <div {{ bem('value-row', [], colors__base_class, ['text-copy-button']) }}>
+              <span {{ bem('label', [], colors__base_class) }}>HEX</span>
+              {# pre-text__text class is required by yds-text-copy-button.js to read the copy value #}
+              <code class="cl-colors__value pre-text__text">{{ color.hex }}</code>
+              <button
+                class="cl-colors__copy-btn text-copy-button__button"
+                type="button"
+              >
+                {# Copy icon (shown by default) #}
+                <svg class="cl-colors__icon-copy" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                </svg>
+                {# Check icon (shown when copied, toggled by JS via --copied modifier) #}
+                <svg class="cl-colors__icon-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>
+                <span {{ bem('copy-label', [], colors__base_class) }}>Copy HEX {{ color.hex }}</span>
+              </button>
+            </div>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endfor %}


### PR DESCRIPTION

## [#1239: Split Storybook color page into web colors and print colors pages](https://github.com/yalesites-org/YaleSites-Internal/issues/1239)

### Description of work
- Web Colors: HEX values only, CSS var lines, token-driven swatches
- Print Colors: PMS + CMYK (coated/uncoated)
- Web + Print Colors: single-page view, JS-composed from the two templates
- Both templates are subsection-aware (heading levels shift when embedded)
- Intro copy slots present as placeholders for PM to populate
- SCSS added for tier wrappers, combined-page sections, and intro placeholder

### Testing Link(s)
- [ ] [Web and Print Colors](https://deploy-preview-647--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--web-and-print-colors)
- [ ] [Web Colors](https://deploy-preview-647--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--web-colors)
- [ ] [Print Colors](https://deploy-preview-647--dev-component-library-twig.netlify.app/?path=/story/tokens-colors--print-colors)

### Functional Review Steps
- [ ] Verify you can install the component with the CLI

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/bTjNHdiy1OdgHrP3b9m7uc/Yale-UI-Kit?node-id=11249-6771)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
