### PR TITLE
1299: Image Banner: Add "mini" media height option

### DIFF
--- a/components/02-molecules/banner/image-banner-props.yml
+++ b/components/02-molecules/banner/image-banner-props.yml
@@ -24,11 +24,12 @@ size:
   name: Image Size
   type: select
   required: false
-  description: 'Image height variation: tall or short'
+  description: 'Image height variation: tall, short, or mini'
   default: tall
   options:
     - tall
     - short
+    - mini
   control: select
 
 withVideo:

--- a/components/02-molecules/banner/image-banner.mdx
+++ b/components/02-molecules/banner/image-banner.mdx
@@ -7,7 +7,7 @@ import componentProps from './image-banner-props.yml';
 
 # Image Banner
 
-The Image Banner is a streamlined, visually focused banner that displays a full-width image with an optional caption. It prioritizes the image itself over text content, making it well-suited for visual storytelling, photography showcases, or pages where the imagery is the primary message. Available in tall and short height variations.
+The Image Banner is a streamlined, visually focused banner that displays a full-width image with an optional caption. It prioritizes the image itself over text content, making it well-suited for visual storytelling, photography showcases, or pages where the imagery is the primary message. Available in tall, short, and mini height variations.
 
 ## Interactive Preview
 
@@ -35,7 +35,7 @@ Use the `image_banner__content__background` property to apply different themes.
 
 ## Size Variations
 
-The Image Banner is available in two heights. Use the interactive preview above to switch between them, or see the [Visreg page](?path=/story/molecules-banners-image-banner-visreg--visreg) for a side-by-side comparison.
+The Image Banner is available in three heights. Use the interactive preview above to switch between them, or see the [Visreg page](?path=/story/molecules-banners-image-banner-visreg--visreg) for a side-by-side comparison.
 
 ### Short
 
@@ -43,6 +43,14 @@ A reduced height variant — useful when you need a visual accent without the fu
 
 <div className="sb-full-bleed-canvas">
   <Canvas of={ImageBannerStories.ImageBannerShort} />
+</div>
+
+### Mini
+
+The most compact height variant, matching the Grand Hero Banner mini option. Use it when you need a small image accent rather than a full-sized banner.
+
+<div className="sb-full-bleed-canvas">
+  <Canvas of={ImageBannerStories.ImageBannerMini} />
 </div>
 
 ## Technical Specifications

--- a/components/02-molecules/banner/image-banner.stories.js
+++ b/components/02-molecules/banner/image-banner.stories.js
@@ -34,3 +34,7 @@ export const ImageBanner = (args) => renderBanner(args);
 export const ImageBannerShort = (args) => renderBanner(args);
 ImageBannerShort.args = { size: 'short' };
 ImageBannerShort.storyName = 'Short';
+
+export const ImageBannerMini = (args) => renderBanner(args);
+ImageBannerMini.args = { size: 'mini' };
+ImageBannerMini.storyName = 'Mini';

--- a/components/02-molecules/banner/image-banner.visreg.stories.js
+++ b/components/02-molecules/banner/image-banner.visreg.stories.js
@@ -49,7 +49,7 @@ export const Visreg = () => {
           image_banner__video: 'false',
           image_banner__caption: imageCaption,
         }),
-      ['tall', 'short'],
+      ['tall', 'short', 'mini'],
       'Size Variations',
       '',
       'Size',

--- a/components/02-molecules/banner/image/yds-image-banner.scss
+++ b/components/02-molecules/banner/image/yds-image-banner.scss
@@ -25,6 +25,10 @@ $break-image-banner: tokens.$break-m;
     align-items: center;
   }
 
+  &[data-image-banner-size='mini'] {
+    min-height: 14rem;
+  }
+
   &[data-image-banner-size='short'] {
     min-height: 28rem;
   }
@@ -182,6 +186,10 @@ $break-image-banner: tokens.$break-m;
 
     [data-image-banner-size='short'] & {
       min-height: 28rem;
+    }
+
+    [data-image-banner-size='mini'] & {
+      min-height: 14rem;
     }
   }
 

--- a/components/02-molecules/banner/image/yds-image-banner.scss
+++ b/components/02-molecules/banner/image/yds-image-banner.scss
@@ -194,6 +194,14 @@ $break-image-banner: tokens.$break-m;
   }
 
   figcaption {
+    // The caption sits on a fixed white bar (background-color below). Themed
+    // banners remap --color-text to white (slot-eight) in component themes
+    // one/three/five, which rendered the caption white-on-white. Reset it to
+    // slot-seven -- the palette's "text on light background" slot, dark in
+    // every theme -- so the shared .caption color rule stays WCAG-readable.
+    // For a flat dark caption later, swap this line to var(--color-basic-black).
+    --color-text: var(--color-slot-seven);
+
     position: absolute;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
## [1299: Image Banner: Add "mini" media height option](https://github.com/yalesites-org/YaleSites-Internal/issues/1299)

### Description of work
- Add a `mini` size variant (14rem) to the Image Banner component, matching the Grand Hero Banner mini option.
- Set `min-height` for `mini` on both the banner container and the inner image, following the existing `tall`/`short` pattern.
- Expose the new size through `image-banner-props.yml`, a `Mini` story, and the visreg size variations, and document it on the component MDX page.
- Other work completed in: yalesites-org/yalesites-project#1295

### Functional testing steps:
- [ ] In Storybook, open Molecules > Banners > Image Banner and select the `Mini` story (or set the Image Size control to `mini`); confirm the banner renders at the compact 14rem height.
- [ ] Confirm the `tall` and `short` variants are visually unchanged.
- [ ] Open the Image Banner Visreg page and confirm a `mini` size variation now appears alongside tall and short.
- [ ] Test the Mini option end-to-end in the Drupal multidev: yalesites-org/yalesites-project#1295

References yalesites-org/YaleSites-Internal#1299



Created with AI


---

## Caption contrast fix (follow-up to review)

A review comment on this PR found the image banner caption rendering **white-on-white** in some global theme settings. Fixed in component-library-twig (`components/02-molecules/banner/image/yds-image-banner.scss`), CLT commit `ad27f808`.

**Root cause:** The caption sits on a hardcoded white bar (`background-color: var(--color-basic-white)`). In themed banners the shared `.caption` rule set the text to `var(--color-text)`, which component themes one/three/five remap to white (`slot-eight`) — i.e. white text on a white bar.

**Fix:** On the `figcaption`, reset `--color-text` to `var(--color-slot-seven)` — the palette's existing "text on light background" slot. It resolves to a dark color in every global and component theme, so the shared caption rule stays readable. No invented colors; an existing token only. Documented in-code; can be swapped to `var(--color-basic-black)` if a flat black caption is preferred later.

**Caption text color by theme (on the white bar):**

| Context | Resolved color | Contrast |
|---|---|---|
| default / component theme `two` | brown-gray `rgb(120,112,104)` | 4.87:1 (unchanged) |
| component themes `one`/`three`/`four`/`five` | slot-seven → gray-800 `rgb(33,33,33)` | 16.1:1 |
| any component theme under global theme `five` | slot-seven → gray-900 `rgb(28,28,28)` | 17.04:1 |
| any component theme under global theme `four` | slot-seven → blue-yale `rgb(0,54,107)` | 12.07:1 |

**Verified:** all 7 global × 6 component-theme permutations (42 total) pass WCAG 2.1 A/AA (minimum 4.87:1) in **both** Storybook and the Drupal/Lando instance.

**Out of scope:** a link placed *inside* a caption (none in the test content) still inherits the banner link color — a pre-existing behavior, not changed here.
