### PR TITLE
1202: Migrate 14 remaining MDX component docs to YAML-driven props tables

### DIFF
--- a/components/01-atoms/videos/video-embed/video-embed-props.yml
+++ b/components/01-atoms/videos/video-embed/video-embed-props.yml
@@ -1,0 +1,15 @@
+# video-embed-props.yml
+#
+# Video Embed component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+content:
+  twigProp: video_embed__content
+  name: Content
+  type: string
+  required: true
+  description: >
+    The embedded video markup, typically an iframe. Rendered with the |raw
+    filter so the iframe renders instead of displaying as plain text.
+  control: text

--- a/components/01-atoms/videos/video-embed/video-embed.mdx
+++ b/components/01-atoms/videos/video-embed/video-embed.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as VideoEmbedStories from './video-embed.stories';
+import { twigPropsTable } from '../../../_storybook/twig-props-table.mdx';
+import componentProps from './video-embed-props.yml';
 
 <Meta of={VideoEmbedStories} name="Overview" />
 
@@ -12,68 +14,13 @@ The video embed component provides a responsive container for embedded videos fr
 Use the controls panel below to see the video embed component in action.
 
 <Canvas of={VideoEmbedStories.videoEmbed} />
+<Controls of={VideoEmbedStories.videoEmbed} />
 
 ## Properties
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>video_embed__url</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>Video embed URL (iframe src)</td>
-    </tr>
-  </tbody>
-</table>
-
-### Optional Properties
-
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>video_embed__title</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>-</td>
-      <td>Accessible title for the video iframe</td>
-    </tr>
-    <tr>
-      <td>
-        <code>video_embed__aspect_ratio</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'16:9'</code>
-      </td>
-      <td>Video aspect ratio (16:9, 4:3, 1:1)</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ## Supported Video Platforms
 
@@ -180,9 +127,7 @@ The component supports standard video aspect ratios:
 
 ```twig
 {{ include('@atoms/videos/video-embed/yds-video-embed.twig', {
-  video_embed__url: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
-  video_embed__title: 'Video Title for Accessibility',
-  video_embed__aspect_ratio: '16:9'
+  video_embed__content: '<iframe src="https://www.youtube.com/embed/VIDEO_ID" title="Video Title for Accessibility" allowfullscreen></iframe>'
 }) }}
 ```
 

--- a/components/01-atoms/videos/video-embed/video-embed.stories.js
+++ b/components/01-atoms/videos/video-embed/video-embed.stories.js
@@ -1,6 +1,8 @@
 import videoEmbedTwig from './yds-video-embed.twig';
 
 import videoEmbedData from './video-embed.yml';
