### PR TITLE
1349: RC: Embed block: missing title attribute on Bluesky, Instagram, and event map embeds

### DIFF
--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -431,7 +431,7 @@
                   cta__style: 'outline',
                 } %}
                 <div {{ bem('map', [], event_meta__base_class) }} aria-expanded="false">
-                  <iframe src="https://www.google.com/maps/embed?pb=!1m10!1m8!1m3!1d12355.08068326396!2d{{ place.longitude }}!3d{{ place.latitude }}!3m2!1i1024!2i768!4f13.1!5e0!3m2!1sen!2sus!4v1712273181159!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                  <iframe src="https://www.google.com/maps/embed?pb=!1m10!1m8!1m3!1d12355.08068326396!2d{{ place.longitude }}!3d{{ place.latitude }}!3m2!1i1024!2i768!4f13.1!5e0!3m2!1sen!2sus!4v1712273181159!5m2!1sen!2sus" title="Map showing location of {{ location_display|default('event') }}" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
 
                   {% include "@atoms/controls/cta/yds-cta.twig" with {
                     cta__content: 'Get Directions',


### PR DESCRIPTION
## [1349: RC: Embed block: missing title attribute on Bluesky, Instagram, and event map embeds](https://github.com/yalesites-org/YaleSites-Internal/issues/1349)

### Description of work
- Adds a descriptive `title` attribute to the Google Maps iframe shown in the Event page's "Location" meta block, so screen readers announce what the embedded map is
- Other work completed in: yalesites-org/atomic#470
- Other work completed in: yalesites-org/yalesites-project#1314

### Functional testing steps:
- [ ] View an Event node with a venue/place set
- [ ] Expand the "Show Map" section
- [ ] Inspect the iframe and confirm it has a `title` attribute like "Map showing location of [venue name]"
- [ ] Run Storybook's a11y addon against the Molecules/Meta "Event" story and confirm no frame-title violation

References yalesites-org/YaleSites-Internal#1349