+import componentProps from './video-embed-props.yml';
+import { toArgTypes, toArgs } from '../../../_storybook/component-props';
 
 /**
  * Storybook Definition.
@@ -8,6 +10,12 @@ import videoEmbedData from './video-embed.yml';
 export default {
   title: 'Atoms/Videos/Video Embed',
   tags: ['!dev'],
+  argTypes: toArgTypes(componentProps),
+  args: {
+    ...toArgs(componentProps),
+    content: videoEmbedData.video_embed__content,
+  },
 };
 
-export const videoEmbed = () => videoEmbedTwig(videoEmbedData);
+export const videoEmbed = ({ content }) =>
+  videoEmbedTwig({ video_embed__content: content });

--- a/components/02-molecules/image/image-props.yml
+++ b/components/02-molecules/image/image-props.yml
@@ -26,7 +26,6 @@ caption:
   type: string
   required: false
   description: Caption text displayed below the image (supports HTML)
-  default: null
   control: text
 
 width:
@@ -49,7 +48,6 @@ srcset:
   type: string
   required: false
   description: Responsive image srcset for different viewport sizes
-  default: null
   control: text
 
 sizes:
@@ -58,5 +56,4 @@ sizes:
   type: string
   required: false
   description: Sizes attribute for responsive images (defines image display width at different breakpoints)
-  default: null
   control: text

--- a/components/02-molecules/image/image-props.yml
+++ b/components/02-molecules/image/image-props.yml
@@ -1,0 +1,62 @@
+# image-props.yml
+#
+# Image component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+src:
+  twigProp: image__src
+  name: Image Source
+  type: string
+  required: true
+  description: Image source URL
+  control: text
+
+alt:
+  twigProp: image__alt
+  name: Alt Text
+  type: string
+  required: true
+  description: Alternative text for accessibility (required for all images)
+  control: text
+
+caption:
+  twigProp: content_image__caption
+  name: Caption
+  type: string
+  required: false
+  description: Caption text displayed below the image (supports HTML)
+  default: null
+  control: text
+
+width:
+  twigProp: content_image__width
+  name: Width
+  type: select
+  required: false
+  description: "Width constraint: 'content', 'highlight', 'site', or 'max'"
+  default: content
+  options:
+    - content
+    - highlight
+    - site
+    - max
+  control: select
+
+srcset:
+  twigProp: image__srcset
+  name: Srcset
+  type: string
+  required: false
+  description: Responsive image srcset for different viewport sizes
+  default: null
+  control: text
+
+sizes:
+  twigProp: image__sizes
+  name: Sizes
+  type: string
+  required: false
+  description: Sizes attribute for responsive images (defines image display width at different breakpoints)
+  default: null
+  control: text

--- a/components/02-molecules/image/image.mdx
+++ b/components/02-molecules/image/image.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as ImageStories from './image.stories';
+import { twigPropsTable } from '../../_storybook/twig-props-table.mdx';
+import componentProps from './image-props.yml';
 
 <Meta of={ImageStories} name="Overview" />
 
@@ -11,111 +13,20 @@ The content image component displays responsive images with optional captions in
 
 Use the controls panel below to experiment with the image component's properties.
 
-<Canvas of={ImageStories.ContentImage} />
+<div className="sb-contained-canvas">
+  <Canvas of={ImageStories.ContentImage} />
+</div>
 <Controls of={ImageStories.ContentImage} />
 
 ## Properties
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>image__src</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>Image source URL</td>
-    </tr>
-    <tr>
-      <td>
-        <code>image__alt</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>Alternative text for accessibility (required for all images)</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>content_image__caption</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Caption text displayed below the image (supports HTML)</td>
-    </tr>
-    <tr>
-      <td>
-        <code>content_image__width</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'content'</code>
-      </td>
-      <td>
-        Width constraint: <code>'content'</code>, <code>'highlight'</code>,{' '}
-        <code>'site'</code>, or <code>'max'</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>image__srcset</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Responsive image srcset for different viewport sizes</td>
-    </tr>
-    <tr>
-      <td>
-        <code>image__sizes</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>
-        Sizes attribute for responsive images (defines image display width at
-        different breakpoints)
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ## Width Options
 

--- a/components/02-molecules/image/image.stories.js
+++ b/components/02-molecules/image/image.stories.js
@@ -1,20 +1,30 @@
 import contentImageTwig from './yds-content-image.twig';
 
 import imageData from '../../01-atoms/images/image/image.yml';
+import componentProps from './image-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
 
 export default {
   title: 'Molecules/Image',
   tags: ['!dev'],
-  args: {},
+  argTypes: toArgTypes(componentProps),
+  args: {
+    ...toArgs(componentProps),
+    src: imageData.responsive_images['16x9'].image__src,
+    alt: imageData.responsive_images['16x9'].image__alt,
+    srcset: imageData.responsive_images['16x9'].image__srcset,
+    sizes: imageData.responsive_images['16x9'].image__sizes,
+    caption: 'This is the <a href="#">caption</a> for the 16:9 image above.',
+  },
 };
 
-export const ContentImage = () => `
+export const ContentImage = ({ src, alt, caption, width, srcset, sizes }) => `
   ${contentImageTwig({
-    ...imageData.responsive_images['16x9'],
-    content_image__caption:
-      'This is the <a href="#">caption</a> for the 16:9 image above.',
-    content_image__width: 'content',
+    image__src: src,
+    image__alt: alt,
+    image__srcset: srcset,
+    image__sizes: sizes,
+    content_image__caption: caption,
+    content_image__width: width,
   })}
 `;
-
-ContentImage.args = {};

--- a/components/02-molecules/image/image.stories.js
+++ b/components/02-molecules/image/image.stories.js
@@ -20,6 +20,7 @@ export default {
 
 export const ContentImage = ({ src, alt, caption, width, srcset, sizes }) => `
   ${contentImageTwig({
+    output_image_tag: true,
     image__src: src,
     image__alt: alt,
     image__srcset: srcset,

--- a/components/02-molecules/link-skip/link-skip-props.yml
+++ b/components/02-molecules/link-skip/link-skip-props.yml
@@ -1,0 +1,39 @@
+# link-skip-props.yml
+#
+# Link Skip component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+content:
+  twigProp: link_skip__content
+  name: Content
+  type: string
+  required: true
+  description: The text content displayed in the skip link
+  control: text
+
+url:
+  twigProp: link_skip__url
+  name: URL
+  type: string
+  required: true
+  description: The target anchor link (typically '#main-content' or similar)
+  control: text
+
+baseClass:
+  twigProp: link_skip__base_class
+  name: Base Class
+  type: string
+  required: false
+  description: Base CSS class for the component
+  default: 'link-skip'
+  control: text
+
+extraClass:
+  twigProp: link_skip__extra_class
+  name: Extra Class
+  type: string
+  required: false
+  description: Additional CSS classes for custom styling
+  default: null
+  control: text

--- a/components/02-molecules/link-skip/link-skip-props.yml
+++ b/components/02-molecules/link-skip/link-skip-props.yml
@@ -35,5 +35,4 @@ extraClass:
   type: string
   required: false
   description: Additional CSS classes for custom styling
-  default: null
   control: text

--- a/components/02-molecules/link-skip/link-skip.mdx
+++ b/components/02-molecules/link-skip/link-skip.mdx
@@ -1,7 +1,9 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as LinkSkipStories from './link-skip.stories';
+import { twigPropsTable } from '../../_storybook/twig-props-table.mdx';
+import componentProps from './link-skip-props.yml';
 
-<Meta title="Atoms/Link Skip" />
+<Meta of={LinkSkipStories} name="Overview" />
 
 # Link Skip
 
@@ -20,77 +22,11 @@ Use the controls panel below to experiment with the link skip's properties. Pres
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>link_skip__content</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>The text content displayed in the skip link</td>
-    </tr>
-    <tr>
-      <td>
-        <code>link_skip__url</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        The target anchor link (typically <code>'#main-content'</code> or
-        similar)
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>link_skip__base_class</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'link-skip'</code>
-      </td>
-      <td>Base CSS class for the component</td>
-    </tr>
-    <tr>
-      <td>
-        <code>link_skip__extra_class</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Additional CSS classes for custom styling</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ## Technical Specifications
 

--- a/components/02-molecules/link-skip/link-skip.stories.js
+++ b/components/02-molecules/link-skip/link-skip.stories.js
@@ -1,6 +1,8 @@
 import linkSkipTwig from './yds-link-skip.twig';
 
 import linkSkipData from './link-skip.yml';
+import componentProps from './link-skip-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
 
 /**
  * Storybook Definition.
@@ -8,9 +10,18 @@ import linkSkipData from './link-skip.yml';
 export default {
   title: 'Atoms/Link Skip',
   tags: ['!dev'],
+  argTypes: toArgTypes(componentProps),
+  args: {
+    ...toArgs(componentProps),
+    content: linkSkipData.link_skip__content,
+    url: linkSkipData.link_skip__url,
+  },
 };
 
-export const LinkSkip = () =>
+export const LinkSkip = ({ content, url, baseClass, extraClass }) =>
   linkSkipTwig({
-    ...linkSkipData,
+    link_skip__content: content,
+    link_skip__url: url,
+    link_skip__base_class: baseClass,
+    link_skip__extra_class: extraClass,
   });

--- a/components/02-molecules/pull-quote/pull-quote-props.yml
+++ b/components/02-molecules/pull-quote/pull-quote-props.yml
@@ -20,7 +20,6 @@ attribution:
   type: string
   required: false
   description: Attribution text for the quote (e.g., author name, source)
-  default: null
   control: text
 
 style:

--- a/components/02-molecules/pull-quote/pull-quote-props.yml
+++ b/components/02-molecules/pull-quote/pull-quote-props.yml
@@ -1,0 +1,50 @@
+# pull-quote-props.yml
+#
+# Pull Quote component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+#
+# Edit descriptions and details freely - changes appear in Storybook on reload.
+
+quote:
+  twigProp: pull_quote__quote
+  name: Quote
+  type: string
+  required: true
+  description: The quote text to display (supports HTML)
+  control: text
+
+attribution:
+  twigProp: pull_quote__attribution
+  name: Attribution
+  type: string
+  required: false
+  description: Attribution text for the quote (e.g., author name, source)
+  default: null
+  control: text
+
+style:
+  twigProp: pull_quote__style
+  name: Style
+  type: select
+  required: false
+  description: "Visual style: 'bar-left', 'bar-right', or 'quote-left'"
+  default: bar-left
+  options:
+    - bar-left
+    - bar-right
+    - quote-left
+  control: select
+
+accentTheme:
+  twigProp: pull_quote__accent_theme
+  name: Accent Theme
+  type: select
+  required: false
+  description: "Accent color theme: 'one', 'two', or 'three'"
+  default: one
+  options:
+    - one
+    - two
+    - three
+  control: select

--- a/components/02-molecules/pull-quote/pull-quote.mdx
+++ b/components/02-molecules/pull-quote/pull-quote.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as PullQuoteStories from './pull-quote.stories';
+import { twigPropsTable } from '../../_storybook/twig-props-table.mdx';
+import componentProps from './pull-quote-props.yml';
 
 <Meta of={PullQuoteStories} name="Overview" />
 
@@ -18,83 +20,11 @@ Use the controls panel below to experiment with the pull quote's properties in r
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>pull_quote__quote</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>The quote text to display (supports HTML)</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>pull_quote__attribution</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Attribution text for the quote (e.g., author name, source)</td>
-    </tr>
-    <tr>
-      <td>
-        <code>pull_quote__style</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'bar-left'</code>
-      </td>
-      <td>
-        Visual style: <code>'bar-left'</code>, <code>'bar-right'</code>, or{' '}
-        <code>'quote-left'</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>pull_quote__accent_theme</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'one'</code>
-      </td>
-      <td>
-        Accent color theme: <code>'one'</code>, <code>'two'</code>, or{' '}
-        <code>'three'</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ## Style Variations
 

--- a/components/02-molecules/pull-quote/pull-quote.stories.js
+++ b/components/02-molecules/pull-quote/pull-quote.stories.js
@@ -1,27 +1,25 @@
 import pullQuoteTwig from './yds-pull-quote.twig';
 
 import pullQuoteData from './pull-quote.yml';
+import componentProps from './pull-quote-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
 
 export default {
   title: 'Molecules/Quotes/Pull Quote',
   tags: ['!dev'],
-  args: {},
+  argTypes: toArgTypes(componentProps),
+  args: {
+    ...toArgs(componentProps),
+    quote: pullQuoteData.pull_quote__quote,
+    attribution: pullQuoteData.pull_quote__attribution,
+  },
 };
 
-export const pullQuote = () => `
+export const pullQuote = ({ quote, attribution, style, accentTheme }) => `
   ${pullQuoteTwig({
-    pull_quote__quote: pullQuoteData.pull_quote__quote,
-    pull_quote__attribution: pullQuoteData.pull_quote__attribution,
-  })}
-  ${pullQuoteTwig({
-    pull_quote__quote: pullQuoteData.pull_quote__quote,
-    pull_quote__style: 'bar-right',
-  })}
-  ${pullQuoteTwig({
-    pull_quote__quote: pullQuoteData.pull_quote__quote,
-    pull_quote__attribution: pullQuoteData.pull_quote__attribution,
-    pull_quote__style: 'quote-left',
+    pull_quote__quote: quote,
+    pull_quote__attribution: attribution,
+    pull_quote__style: style,
+    pull_quote__accent_theme: accentTheme,
   })}
 `;
-
-pullQuote.args = {};

--- a/components/02-molecules/quote-callout/quote-callout-props.yml
+++ b/components/02-molecules/quote-callout/quote-callout-props.yml
@@ -1,0 +1,100 @@
+# quote-callout-props.yml
+#
+# Quote Callout component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+quote:
+  twigProp: quote_callout__quote
+  name: Quote
+  type: string
+  required: true
+  description: The quote text to display (supports HTML for formatting)
+  control: text
+
+attribution:
+  twigProp: quote_callout__attribution
+  name: Attribution
+  type: string
+  required: false
+  description: Attribution text for the quote (e.g., person's name, title, or affiliation)
+  default: null
+  control: text
+
+style:
+  twigProp: quote_callout__style
+  name: Style
+  type: string
+  required: false
+  description: "Visual style: 'bar' (accent bar), 'quote' (decorative quote marks), or 'image' (with image)"
+  default: bar
+  options:
+    - bar
+    - quote
+    - image
+  control: select
+
+quoteAlignment:
+  twigProp: quote_callout__quote_alignment
+  name: Quote Alignment
+  type: string
+  required: false
+  description: "Text alignment: 'left' or 'right'"
+  default: left
+  options:
+    - left
+    - right
+  control: select
+
+accentTheme:
+  twigProp: quote_callout__accent_theme
+  name: Accent Theme (dial)
+  type: string
+  required: false
+  description: Theme dial for accent color (e.g., 'one', 'two', 'three')
+  default: one
+  options:
+    - one
+    - two
+    - three
+    - four
+    - five
+  control: select
+
+quoteImage:
+  twigProp: quote_callout__quote_image
+  name: Quote Image
+  type: string
+  required: false
+  description: >
+    Image display option: 'with-image' or 'no-image'. When 'with-image' is
+    selected, responsive image properties should also be provided
+  default: no-image
+  options:
+    - no-image
+    - with-image
+  control: select
+
+imageSrc:
+  twigProp: image__src
+  name: Image Source
+  type: string
+  required: false
+  description: Primary image source URL
+  twigOnly: true
+
+imageAlt:
+  twigProp: image__alt
+  name: Image Alt Text
+  type: string
+  required: false
+  description: Alternative text for accessibility
+  twigOnly: true
+
+imageSrcset:
+  twigProp: image__srcset
+  name: Image Srcset
+  type: array
+  required: false
+  description: Responsive image source set for different viewport sizes
+  twigOnly: true

--- a/components/02-molecules/quote-callout/quote-callout-props.yml
+++ b/components/02-molecules/quote-callout/quote-callout-props.yml
@@ -18,13 +18,12 @@ attribution:
   type: string
   required: false
   description: Attribution text for the quote (e.g., person's name, title, or affiliation)
-  default: null
   control: text
 
 style:
   twigProp: quote_callout__style
   name: Style
-  type: string
+  type: select
   required: false
   description: "Visual style: 'bar' (accent bar), 'quote' (decorative quote marks), or 'image' (with image)"
   default: bar
@@ -37,7 +36,7 @@ style:
 quoteAlignment:
   twigProp: quote_callout__quote_alignment
   name: Quote Alignment
-  type: string
+  type: select
   required: false
   description: "Text alignment: 'left' or 'right'"
   default: left
@@ -49,7 +48,7 @@ quoteAlignment:
 accentTheme:
   twigProp: quote_callout__accent_theme
   name: Accent Theme (dial)
-  type: string
+  type: select
   required: false
   description: Theme dial for accent color (e.g., 'one', 'two', 'three')
   default: one
@@ -64,7 +63,7 @@ accentTheme:
 quoteImage:
   twigProp: quote_callout__quote_image
   name: Quote Image
-  type: string
+  type: select
   required: false
   description: >
     Image display option: 'with-image' or 'no-image'. When 'with-image' is

--- a/components/02-molecules/quote-callout/quote-callout.mdx
+++ b/components/02-molecules/quote-callout/quote-callout.mdx
@@ -1,5 +1,10 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as QuoteCalloutStories from './quote-callout.stories';
+import {
+  twigPropsTable,
+  twigOnlyPropsTable,
+} from '../../_storybook/twig-props-table.mdx';
+import componentProps from './quote-callout-props.yml';
 
 <Meta of={QuoteCalloutStories} name="Overview" />
 
@@ -18,156 +23,17 @@ Use the controls panel below to experiment with the quote callout's properties i
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>quote_callout__quote</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>The quote text to display (supports HTML for formatting)</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>quote_callout__attribution</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>
-        Attribution text for the quote (e.g., person's name, title, or
-        affiliation)
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>quote_callout__style</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'bar'</code>
-      </td>
-      <td>
-        Visual style: <code>'bar'</code> (accent bar), <code>'quote'</code>{' '}
-        (decorative quote marks), or <code>'image'</code> (with image)
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>quote_callout__quote_alignment</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'left'</code>
-      </td>
-      <td>
-        Text alignment: <code>'left'</code> or <code>'right'</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>quote_callout__accent_theme</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'one'</code>
-      </td>
-      <td>Theme dial for accent color (e.g., 'one', 'two', 'three')</td>
-    </tr>
-    <tr>
-      <td>
-        <code>quote_callout__quote_image</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'no-image'</code>
-      </td>
-      <td>
-        Image display option: <code>'with-image'</code> or{' '}
-        <code>'no-image'</code>. When <code>'with-image'</code> is selected,
-        responsive image properties should also be provided
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ### Image Properties (when quote_callout\_\_quote_image is 'with-image')
 
 When using the image style, include responsive image properties:
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>image__src</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>Primary image source URL</td>
-    </tr>
-    <tr>
-      <td>
-        <code>image__alt</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>Alternative text for accessibility</td>
-    </tr>
-    <tr>
-      <td>
-        <code>image__srcset</code>
-      </td>
-      <td>
-        <code>array</code>
-      </td>
-      <td>Responsive image source set for different viewport sizes</td>
-    </tr>
-  </tbody>
-</table>
+{twigOnlyPropsTable(componentProps)}
 
 ## Component Variations
 

--- a/components/02-molecules/quote-callout/quote-callout.stories.js
+++ b/components/02-molecules/quote-callout/quote-callout.stories.js
@@ -1,40 +1,35 @@
 import quoteCalloutTwig from './yds-quote-callout.twig';
 import quoteCalloutData from './quote-callout.yml';
 import imageData from '../../01-atoms/images/image/image.yml';
+import componentProps from './quote-callout-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
 
 export default {
   title: 'Molecules/Quotes/Quote Callout',
   tags: ['!dev'],
+  argTypes: toArgTypes(componentProps),
+  args: {
+    ...toArgs(componentProps),
+    quote: quoteCalloutData.quote_callout__quote,
+    attribution: quoteCalloutData.quote_callout__attribution,
+  },
 };
 
-export const QuoteCallout = () => `
+export const QuoteCallout = ({
+  quote,
+  attribution,
+  style,
+  quoteAlignment,
+  accentTheme,
+  quoteImage,
+}) => `
   ${quoteCalloutTwig({
-    quote_callout__quote: quoteCalloutData.quote_callout__quote,
-    quote_callout__attribution: quoteCalloutData.quote_callout__attribution,
-  })}
-  ${quoteCalloutTwig({
-    quote_callout__quote: quoteCalloutData.quote_callout__quote,
-    quote_callout__style: 'bar',
-    quote_callout__quote_alignment: 'right',
-  })}
-  ${quoteCalloutTwig({
-    quote_callout__quote: quoteCalloutData.quote_callout__quote,
-    quote_callout__attribution: quoteCalloutData.quote_callout__attribution,
-    quote_callout__style: 'quote',
-    quote_callout__quote_alignment: 'left',
-  })}
-  ${quoteCalloutTwig({
-    quote_callout__quote: quoteCalloutData.quote_callout__quote,
-    quote_callout__attribution: quoteCalloutData.quote_callout__attribution,
-    quote_callout__style: 'quote',
-    quote_callout__quote_alignment: 'right',
-  })}
-  ${quoteCalloutTwig({
-    quote_callout__quote: quoteCalloutData.quote_callout__quote,
-    quote_callout__attribution: quoteCalloutData.quote_callout__attribution,
-    quote_callout__style: 'image',
-    quote_callout__quote_alignment: 'left',
-    quote_callout__quote_image: 'with-image',
+    quote_callout__quote: quote,
+    quote_callout__attribution: attribution,
+    quote_callout__style: style,
+    quote_callout__quote_alignment: quoteAlignment,
+    quote_callout__accent_theme: accentTheme,
+    quote_callout__quote_image: quoteImage,
     ...imageData.responsive_images['1x1'],
   })}
 `;

--- a/components/02-molecules/read-time/read-time-props.yml
+++ b/components/02-molecules/read-time/read-time-props.yml
@@ -1,0 +1,14 @@
+# read-time-props.yml
+#
+# Read Time component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+label:
+  twigProp: read_time__label
+  name: Label
+  type: string
+  required: false
+  description: Label text displayed before the calculated time
+  default: Estimated read time
+  control: text

--- a/components/02-molecules/read-time/read-time.mdx
+++ b/components/02-molecules/read-time/read-time.mdx
@@ -1,7 +1,9 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as ReadTimeStories from './read-time.stories';
+import { twigPropsTable } from '../../_storybook/twig-props-table.mdx';
+import componentProps from './read-time-props.yml';
 
-<Meta title="Atoms/Read Time" />
+<Meta of={ReadTimeStories} name="Overview" />
 
 # Read Time
 
@@ -14,35 +16,13 @@ The Read Time component displays below the sample content. It automatically calc
 <div className="sb-contained-canvas">
   <Canvas of={ReadTimeStories.ReadTime} />
 </div>
+<Controls of={ReadTimeStories.ReadTime} />
 
 ## Properties
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>read_time__label</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'Estimated read time'</code>
-      </td>
-      <td>Label text displayed before the calculated time</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ## Technical Specifications
 

--- a/components/02-molecules/read-time/read-time.stories.js
+++ b/components/02-molecules/read-time/read-time.stories.js
@@ -1,4 +1,6 @@
 import readTimeTwig from './yds-read-time.twig';
+import componentProps from './read-time-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
 
 import './yds-read-time';
 
@@ -8,9 +10,11 @@ import './yds-read-time';
 export default {
   title: 'Atoms/Read Time',
   tags: ['!dev'],
+  argTypes: toArgTypes(componentProps),
+  args: toArgs(componentProps),
 };
 
-export const ReadTime = () => {
+export const ReadTime = ({ label }) => {
   return `
     <div id="main-content">
       <p>A bulldozer sees a beast as an unstripped scene. Extending this logic, a childing beat without transports is truly a couch of unmaimed lutes. A tornado is an erstwhile creditor. This is not to discredit the idea that a cowbell of the lotion is assumed to be a hoven odometer.</p>
@@ -23,7 +27,7 @@ export const ReadTime = () => {
       <p>Authors often misinterpret the mole as a caboched child, when in actuality it feels more like a clonic grouse. An innocent is the subway of a russia. Some posit the plummy cake to be less than rascal. Few can name an artless fountain that isn't an erose norwegian.</p>
       <p>A dolphin is a helicopter's coke. In modern times a move sees a decimal as a fragile india. This is not to discredit the idea that the kindless view reveals itself as an abject fender to those who look. The vessels could be said to resemble pauseful kicks.</p>
       <p>The heart of a math becomes an occult drop. Spindly hands show us how celeries can be colonies. A suggestion sees a riverbed as an unvoiced color.</p>
-      ${readTimeTwig()}
+      ${readTimeTwig({ read_time__label: label })}
     </div>
   `;
 };

--- a/components/02-molecules/search-result/search-result-props.yml
+++ b/components/02-molecules/search-result/search-result-props.yml
@@ -25,7 +25,6 @@ highlighted:
   type: string
   required: false
   description: 'Text excerpt with search term highlighted using <strong> tags'
-  default: null
   control: text
 
 teaser:
@@ -34,7 +33,6 @@ teaser:
   type: string
   required: false
   description: Meta description or excerpt text (supports HTML)
-  default: null
   control: text
 
 contentType:
@@ -43,7 +41,6 @@ contentType:
   type: string
   required: false
   description: "Content type label (e.g., 'post', 'page', 'event')"
-  default: null
   control: text
 
 breadcrumbsItems:
@@ -52,7 +49,6 @@ breadcrumbsItems:
   type: array
   required: false
   description: Breadcrumb trail items showing content hierarchy
-  default: null
 
 isCas:
   twigProp: is_cas
@@ -69,4 +65,3 @@ prefixIcon:
   type: string
   required: false
   description: "Icon name to display as prefix (e.g., 'lock-solid' for CAS content)"
-  default: null

--- a/components/02-molecules/search-result/search-result-props.yml
+++ b/components/02-molecules/search-result/search-result-props.yml
@@ -1,0 +1,72 @@
+# search-result-props.yml
+#
+# Search Result component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+heading:
+  twigProp: search_result__title
+  name: Heading
+  type: string
+  required: true
+  description: The title/heading of the search result (typically the page title)
+  control: text
+
+url:
+  twigProp: search_result__url
+  name: URL
+  type: string
+  required: true
+  description: The URL link to the full content
+
+highlighted:
+  twigProp: search_result__highlighted
+  name: Search Results Highlighted
+  type: string
+  required: false
+  description: 'Text excerpt with search term highlighted using <strong> tags'
+  default: null
+  control: text
+
+teaser:
+  twigProp: search_result__teaser
+  name: Search Results Teaser
+  type: string
+  required: false
+  description: Meta description or excerpt text (supports HTML)
+  default: null
+  control: text
+
+contentType:
+  twigProp: search_result__content_type
+  name: Search Results Content Type
+  type: string
+  required: false
+  description: "Content type label (e.g., 'post', 'page', 'event')"
+  default: null
+  control: text
+
+breadcrumbsItems:
+  twigProp: breadcrumbs__items
+  name: Breadcrumbs Items
+  type: array
+  required: false
+  description: Breadcrumb trail items showing content hierarchy
+  default: null
+
+isCas:
+  twigProp: is_cas
+  name: Is CAS
+  type: boolean
+  required: false
+  description: Whether the content requires CAS authentication
+  default: false
+  control: boolean
+
+prefixIcon:
+  twigProp: search_result__prefix__icon
+  name: Prefix Icon
+  type: string
+  required: false
+  description: "Icon name to display as prefix (e.g., 'lock-solid' for CAS content)"
+  default: null

--- a/components/02-molecules/search-result/search-result-props.yml
+++ b/components/02-molecules/search-result/search-result-props.yml
@@ -18,6 +18,7 @@ url:
   type: string
   required: true
   description: The URL link to the full content
+  control: text
 
 highlighted:
   twigProp: search_result__highlighted

--- a/components/02-molecules/search-result/search-result.mdx
+++ b/components/02-molecules/search-result/search-result.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as SearchResultStories from './yds-search-result.stories';
+import { twigPropsTable } from '../../_storybook/twig-props-table.mdx';
+import componentProps from './search-result-props.yml';
 
 <Meta of={SearchResultStories} name="Overview" />
 
@@ -18,126 +20,11 @@ Use the controls panel below to experiment with the search result's properties i
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>search_result__title</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>The title/heading of the search result (typically the page title)</td>
-    </tr>
-    <tr>
-      <td>
-        <code>search_result__url</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>The URL link to the full content</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>search_result__highlighted</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>
-        Text excerpt with search term highlighted using &lt;strong&gt; tags
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>search_result__teaser</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Meta description or excerpt text (supports HTML)</td>
-    </tr>
-    <tr>
-      <td>
-        <code>search_result__content_type</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Content type label (e.g., 'post', 'page', 'event')</td>
-    </tr>
-    <tr>
-      <td>
-        <code>breadcrumbs__items</code>
-      </td>
-      <td>
-        <code>array</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Breadcrumb trail items showing content hierarchy</td>
-    </tr>
-    <tr>
-      <td>
-        <code>is_cas</code>
-      </td>
-      <td>
-        <code>boolean</code>
-      </td>
-      <td>
-        <code>false</code>
-      </td>
-      <td>Whether the content requires CAS authentication</td>
-    </tr>
-    <tr>
-      <td>
-        <code>search_result__prefix__icon</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>
-        Icon name to display as prefix (e.g., 'lock-solid' for CAS content)
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ## Component Features
 

--- a/components/02-molecules/search-result/yds-search-result.stories.js
+++ b/components/02-molecules/search-result/yds-search-result.stories.js
@@ -4,35 +4,18 @@ import searchResultTwig from './yds-search-result.twig';
 // Data files
 import searchResultData from './search-result.yml';
 import breadcrumbData from './breadcrumbs.yml';
+import componentProps from './search-result-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
 
 /**
  * Storybook Definition.
  */
 export default {
   title: 'Molecules/Search Result',
-  argTypes: {
-    heading: {
-      name: 'Heading',
-      type: 'string',
-    },
-    highlighted: {
-      name: 'Search Results Highlighted',
-      type: 'string',
-    },
-    teaser: {
-      name: 'Search Results Teaser',
-      type: 'string',
-    },
-    contentType: {
-      name: 'Search Results Content Type',
-      type: 'string',
-    },
-    isCas: {
-      name: 'Is CAS',
-      type: 'boolean',
-    },
-  },
+  tags: ['!dev'],
+  argTypes: toArgTypes(componentProps),
   args: {
+    ...toArgs(componentProps),
     heading: searchResultData.search_result__title,
     highlighted: searchResultData.search_result__highlighted,
     teaser: searchResultData.search_result__teaser,
@@ -57,5 +40,3 @@ export const SearchResult = ({
     search_result__prefix__icon: isCas ? 'lock-solid' : '',
     is_cas: isCas,
   });
-
-SearchResult.tags = ['!dev'];

--- a/components/02-molecules/search-result/yds-search-result.stories.js
+++ b/components/02-molecules/search-result/yds-search-result.stories.js
@@ -17,6 +17,7 @@ export default {
   args: {
     ...toArgs(componentProps),
     heading: searchResultData.search_result__title,
+    url: '#',
     highlighted: searchResultData.search_result__highlighted,
     teaser: searchResultData.search_result__teaser,
     contentType: searchResultData.search_result__content_type,
@@ -25,6 +26,7 @@ export default {
 
 export const SearchResult = ({
   heading,
+  url,
   highlighted,
   teaser,
   contentType,
@@ -33,7 +35,7 @@ export const SearchResult = ({
   searchResultTwig({
     search_result__teaser: teaser,
     search_result__title: heading,
-    search_result__url: '#',
+    search_result__url: url,
     search_result__highlighted: highlighted,
     breadcrumbs__items: breadcrumbData.items,
     search_result__content_type: contentType,

--- a/components/02-molecules/social-links/social-links-props.yml
+++ b/components/02-molecules/social-links/social-links-props.yml
@@ -1,0 +1,47 @@
+# social-links-props.yml
+#
+# Social Links component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+icons:
+  twigProp: icons
+  name: Icons
+  type: array
+  required: true
+  description: Array of social media link objects, each containing a url, name, and icon
+  detail: >
+    Array of objects passed to the Twig template. Each item requires url, name,
+    and icon (see the individual icon properties below). This prop is
+    constructed in the story's render function and is not directly editable
+    via the Controls panel.
+
+url:
+  twigProp: url
+  name: URL
+  type: string
+  required: true
+  description: The URL destination for the social media platform
+  detail: >
+    Belongs to each item in the icons array. The URL destination for the
+    social media platform.
+
+name:
+  twigProp: name
+  name: Name
+  type: string
+  required: true
+  description: Visually hidden text for screen readers that identifies the social media platform
+  detail: >
+    Belongs to each item in the icons array. Visually hidden text for screen
+    readers that identifies the social media platform.
+
+icon:
+  twigProp: icon
+  name: Icon
+  type: string
+  required: true
+  description: The icon identifier for the social media platform (e.g., 'facebook', 'x-twitter', 'linkedin')
+  detail: >
+    Belongs to each item in the icons array. The icon identifier for the
+    social media platform (e.g., 'facebook', 'x-twitter', 'linkedin').

--- a/components/02-molecules/social-links/social-links.mdx
+++ b/components/02-molecules/social-links/social-links.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as SocialLinksStories from './social-links.stories';
+import { twigPropsTable } from '../../_storybook/twig-props-table.mdx';
+import componentProps from './social-links-props.yml';
 
 <Meta of={SocialLinksStories} name="Overview" />
 
@@ -20,78 +22,10 @@ Use the controls panel below to experiment with the Social Links properties in r
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>icons</code>
-      </td>
-      <td>
-        <code>array</code>
-      </td>
-      <td>
-        Array of social media link objects. Each link should contain{' '}
-        <code>url</code>, <code>name</code>, and <code>icon</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
+The `icons` array and the per-item properties each object in the array should
+contain (`url`, `name`, and `icon`) are documented below.
 
-### Individual Icon Properties
-
-Each object in the `icons` array should contain:
-
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>url</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>The URL destination for the social media platform</td>
-    </tr>
-    <tr>
-      <td>
-        <code>name</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        Visually hidden text for screen readers that identifies the social media
-        platform
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>icon</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        The icon identifier for the social media platform (e.g., 'facebook',
-        'x-twitter', 'linkedin')
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ## Supported Platforms
 

--- a/components/02-molecules/social-links/social-links.stories.js
+++ b/components/02-molecules/social-links/social-links.stories.js
@@ -1,6 +1,8 @@
 import socialLinksTwig from './yds-social-links.twig';
 
 import socialLinksData from './social-links.yml';
+import componentProps from './social-links-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
 
 /**
  * Storybook Definition.
@@ -8,6 +10,10 @@ import socialLinksData from './social-links.yml';
 export default {
   title: 'Molecules/Social Links',
   tags: ['!dev'],
+  argTypes: toArgTypes(componentProps),
+  args: {
+    ...toArgs(componentProps),
+  },
 };
 
 export const SocialLinks = () => socialLinksTwig(socialLinksData);

--- a/components/02-molecules/text/text-props.yml
+++ b/components/02-molecules/text/text-props.yml
@@ -1,0 +1,25 @@
+# text-props.yml
+#
+# Text Field component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+content:
+  twigProp: text_field__content
+  name: Content
+  type: string
+  required: true
+  description: HTML content containing the formatted text to display
+  control: text
+
+variation:
+  twigProp: text_field__variation
+  name: Text Field Variation
+  type: string
+  required: false
+  description: "Visual variation: 'default' or 'emphasized' (for increased prominence)"
+  default: default
+  options:
+    - default
+    - emphasized
+  control: select

--- a/components/02-molecules/text/text-props.yml
+++ b/components/02-molecules/text/text-props.yml
@@ -15,7 +15,7 @@ content:
 variation:
   twigProp: text_field__variation
   name: Text Field Variation
-  type: string
+  type: select
   required: false
   description: "Visual variation: 'default' or 'emphasized' (for increased prominence)"
   default: default

--- a/components/02-molecules/text/text.mdx
+++ b/components/02-molecules/text/text.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as TextStories from './typography.stories';
+import { twigPropsTable } from '../../_storybook/twig-props-table.mdx';
+import componentProps from './text-props.yml';
 
 <Meta of={TextStories} name="Overview" />
 
@@ -18,55 +20,11 @@ Use the controls panel below to experiment with the text field's properties in r
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>text_field__content</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>HTML content containing the formatted text to display</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>text_field__variation</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>default</code>
-      </td>
-      <td>
-        Visual variation: 'default' or 'emphasized' (for increased prominence)
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ## Supported Elements
 

--- a/components/02-molecules/text/typography.stories.js
+++ b/components/02-molecules/text/typography.stories.js
@@ -4,6 +4,9 @@ import textFieldTwig from './yds-text-field.twig';
 // Data files
 import textData from './text-field.yml';
 
+import componentProps from './text-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
+
 import '../../01-atoms/typography/text/yds-text';
 
 /**
@@ -12,36 +15,19 @@ import '../../01-atoms/typography/text/yds-text';
 export default {
   title: 'Atoms/Text',
   tags: ['!dev'],
-  argTypes: {
-    variation: {
-      name: 'Text Field Variation',
-      options: ['default', 'emphasized'],
-      control: 'select',
-    },
-  },
+  argTypes: toArgTypes(componentProps),
   args: {
-    variation: 'default',
+    ...toArgs(componentProps),
+    content: textData.text_field__content,
   },
 };
 
-export const TextField = {
-  argTypes: {
-    variation: {
-      name: 'Text Field Variation',
-      options: ['default', 'emphasized'],
-      control: 'select',
-    },
-  },
-  args: {
-    variation: 'default',
-  },
-  render: ({ variation }) => `
-    ${textFieldTwig({
-      text_field__content: textData.text_field__content,
-      text_field__variation: variation,
-    })}
-  `,
-};
+export const TextField = ({ content, variation }) => `
+  ${textFieldTwig({
+    text_field__content: content,
+    text_field__variation: variation,
+  })}
+`;
 
 // Make Interactive story an alias to TextField
 export const Interactive = TextField;

--- a/components/02-molecules/tile-item/tile-item-props.yml
+++ b/components/02-molecules/tile-item/tile-item-props.yml
@@ -1,0 +1,122 @@
+# tile-item-props.yml
+#
+# Tile Item component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+#
+# Edit descriptions and details freely - changes appear in Storybook on reload.
+
+content:
+  twigProp: tile__item__content
+  name: Content
+  type: string
+  required: true
+  description: Main content text for the tile (supports HTML)
+  control: text
+
+heading:
+  twigProp: tile__item__heading
+  name: Heading
+  type: string
+  required: false
+  description: "Large heading text (used with 'heading' presentation style)"
+  default: null
+  control: text
+
+contentLink:
+  twigProp: tile__item__content_link
+  name: Content Link
+  type: string
+  required: false
+  description: URL to make the entire tile clickable
+  default: null
+  control: text
+
+presentationStyle:
+  twigProp: tile__item__presentation_style
+  name: Presentation Style
+  type: select
+  required: false
+  description: "Visual style: 'heading', 'icon', or 'text-only'"
+  default: heading
+  options:
+    - heading
+    - icon
+    - text-only
+  control: select
+
+alignment:
+  twigProp: tile__item__alignment
+  name: Alignment
+  type: select
+  required: false
+  description: "Text alignment: 'left', 'center', or 'right'"
+  default: left
+  options:
+    - left
+    - center
+    - right
+  control: select
+
+verticalAlignment:
+  twigProp: tile__item__vertical_alignment
+  name: Vertical Alignment
+  type: select
+  required: false
+  description: "Vertical content position: 'top' or 'bottom'"
+  default: top
+  options:
+    - top
+    - bottom
+  control: select
+
+themeColor:
+  twigProp: tile__item__theme
+  name: Component Theme (dial)
+  type: select
+  required: false
+  description: Component theme from the color dial
+  detail: >
+    Applies a color theme to the tile item. Options are derived from the
+    component-themes design tokens. Maps to tile__item__theme.
+  default: one
+  options:
+    - one
+    - two
+    - three
+    - four
+    - five
+  control: select
+
+image:
+  twigProp: tile__item__bg_image
+  name: With Image
+  type: boolean
+  required: false
+  description: Display a background image behind the tile content
+  detail: >
+    When true, passes 'true' to tile__item__bg_image in the Twig template to
+    display a background image behind the tile.
+  default: false
+  control: boolean
+
+withAnimation:
+  twigProp: tile__item__animation
+  name: With Animation
+  type: boolean
+  required: false
+  description: Enable hover animation on the tile
+  detail: >
+    When true, passes 'true' to tile__item__animation in the Twig template
+    to enable hover animation.
+  default: false
+  control: boolean
+
+iconName:
+  twigProp: tile__item__icon_name
+  name: Icon Name
+  type: string
+  required: false
+  description: "Icon identifier (used with 'icon' presentation style, e.g., 'sack-dollar-solid')"
+  default: null
+  control: text

--- a/components/02-molecules/tile-item/tile-item-props.yml
+++ b/components/02-molecules/tile-item/tile-item-props.yml
@@ -20,7 +20,6 @@ heading:
   type: string
   required: false
   description: "Large heading text (used with 'heading' presentation style)"
-  default: null
   control: text
 
 contentLink:
@@ -29,7 +28,6 @@ contentLink:
   type: string
   required: false
   description: URL to make the entire tile clickable
-  default: null
   control: text
 
 presentationStyle:
@@ -118,5 +116,4 @@ iconName:
   type: string
   required: false
   description: "Icon identifier (used with 'icon' presentation style, e.g., 'sack-dollar-solid')"
-  default: null
   control: text

--- a/components/02-molecules/tile-item/tile-item.mdx
+++ b/components/02-molecules/tile-item/tile-item.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as TileItemStories from './tile-item.stories';
+import { twigPropsTable } from '../../_storybook/twig-props-table.mdx';
+import componentProps from './tile-item-props.yml';
 
 <Meta of={TileItemStories} name="Overview" />
 
@@ -18,164 +20,11 @@ Use the controls panel below to experiment with the tile item's properties in re
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>tile__item__content</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>Main content text for the tile (supports HTML)</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>tile__item__heading</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Large heading text (used with 'heading' presentation style)</td>
-    </tr>
-    <tr>
-      <td>
-        <code>tile__item__content_link</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>URL to make the entire tile clickable</td>
-    </tr>
-    <tr>
-      <td>
-        <code>tile__item__presentation_style</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'heading'</code>
-      </td>
-      <td>
-        Visual style: <code>'heading'</code>, <code>'icon'</code>, or{' '}
-        <code>'text-only'</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tile__item__alignment</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'left'</code>
-      </td>
-      <td>
-        Text alignment: <code>'left'</code>, <code>'center'</code>, or{' '}
-        <code>'right'</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tile__item__vertical_alignment</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'top'</code>
-      </td>
-      <td>
-        Vertical content position: <code>'top'</code> or <code>'bottom'</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tile__item__theme</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'one'</code>
-      </td>
-      <td>Component theme from the color dial</td>
-    </tr>
-    <tr>
-      <td>
-        <code>tile__item__bg_image</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'false'</code>
-      </td>
-      <td>
-        Show background image: <code>'true'</code> or <code>'false'</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tile__item__animation</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'false'</code>
-      </td>
-      <td>
-        Enable hover animation: <code>'true'</code> or <code>'false'</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tile__item__icon_name</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>
-        Icon identifier (used with 'icon' presentation style, e.g.,
-        'sack-dollar-solid')
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ## Presentation Styles
 

--- a/components/02-molecules/tile-item/tile-item.stories.js
+++ b/components/02-molecules/tile-item/tile-item.stories.js
@@ -3,53 +3,51 @@ import tileItemTwig from './yds-tile-item.twig';
 import tileItemData from './tile-item.yml';
 
 import imageData from '../../01-atoms/images/image/image.yml';
+import componentProps from './tile-item-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
 
 export default {
   title: 'Molecules/Tile Item',
   tags: ['!dev'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: toArgTypes(componentProps),
+  args: {
+    ...toArgs(componentProps),
+    content: tileItemData.tile__item__content,
+    heading: tileItemData.tile__item__heading,
+    contentLink: 'https://www.yale.edu',
+  },
 };
 
-export const TileItem = () => `
+export const TileItem = ({
+  content,
+  heading,
+  contentLink,
+  presentationStyle,
+  alignment,
+  verticalAlignment,
+  themeColor,
+  image,
+  withAnimation,
+  iconName,
+}) => `
   <div class="tiles" data-component-grid-count='three' data-component-width="site">
     <div class='tiles__inner'>
       <ul class='tiles__wrap'>
         ${tileItemTwig({
-          tile__item__heading: tileItemData.tile__item__heading,
-          tile__item__content: tileItemData.tile__item__content,
-          tile__item__content_link: 'https://www.yale.edu',
-          tile__item__presentation_style: 'heading',
-          tile__item__alignment: 'left',
-          tile__item__vertical_alignment: 'top',
-          tile__item__bg_image: 'true',
+          tile__item__heading: heading,
+          tile__item__content: content,
+          tile__item__content_link: contentLink,
+          tile__item__presentation_style: presentationStyle,
+          tile__item__alignment: alignment,
+          tile__item__vertical_alignment: verticalAlignment,
+          tile__item__theme: themeColor,
+          tile__item__bg_image: image ? 'true' : 'false',
           ...imageData.responsive_images['1x1'],
-          tile__item__animation: 'false',
-        })}
-        ${tileItemTwig({
-          tile__item__content: 'This is a tile with top vertical alignment',
-          tile__item__content_link: 'https://www.yale.edu',
-          tile__item__vertical_alignment: 'top',
-          tile__item__presentation_style: 'text-only',
-          tile__item__alignment: 'left',
-          tile__item__bg_image: 'true',
-          ...imageData.responsive_images['1x1'],
-          tile__item__animation: 'false',
-        })}
-        ${tileItemTwig({
-          tile__item__content: 'This is a tile with bottom vertical alignment',
-          tile__item__content_link: 'https://www.yale.edu',
-          tile__item__vertical_alignment: 'bottom',
-          tile__item__presentation_style: 'text-only',
-          tile__item__alignment: 'left',
-          tile__item__bg_image: 'true',
-          ...imageData.responsive_images['1x1'],
-          tile__item__animation: 'false',
-        })}
-        ${tileItemTwig({
-          tile__item__heading: tileItemData.tile__item__heading,
-          tile__item__presentation_style: 'icon',
-          tile__item__alignment: 'right',
-          tile__item__bg_image: 'false',
-          tile__item__animation: 'false',
+          tile__item__animation: withAnimation ? 'true' : 'false',
+          tile__item__icon_name: iconName,
         })}
       </ul>
     </div>

--- a/components/03-organisms/calendar/calendar-props.yml
+++ b/components/03-organisms/calendar/calendar-props.yml
@@ -1,0 +1,12 @@
+# calendar-props.yml
+#
+# Calendar component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+month:
+  twigProp: month
+  name: Month
+  type: array
+  required: true
+  description: Array of weeks, each containing an array of day objects with date and events data

--- a/components/03-organisms/calendar/calendar.mdx
+++ b/components/03-organisms/calendar/calendar.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as CalendarStories from './calendar.stories';
+import { twigPropsTable } from '../../_storybook/twig-props-table.mdx';
+import componentProps from './calendar-props.yml';
 
 <Meta of={CalendarStories} name="Overview" />
 
@@ -18,29 +20,7 @@ Use the controls panel below to experiment with the calendar's properties in rea
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>month</code>
-      </td>
-      <td>
-        <code>array</code>
-      </td>
-      <td>
-        Array of weeks, each containing an array of day objects with date and
-        events data
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ## Calendar Structure
 

--- a/components/03-organisms/calendar/calendar.stories.js
+++ b/components/03-organisms/calendar/calendar.stories.js
@@ -1,15 +1,19 @@
 import './yds-calendar';
 import calendarTwig from './yds-calendar.twig';
 import monthData from './calendar.yml';
+import componentProps from './calendar-props.yml';
+import { toArgTypes, toArgs } from '../../_storybook/component-props';
 
 export default {
   title: 'Organisms/Calendar',
   tags: ['!dev'],
-  args: {},
+  argTypes: toArgTypes(componentProps),
+  args: {
+    ...toArgs(componentProps),
+    month: monthData,
+  },
 };
 
-export const Calendar = () => {
-  return calendarTwig({ month: monthData });
+export const Calendar = ({ month }) => {
+  return calendarTwig({ month });
 };
-
-Calendar.args = {};

--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs-props.yml
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs-props.yml
@@ -1,0 +1,47 @@
+# breadcrumbs-props.yml
+#
+# Breadcrumbs component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+items:
+  twigProp: items
+  name: Items
+  type: array
+  required: true
+  description: Array of breadcrumb items representing the navigation path
+  detail: >
+    Array of objects passed to the Twig template. Each item requires a title
+    and url, with an optional is_active flag. This prop is constructed from the
+    story's fixed data and is not directly editable via the Controls panel.
+
+title:
+  twigProp: items[].title
+  name: Title
+  type: string
+  required: true
+  description: The text label for the breadcrumb link
+  detail: >
+    Belongs to each item in the items array. The text label displayed for the
+    breadcrumb link.
+
+url:
+  twigProp: items[].url
+  name: URL
+  type: string
+  required: true
+  description: The URL destination for the breadcrumb link
+  detail: >
+    Belongs to each item in the items array. The URL destination for the
+    breadcrumb link.
+
+isActive:
+  twigProp: items[].is_active
+  name: Is Active
+  type: boolean
+  required: false
+  description: Marks the current page (typically the last item)
+  detail: >
+    Belongs to each item in the items array. Marks the current page, typically
+    the last item. Active items are rendered as plain text rather than links.
+  default: false

--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs.mdx
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as BreadcrumbsStories from './breadcrumbs.stories';
+import { twigPropsTable } from '../../../_storybook/twig-props-table.mdx';
+import componentProps from './breadcrumbs-props.yml';
 
 <Meta of={BreadcrumbsStories} name="Overview" />
 
@@ -20,74 +22,11 @@ Use the controls panel below to experiment with the breadcrumbs properties in re
 
 ### Required Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>items</code>
-      </td>
-      <td>
-        <code>array</code>
-      </td>
-      <td>Array of breadcrumb items representing the navigation path</td>
-    </tr>
-    <tr>
-      <td>
-        <code>items[].title</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>The text label for the breadcrumb link</td>
-    </tr>
-    <tr>
-      <td>
-        <code>items[].url</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>The URL destination for the breadcrumb link</td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'required')}
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>items[].is_active</code>
-      </td>
-      <td>
-        <code>boolean</code>
-      </td>
-      <td>
-        <code>false</code>
-      </td>
-      <td>
-        Marks the current page (typically the last item). Active items are not
-        linked.
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ## Technical Specifications
 

--- a/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
+++ b/components/03-organisms/menu/breadcrumbs/breadcrumbs.stories.js
@@ -4,6 +4,10 @@ import breadcrumbsTwig from './yds-breadcrumbs.twig';
 // Data.
 import breadcrumbsData from './breadcrumbs.yml';
 
+// Props.
+import componentProps from './breadcrumbs-props.yml';
+import { toArgTypes, toArgs } from '../../../_storybook/component-props';
+
 // JavaScript.
 import './yds-breadcrumbs';
 
@@ -13,9 +17,8 @@ import './yds-breadcrumbs';
 export default {
   title: 'Organisms/Menu/Breadcrumbs',
   tags: ['!dev'],
-  args: {},
+  argTypes: toArgTypes(componentProps),
+  args: toArgs(componentProps),
 };
 
 export const Breadcrumbs = () => breadcrumbsTwig({ ...breadcrumbsData });
-
-Breadcrumbs.args = {};

--- a/components/03-organisms/menu/utility-nav/utility-nav-props.yml
+++ b/components/03-organisms/menu/utility-nav/utility-nav-props.yml
@@ -21,7 +21,6 @@ linkContent:
   type: string
   required: false
   description: Text content for the primary call-to-action button
-  default: null
   control: text
 
 linkUrl:
@@ -30,7 +29,6 @@ linkUrl:
   type: string
   required: false
   description: URL destination for the primary call-to-action button
-  default: null
   control: text
 
 search:
@@ -57,7 +55,6 @@ dropdownLinkContent:
   type: string
   required: false
   description: Text content for the dropdown menu trigger button
-  default: null
   control: text
 
 dropdownLinkUrl:
@@ -66,7 +63,6 @@ dropdownLinkUrl:
   type: string
   required: false
   description: URL destination for the dropdown menu trigger button
-  default: null
   control: text
 
 dropdownItems:

--- a/components/03-organisms/menu/utility-nav/utility-nav-props.yml
+++ b/components/03-organisms/menu/utility-nav/utility-nav-props.yml
@@ -1,0 +1,81 @@
+# utility-nav-props.yml
+#
+# Utility Nav component property definitions.
+# This file is the single source of truth for both Storybook controls
+# and MDX documentation tables.
+
+items:
+  twigProp: items
+  name: Items
+  type: array
+  required: false
+  description: Array of navigation menu items with title and url properties
+  detail: >
+    Array of standard menu link objects rendered in the utility bar. Each
+    item requires title and url. Provided by the component's default data
+    and not directly editable via the Controls panel.
+
+linkContent:
+  twigProp: utility_nav__link__content
+  name: Link Content
+  type: string
+  required: false
+  description: Text content for the primary call-to-action button
+  default: null
+  control: text
+
+linkUrl:
+  twigProp: utility_nav__link__url
+  name: Link URL
+  type: string
+  required: false
+  description: URL destination for the primary call-to-action button
+  default: null
+  control: text
+
+search:
+  twigProp: utility_nav__search
+  name: Search
+  type: boolean
+  required: false
+  description: Whether to display the search input field
+  default: false
+  control: boolean
+
+ctaTheme:
+  twigProp: utility_nav__cta__theme
+  name: CTA Theme
+  type: string
+  required: false
+  description: Theme variant for the call-to-action button styling
+  default: none
+  control: text
+
+dropdownLinkContent:
+  twigProp: utility_nav__dropdown_link__content
+  name: Dropdown Link Content
+  type: string
+  required: false
+  description: Text content for the dropdown menu trigger button
+  default: null
+  control: text
+
+dropdownLinkUrl:
+  twigProp: utility_nav__dropdown_link__url
+  name: Dropdown Link URL
+  type: string
+  required: false
+  description: URL destination for the dropdown menu trigger button
+  default: null
+  control: text
+
+dropdownItems:
+  twigProp: utility_nav__dropdown__items
+  name: Dropdown Items
+  type: array
+  required: false
+  description: Array of dropdown menu items with title and url properties for the dropdown menu
+  detail: >
+    Array of standard menu link objects rendered in the dropdown menu. Each
+    item requires title and url. Provided by the component's default data
+    and not directly editable via the Controls panel.

--- a/components/03-organisms/menu/utility-nav/utility-nav.mdx
+++ b/components/03-organisms/menu/utility-nav/utility-nav.mdx
@@ -1,5 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as UtilityNavStories from './utility-nav.stories';
+import { twigPropsTable } from '../../../_storybook/twig-props-table.mdx';
+import componentProps from './utility-nav-props.yml';
 
 <Meta of={UtilityNavStories} name="Overview" />
 
@@ -18,117 +20,7 @@ Use the controls panel below to experiment with the utility nav's properties in 
 
 ### Optional Properties
 
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>items</code>
-      </td>
-      <td>
-        <code>array</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Array of navigation menu items with title and url properties</td>
-    </tr>
-    <tr>
-      <td>
-        <code>utility_nav__link__content</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Text content for the primary call-to-action button</td>
-    </tr>
-    <tr>
-      <td>
-        <code>utility_nav__link__url</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>URL destination for the primary call-to-action button</td>
-    </tr>
-    <tr>
-      <td>
-        <code>utility_nav__search</code>
-      </td>
-      <td>
-        <code>boolean</code>
-      </td>
-      <td>
-        <code>false</code>
-      </td>
-      <td>Whether to display the search input field</td>
-    </tr>
-    <tr>
-      <td>
-        <code>utility_nav__cta__theme</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>'none'</code>
-      </td>
-      <td>Theme variant for the call-to-action button styling</td>
-    </tr>
-    <tr>
-      <td>
-        <code>utility_nav__dropdown_link__content</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>Text content for the dropdown menu trigger button</td>
-    </tr>
-    <tr>
-      <td>
-        <code>utility_nav__dropdown_link__url</code>
-      </td>
-      <td>
-        <code>string</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>URL destination for the dropdown menu trigger button</td>
-    </tr>
-    <tr>
-      <td>
-        <code>utility_nav__dropdown__items</code>
-      </td>
-      <td>
-        <code>array</code>
-      </td>
-      <td>
-        <code>null</code>
-      </td>
-      <td>
-        Array of dropdown menu items with title and url properties for the
-        dropdown menu
-      </td>
-    </tr>
-  </tbody>
-</table>
+{twigPropsTable(componentProps, 'optional')}
 
 ## Component Features
 

--- a/components/03-organisms/menu/utility-nav/utility-nav.stories.js
+++ b/components/03-organisms/menu/utility-nav/utility-nav.stories.js
@@ -3,6 +3,8 @@ import utilityNavTwig from './yds-utility-nav.twig';
 
 // Data.
 import utilityNavData from './utility-nav.yml';
+import componentProps from './utility-nav-props.yml';
+import { toArgTypes, toArgs } from '../../../_storybook/component-props';
 
 import './utility-nav-dropdown-menu';
 
@@ -12,9 +14,33 @@ import './utility-nav-dropdown-menu';
 export default {
   title: 'Organisms/Menu/Utility Nav',
   tags: ['!dev'],
-  args: {},
+  argTypes: toArgTypes(componentProps),
+  args: {
+    ...toArgs(componentProps),
+    linkContent: utilityNavData.utility_nav__link__content,
+    linkUrl: utilityNavData.utility_nav__link__url,
+    search: utilityNavData.utility_nav__search,
+    ctaTheme: utilityNavData.utility_nav__cta__theme,
+    dropdownLinkContent: utilityNavData.utility_nav__dropdown_link__content,
+    dropdownLinkUrl: utilityNavData.utility_nav__dropdown_link__url,
+  },
 };
 
-export const UtilityNav = () => utilityNavTwig(utilityNavData);
-
-UtilityNav.args = {};
+export const UtilityNav = ({
+  linkContent,
+  linkUrl,
+  search,
+  ctaTheme,
+  dropdownLinkContent,
+  dropdownLinkUrl,
+}) =>
+  utilityNavTwig({
+    items: utilityNavData.items,
+    utility_nav__link__content: linkContent,
+    utility_nav__link__url: linkUrl,
+    utility_nav__search: search,
+    utility_nav__cta__theme: ctaTheme,
+    utility_nav__dropdown_link__content: dropdownLinkContent,
+    utility_nav__dropdown_link__url: dropdownLinkUrl,
+    utility_nav__dropdown__items: utilityNavData.utility_nav__dropdown__items,
+  });

--- a/components/_storybook/component-props.js
+++ b/components/_storybook/component-props.js
@@ -18,6 +18,7 @@
  */
 export function toArgTypes(props) {
   return Object.entries(props).reduce((acc, [key, prop]) => {
+    if (prop.twigOnly) return acc;
     acc[key] = {
       name: prop.name,
       description: prop.description,
@@ -57,6 +58,7 @@ export function toArgTypes(props) {
  */
 export function toArgs(props) {
   return Object.entries(props).reduce((acc, [key, prop]) => {
+    if (prop.twigOnly) return acc;
     if (prop.controlDefault !== undefined) acc[key] = prop.controlDefault;
     else if (prop.default !== undefined) acc[key] = prop.default;
     return acc;

--- a/components/_storybook/twig-props-table.mdx
+++ b/components/_storybook/twig-props-table.mdx
@@ -1,5 +1,6 @@
 export function twigPropsTable(props, filter) {
   const entries = Object.entries(props).filter(([, p]) => {
+    if (p.twigOnly) return false;
     if (filter === 'required') return p.required;
     if (filter === 'optional') return !p.required;
     return true;
@@ -27,6 +28,35 @@ return (
         </td>
         <td>
           <code>{prop.default !== undefined ? String(prop.default) : '—'}</code>
+        </td>
+        <td>{prop.detail || prop.description || '—'}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+); }
+
+export function twigOnlyPropsTable(props) {
+  const entries = Object.entries(props).filter(([, p]) => p.twigOnly);
+
+if (entries.length === 0) return null;
+
+return (
+
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    {entries.map(([key, prop]) => (
+      <tr key={key}>
+        <td>{prop.twigProp ? <code>{prop.twigProp}</code> : '—'}</td>
+        <td>
+          <code>{prop.type || '—'}</code>
         </td>
         <td>{prop.detail || prop.description || '—'}</td>
       </tr>

--- a/components/_storybook/twig-props-table.mdx
+++ b/components/_storybook/twig-props-table.mdx
@@ -1,3 +1,38 @@
+export function renderPropsTable(entries, showDefault) {
+  if (entries.length === 0) return null;
+
+return (
+
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      {showDefault ? <th>Default</th> : null}
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    {entries.map(([key, prop]) => (
+      <tr key={key}>
+        <td>{prop.twigProp ? <code>{prop.twigProp}</code> : '—'}</td>
+        <td>
+          <code>{prop.type || '—'}</code>
+        </td>
+        {showDefault ? (
+          <td>
+            <code>
+              {prop.default !== undefined ? String(prop.default) : '—'}
+            </code>
+          </td>
+        ) : null}
+        <td>{prop.detail || prop.description || '—'}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+); }
+
 export function twigPropsTable(props, filter) {
   const entries = Object.entries(props).filter(([, p]) => {
     if (p.twigOnly) return false;
@@ -5,62 +40,10 @@ export function twigPropsTable(props, filter) {
     if (filter === 'optional') return !p.required;
     return true;
   });
-
-if (entries.length === 0) return null;
-
-return (
-
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    {entries.map(([key, prop]) => (
-      <tr key={key}>
-        <td>{prop.twigProp ? <code>{prop.twigProp}</code> : '—'}</td>
-        <td>
-          <code>{prop.type || '—'}</code>
-        </td>
-        <td>
-          <code>{prop.default !== undefined ? String(prop.default) : '—'}</code>
-        </td>
-        <td>{prop.detail || prop.description || '—'}</td>
-      </tr>
-    ))}
-  </tbody>
-</table>
-); }
+  return renderPropsTable(entries, true);
+}
 
 export function twigOnlyPropsTable(props) {
   const entries = Object.entries(props).filter(([, p]) => p.twigOnly);
-
-if (entries.length === 0) return null;
-
-return (
-
-<table>
-  <thead>
-    <tr>
-      <th>Property</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    {entries.map(([key, prop]) => (
-      <tr key={key}>
-        <td>{prop.twigProp ? <code>{prop.twigProp}</code> : '—'}</td>
-        <td>
-          <code>{prop.type || '—'}</code>
-        </td>
-        <td>{prop.detail || prop.description || '—'}</td>
-      </tr>
-    ))}
-  </tbody>
-</table>
-); }
+  return renderPropsTable(entries, false);
+}


### PR DESCRIPTION
## [1202: Migrate 14 remaining MDX component docs to YAML-driven props tables](https://github.com/yalesites-org/YaleSites-Internal/issues/1202)

### Description of work
- Migrated the 13 components still hand-coding inline `<table>` HTML for their props docs to the YAML-driven pattern: each now has a `<name>-props.yml` single source of truth, an `.mdx` rendering tables via the shared `twigPropsTable`/`twigOnlyPropsTable` helpers, and a `.stories.js` wired to Storybook controls via `toArgTypes`/`toArgs`. Components: video-embed, image, link-skip, pull-quote, quote-callout, read-time, search-result, social-links, text, tile-item, calendar, breadcrumbs, utility-nav.
- Added a shared `twigOnlyPropsTable()` helper and a `twigOnly` prop flag so template-only props (e.g. quote-callout's conditional image fields) get their own docs table and are excluded from Storybook controls. Backward-compatible — no existing `-props.yml` sets the flag, so the 42 already-migrated components render identically.
- Corrected video-embed docs, which documented three props (`video_embed__url/title/aspect_ratio`) the template never consumes — it only renders `video_embed__content`. Now documents the real prop.
- The `tables` atom (the 14th) was intentionally left as-is: it has no component props (only prose + code-fence examples), so there is nothing to migrate.
- Non-props tables (Technical Specifications, Aspect Ratios, Day/Event object structures) were deliberately retained.

### Functional testing steps:
- [x] In the Netlify Storybook deploy preview for this PR, open each migrated component's doc page and confirm the Required/Optional (and Twig-Only, where present) props tables render as formatted tables.
- [ ] Confirm the Controls panel binds and updates the Canvas preview for each migrated component.
- [ ] Spot-check video-embed (its `content` control drives the preview) and quote-callout (uses the new Twig-Only table).
- [ ] Confirm non-props tables (Technical Specifications, Aspect Ratios, Day/Event Object) still render.
- [ ] Confirm already-migrated components (e.g. accordion, custom-card) are unchanged.

References yalesites-org/YaleSites-Internal#1202
