### PR TITLE
1363: Wave 8: Full-library completion (Storybook-only and demo components)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Then you can install the package like any other npm dependency.
 npm install @yalesites-org/component-library-twig
 ```
 
+## Single Directory Components (SDC)
+
+YaleSites components are being migrated to Drupal [Single Directory Components](https://www.drupal.org/docs/develop/theming-drupal/using-single-directory-components) (epic [#1351](https://github.com/yalesites-org/YaleSites-Internal/issues/1351)). Each migrated component keeps its canonical Twig, SCSS, and JS in this library — still driving Storybook and Percy — while a thin-wrapper SDC in the `atomic` theme (`atomic/components/<name>/`) carries the schema and delegates rendering back to it. The library remains the single source of truth for markup and styles.
+
+The full documentation set, including a status overview, the conversion recipe, and a guide to building a new block as an SDC, lives in [`docs/sdc/`](docs/sdc/README.md).
+
 ## Releases
 
 Any time something is pushed to the `main` branch on GitHub, a [GitHub Action](.github/workflows/release.yml) is run to determine whether a new release is needed (via semantic-release.)

--- a/components/02-molecules/accordion/yds-accordion.test.js
+++ b/components/02-molecules/accordion/yds-accordion.test.js
@@ -1,0 +1,117 @@
+/**
+ * Behavioral tests for the Accordion (Drupal.behaviors.accordion).
+ *
+ * This is the pattern Wave 3b extends to the other interactive components. It
+ * exercises the JS behavior directly against a DOM fixture that mirrors the
+ * rendered accordion markup, asserting the things Percy cannot see: initial
+ * collapsed state, expand/collapse on activation, keyboard operability (the
+ * toggles are native <button>s), ARIA state changes, and the Expand/Collapse-all
+ * control.
+ */
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const behaviorSrc = readFileSync(
+  'components/02-molecules/accordion/yds-accordion.js',
+  'utf8',
+);
+
+// A fixture mirroring the rendered accordion markup the behavior operates on
+// (.accordion / .accordion-item / .accordion-item__toggle / __content /
+// .accordion__controls / .accordion__toggle-all). Two items so the toggle-all
+// control is shown (the behavior hides it for a single item).
+const fixture = (items = 2) => {
+  const rows = Array.from({ length: items })
+    .map(
+      (_, i) => `
+      <div class="accordion-item" data-accordion-expanded="true">
+        <h3 class="accordion-item__heading">
+          <button class="accordion-item__toggle" aria-expanded="true">Item ${
+            i + 1
+          }</button>
+        </h3>
+        <div class="accordion-item__content">Content ${i + 1}</div>
+      </div>`,
+    )
+    .join('');
+  return `
+    <div class="accordion" data-component-theme="one">
+      <div class="accordion__inner">
+        <ul class="accordion__controls">
+          <li><button class="accordion__toggle-all" aria-expanded="false">Expand All</button></li>
+        </ul>
+        ${rows}
+      </div>
+    </div>`;
+};
+
+function attachBehavior(context) {
+  // yds-accordion.js assigns Drupal.behaviors.accordion using a global Drupal.
+  global.Drupal = { behaviors: {} };
+  // eslint-disable-next-line no-new-func
+  new Function('Drupal', behaviorSrc)(global.Drupal);
+  global.Drupal.behaviors.accordion.attach(context);
+}
+
+const items = () => [...document.querySelectorAll('.accordion-item')];
+const toggle = (item) => item.querySelector('.accordion-item__toggle');
+const expanded = (item) =>
+  item.getAttribute('data-accordion-expanded') === 'true';
+
+describe('Drupal.behaviors.accordion', () => {
+  beforeEach(() => {
+    document.body.innerHTML = fixture(2);
+  });
+
+  it('collapses all items on attach', () => {
+    attachBehavior(document.body);
+    items().forEach((item) => {
+      expect(expanded(item)).toBe(false);
+      expect(toggle(item).getAttribute('aria-expanded')).toBe('false');
+    });
+  });
+
+  it('expands a single item when its toggle is activated, leaving others collapsed', () => {
+    attachBehavior(document.body);
+    toggle(items()[0]).click();
+    expect(expanded(items()[0])).toBe(true);
+    expect(toggle(items()[0]).getAttribute('aria-expanded')).toBe('true');
+    expect(expanded(items()[1])).toBe(false);
+  });
+
+  it('collapses an expanded item when its toggle is activated again', () => {
+    attachBehavior(document.body);
+    const first = items()[0];
+    toggle(first).click();
+    expect(expanded(first)).toBe(true);
+    toggle(first).click();
+    expect(expanded(first)).toBe(false);
+    expect(toggle(first).getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('toggles are native buttons (keyboard operable) and update ARIA on activation', () => {
+    attachBehavior(document.body);
+    const btn = toggle(items()[0]);
+    expect(btn.tagName).toBe('BUTTON');
+    // Enter/Space on a native button dispatch a click; assert the activation
+    // path updates the ARIA state the behavior manages.
+    btn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('Expand All control expands every item', () => {
+    attachBehavior(document.body);
+    document.querySelector('.accordion__toggle-all').click();
+    items().forEach((item) => {
+      expect(expanded(item)).toBe(true);
+    });
+  });
+
+  it('hides the Expand/Collapse-all control when there is only one item', () => {
+    document.body.innerHTML = fixture(1);
+    attachBehavior(document.body);
+    expect(document.querySelector('.accordion__controls').style.display).toBe(
+      'none',
+    );
+  });
+});

--- a/components/02-molecules/tabs/yds-tabs.test.js
+++ b/components/02-molecules/tabs/yds-tabs.test.js
@@ -1,0 +1,89 @@
+/**
+ * Behavioral tests for the Tabs (Drupal.behaviors.tabs) — Wave 3b (#1357).
+ *
+ * Percy can't see this: click/keyboard tab activation and the ARIA/is-active
+ * state changes. The overflow logic in the behavior is layout-dependent
+ * (getBoundingClientRect), which jsdom reports as zero, so it stays inert here;
+ * we exercise the activation path (goToTab) via click and arrow keys.
+ */
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const behaviorSrc = readFileSync(
+  'components/02-molecules/tabs/yds-tabs.js',
+  'utf8',
+);
+
+// Fixture mirroring the rendered tabs markup (2 tabs; tab 0 initially active).
+const fixture = () => `
+  <div class="tabs" data-overflow="none">
+    <div class="tabs__tabs">
+      <button class="tabs__control tabs__control--left" aria-hidden="true" tabindex="-1"></button>
+      <ul class="tabs__nav" role="tablist">
+        <li class="tabs__item" role="presentation">
+          <a class="tabs__link" role="tab" aria-controls="tab-1-0" href="#tab-1-0" aria-selected="true">One</a>
+        </li>
+        <li class="tabs__item" role="presentation">
+          <a class="tabs__link" role="tab" aria-controls="tab-1-1" href="#tab-1-1" tabindex="-1">Two</a>
+        </li>
+      </ul>
+      <button class="tabs__control tabs__control--right" aria-hidden="true" tabindex="-1"></button>
+    </div>
+    <div class="tabs__container is-active" role="tabpanel" tabindex="0"><div class="tabs__inner"><div class="tabs__content" id="tab-1-0">Panel one</div></div></div>
+    <div class="tabs__container" role="tabpanel" tabindex="0"><div class="tabs__inner"><div class="tabs__content" id="tab-1-1">Panel two</div></div></div>
+  </div>`;
+
+function attachBehavior(context) {
+  global.Drupal = { behaviors: {} };
+  // eslint-disable-next-line no-new-func
+  new Function('Drupal', behaviorSrc)(global.Drupal);
+  global.Drupal.behaviors.tabs.attach(context);
+}
+
+const links = () => [...document.querySelectorAll('.tabs__link')];
+const panels = () => [...document.querySelectorAll('.tabs__container')];
+const selected = (link) => link.getAttribute('aria-selected') === 'true';
+const active = (panel) => panel.classList.contains('is-active');
+
+function pressKey(el, which) {
+  const e = new window.KeyboardEvent('keydown', { bubbles: true });
+  Object.defineProperty(e, 'which', { value: which });
+  el.dispatchEvent(e);
+}
+
+describe('Drupal.behaviors.tabs', () => {
+  beforeEach(() => {
+    document.body.innerHTML = fixture();
+  });
+
+  it('starts with the first tab selected and its panel active', () => {
+    attachBehavior(document.body);
+    expect(selected(links()[0])).toBe(true);
+    expect(active(panels()[0])).toBe(true);
+    expect(active(panels()[1])).toBe(false);
+  });
+
+  it('activates a tab and its panel on click, deactivating the previous', () => {
+    attachBehavior(document.body);
+    links()[1].click();
+    expect(selected(links()[1])).toBe(true);
+    expect(active(panels()[1])).toBe(true);
+    expect(selected(links()[0])).toBe(false);
+    expect(active(panels()[0])).toBe(false);
+  });
+
+  it('moves to the next tab with the Right arrow key', () => {
+    attachBehavior(document.body);
+    pressKey(links()[0], 39);
+    expect(selected(links()[1])).toBe(true);
+    expect(active(panels()[1])).toBe(true);
+  });
+
+  it('moves to the previous tab with the Left arrow key', () => {
+    attachBehavior(document.body);
+    links()[1].click();
+    pressKey(links()[1], 37);
+    expect(selected(links()[0])).toBe(true);
+    expect(active(panels()[0])).toBe(true);
+  });
+});

--- a/docs/sdc/README.md
+++ b/docs/sdc/README.md
@@ -1,0 +1,45 @@
+# Single Directory Components (SDC) on YaleSites
+
+This directory is the documentation set for the YaleSites migration of the Twig
+component library to Drupal [Single Directory Components](https://www.drupal.org/docs/develop/theming-drupal/using-single-directory-components)
+(SDC), tracked by epic [#1351](https://github.com/yalesites-org/YaleSites-Internal/issues/1351).
+
+## What an SDC is here
+
+A YaleSites SDC is a **thin wrapper** that lives in the `atomic` theme
+(`atomic/components/<name>/`) and delegates rendering to the canonical Twig
+template, which stays in this repository (`component-library-twig`) and keeps
+feeding Storybook and Percy unchanged. Each wrapper is two files:
+
+```
+atomic/components/<name>/
+  <name>.component.yml   # the schema: typed props + slots (authored Canvas-forward)
+  <name>.twig            # a shim that include/embeds @atoms|@molecules|@organisms/<name>/...
+```
+
+Drupal SDC only discovers components in an installed extension's own
+`components/` directory; it does **not** scan `node_modules/`. That constraint is
+why the wrapper lives in `atomic` while the real template, SCSS, and JS stay
+canonical in this library. See the migration guide for the full rationale.
+
+## The documents
+
+| Document | Read it when |
+|---|---|
+| [migration-guide.md](migration-guide.md) | You want the overview: why SDC, the architecture, current status, and how the remaining components get migrated. |
+| [recipe-convert-a-component-to-sdc.md](recipe-convert-a-component-to-sdc.md) | You are converting an **existing** CLT component to an SDC. The step-by-step, with every gotcha found in the migration. |
+| [building-a-new-block-as-sdc.md](building-a-new-block-as-sdc.md) | You are building a **brand-new** Layout Builder block and want it to be an SDC from day one. |
+| [recipe-test-a-new-sdc.md](recipe-test-a-new-sdc.md) | You need to test an SDC (schema-validation for every component; behavioral for interactive ones). |
+| [research-spike-1352-canvas-and-web-components.md](research-spike-1352-canvas-and-web-components.md) | You need the Canvas-readiness and Web Component background that set the direction. |
+
+## The two non-obvious rules, up front
+
+1. **SDC prop validation is assertion-gated.** Invalid props (a bad enum, a wrong
+   type) throw in dev and test (PHP assertions on) but render silently in a
+   `--no-dev` production build. Author schemas correctly and test them; do not
+   rely on production to catch a schema mismatch.
+2. **SDC does not inherit Twig context.** Only declared props and slots are in
+   scope inside a component. Anything a nested template needs — most commonly
+   `directory` for the icon sprite path — must be threaded through explicitly.
+
+Both are explained in depth in the recipe.

--- a/docs/sdc/building-a-new-block-as-sdc.md
+++ b/docs/sdc/building-a-new-block-as-sdc.md
@@ -1,0 +1,174 @@
+# Building a new Layout Builder block as an SDC
+
+Use this when you are creating a **brand-new** YaleSites block and want it to be a
+Single Directory Component from the start. If you are converting an existing
+component, use [recipe-convert-a-component-to-sdc.md](recipe-convert-a-component-to-sdc.md)
+instead — this guide reuses the same patterns but starts from nothing.
+
+The end state is the same thin-wrapper shape every migrated component uses: the
+markup/SCSS/JS is canonical in `component-library-twig`, and a small SDC in the
+`atomic` theme carries the schema and delegates to it. Read
+[migration-guide.md](migration-guide.md) for why the wrapper lives in `atomic`.
+
+## 1. Build the component in the library (as usual)
+
+Author the component in `component-library-twig` the normal way (see the repo
+root `README.md` and `CONTRIBUTING.md`): a `components/0X-<tier>/<name>/`
+directory with `yds-<name>.twig`, `_yds-<name>.scss`, an optional
+`yds-<name>.js` Drupal behavior, `<name>-props.yml`, and the Storybook
+`.stories.js` / `.mdx` / `.visreg.stories.js` files. Get it rendering and
+documented in Storybook first. Nothing about SDC changes this step.
+
+Decide the component's inputs now, because they map directly onto the schema:
+
+- **Props** — scalar values (strings, enums, numbers, booleans). Dial-style
+  options (theme, color, alignment) become string enums.
+- **Slots** — anything that is rendered markup or a render array (a heading, a
+  body, a list of items). Render arrays cannot pass JSON-schema scalar validation,
+  so they must be slots, not props.
+
+## 2. Author the SDC schema in `atomic`
+
+Create `atomic/components/<name>/<name>.component.yml`. Author it Canvas-forward —
+every prop gets a `title` and `description`, required props get an `example`:
+
+```yaml
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: <Human Name>
+status: stable
+group: Atoms   # or Molecules / Organisms — matches the component's tier
+description: >
+  One-line summary. Note this is a thin SDC wrapper over the component library's
+  @<tier>/<name>/yds-<name>.twig template.
+props:
+  type: object
+  properties:
+    <name>__theme:
+      type: string
+      title: Theme
+      description: Color theme dial for the component.
+      enum: ['one', 'two', 'three', 'four', 'five']
+      default: 'one'
+    <name>__heading_text:
+      # Optional scalar that Drupal may pass as NULL needs a nullable type.
+      type: ['string', 'null']
+      title: Heading
+      description: Optional heading shown above the body.
+slots:
+  <name>__body:
+    title: Body
+    description: The main rendered content.
+```
+
+Rules that bite if you skip them:
+
+- **A prop and a slot may not share a name**, and an SDC slot must not share a
+  name with the CLT block the shim overrides.
+- **Optional scalar props that Drupal can pass as NULL need `type: ['string',
+  'null']`.** SDC validates NULL against the declared type; a bare `type: string`
+  rejects it. Give the schema a `default` too, but note the default only applies
+  to *absent* props, not NULL ones (the block template handles NULL — step 4).
+- **Enums are string enums**; quote heterogeneous keys (`'one'`, `'true'`,
+  `'100%'`).
+
+If the component has dials, prefer generating the schema instead of hand-typing
+it: add a spec to `scripts/sdc/components.config.js` (in `yalesites-project`) and
+run `node scripts/sdc/generate-sdc.js <name> --write`. The codegen resolves dial
+enums from `ys_themes.component_overrides.yml` against the field formatter, so the
+enum values match what Drupal will actually pass.
+
+## 3. Write the shim (`<name>.twig`)
+
+The shim delegates to the canonical template. Props are in scope as variables;
+slots need the `block()` capture pattern.
+
+Props-only:
+
+```twig
+{{ include('@molecules/<name>/yds-<name>.twig', {
+  <name>__theme: <name>__theme,
+}, with_context = false) }}
+```
+
+With a slot (capture the slot override, pass it into the inner embed, and register
+a non-rendering receiver block so `block()` resolves at compile time):
+
+```twig
+{% set <name>__body_slot = block('<name>__body') %}
+{% embed '@molecules/<name>/yds-<name>.twig' with {
+  <name>__theme: <name>__theme,
+  <name>__body_slot: <name>__body_slot,
+  directory: directory,
+} only %}
+  {% block <name>__items %}{{ <name>__body_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block <name>__body %}{% endblock %}{% endif %}
+```
+
+If the slot feeds an auto-escaping sink in the template (a bare `{{ x }}`, not
+`{{ x|raw }}`), capture it as Markup instead so it is not double-escaped:
+`{% set x %}{{ block('<name>__body')|raw }}{% endset %}`. The recipe has the full
+explanation and the emptiness guard for optional slots. **Thread `directory`**
+whenever the component (or a nested atom) renders an icon.
+
+## 4. Create the Drupal block and its template
+
+A new block is more than the component — it needs the Drupal plumbing that an
+existing block already has:
+
+1. **Block content type + fields.** Create the `block_content` bundle and its
+   fields (body, dial fields such as `field_style_color` / `field_style_alignment`,
+   etc.) via config in `yalesites_profile`.
+2. **View-display formatter.** In
+   `core.entity_view_display.block_content.<bundle>.default.yml`, choose the dial
+   field formatter deliberately: `list_key` outputs machine keys (`one`..`five`),
+   `list_default` outputs labels. **This decides the enum values your schema must
+   accept** — see recipe section 6.
+3. **Dial config.** If the block has dials, add them to
+   `ys_themes.component_overrides.yml` (`<bundle> -> <field> -> {values, default}`).
+4. **Block template.** Create
+   `atomic/templates/block/layout-builder/block--inline-block--<name>.html.twig`
+   and render the SDC from it. This is the adapter layer:
+   - Props-only: `{{ include('atomic:<name>', { ... }, with_context = false) }}`.
+   - With slots: `{% embed 'atomic:<name>' with { ... } %}{% block <slot> %}...{% endblock %}{% endembed %}` —
+     **do not use `only` on the block template's embed**, or the slot block loses
+     access to `content` and `directory`.
+   - **Default legacy NULLs here**, because the schema default does not cover NULL:
+     `content.field_style_color.0['#markup']|default('one')`. Choose the default
+     that matches the component's own pre-existing `|default(...)` behavior.
+   - Thread `directory` if the component renders icons.
+
+## 5. Wire assets
+
+If the component has CSS/JS beyond the global stylesheet, add its library to the
+SDC (not the inner template — `include`/`embed` bypass `#attached`):
+
+```yaml
+# in <name>.component.yml
+libraryOverrides:
+  dependencies:
+    - atomic/<name>
+```
+
+Define `atomic/<name>` in `atomic.libraries.yml` pointing at the compiled
+`dist/` assets, as existing component libraries do.
+
+## 6. Test and verify
+
+- Add a schema-validation case to `atomic/tests/src/Unit/SdcSchemaValidationTest.php`
+  (valid data passes, invalid data fails) and run `lando composer test:sdc`. See
+  [recipe-test-a-new-sdc.md](recipe-test-a-new-sdc.md).
+- If the component is interactive, add a Vitest behavioral test and prove it is
+  meaningful (break the behavior, confirm the test fails, restore).
+- Render the block on a page and confirm it looks right. Render **twice on a fresh
+  `drush cr`** — a single render can be cache-served and hide a prop-validation
+  500 for a NULL prop.
+- Confirm the component's JS attaches (grep the page for its `dist/js/*.js`).
+
+## 7. Ship it
+
+Run the review gate (`/simplify`, `/code-review`, `/security-review` when the diff
+touches user input, assets, or output escaping), lint with `composer code-sniff`,
+and open PRs. Because a new component touches `component-library-twig` and
+`atomic` (and `yalesites-project` for config), use matching branch names across
+the repos so the multidev builds — see the `/yalesites-pr` skill.

--- a/docs/sdc/migration-guide.md
+++ b/docs/sdc/migration-guide.md
@@ -1,0 +1,140 @@
+# SDC migration guide
+
+The overview of the YaleSites component-library migration to Single Directory
+Components (SDC), epic [#1351](https://github.com/yalesites-org/YaleSites-Internal/issues/1351).
+For the step-by-step conversion procedure see
+[recipe-convert-a-component-to-sdc.md](recipe-convert-a-component-to-sdc.md); this
+document is the "why" and the "where are we."
+
+## Why SDC
+
+Drupal core ships SDC since 10.3, and Drupal Canvas (the site-builder that will
+land with a Drupal 11 upgrade) consumes SDCs as its component contract. Migrating
+gives each YaleSites component a machine-readable schema (typed props with
+titles, descriptions, and examples) that the Layout Builder — and eventually
+Canvas — can validate against and build editing UI from, without changing where
+the component's markup, styles, or behavior live.
+
+The forcing function is the calendar. Per the
+[research spike](research-spike-1352-canvas-and-web-components.md) (which cites the
+Drupal.org sources it drew from, as of 2026-07-02): Drupal 10 reaches end-of-life
+in late 2026 with 10.6 as the final D10 minor, and Canvas requires core `^11.2` —
+so Canvas is strictly downstream of a D11 upgrade. Re-verify those release dates
+against Drupal.org before they drive a scheduling decision. Authoring schemas
+Canvas-forward now means they do not need to be redone when D11/Canvas arrive.
+
+## The architecture: thin wrappers in `atomic`
+
+Drupal SDC only discovers components in an installed extension's own `components/`
+directory — it does **not** scan `node_modules/`. So each migrated component gets
+a small SDC in the `atomic` theme that **delegates** to the real template, which
+stays canonical in this library:
+
+```
+atomic/components/<name>/
+  <name>.component.yml   # schema (props + slots)
+  <name>.twig            # thin shim: include/embed @atoms|@molecules|@organisms/<name>/...
+```
+
+- **Markup** stays canonical in `component-library-twig`, still driving Storybook
+  and Percy. The shim's `@atoms`/`@molecules`/`@organisms` includes are permanent
+  by design — that is the thin-wrapper contract, not tech debt.
+- **CSS/JS** keep loading from the existing compiled `dist/` via the current
+  `atomic/*` libraries, attached through the SDC's `libraryOverrides`. Nothing is
+  moved or duplicated.
+- **Dial enums** (the theme/color/alignment options) are generated from
+  `ys_themes.component_overrides.yml` resolved against each field's view-display
+  formatter, never hand-typed, so they cannot drift from what Drupal actually
+  passes.
+
+This shape is valid core SDC and valid Canvas SDC. A fully self-contained SDC
+(template + partials moved into `atomic/components/`) remains a possible later
+end-state but is not a prerequisite.
+
+## Rendering path
+
+A migrated component is reachable two ways, both exercised in the migration:
+
+1. **Render element** — `['#type' => 'component', '#component' => 'atomic:<name>',
+   '#props' => [...], '#slots' => [...]]`. Used for programmatic/isolated render
+   and (eventually) Canvas.
+2. **Layout Builder block** — the block template
+   `atomic/templates/block/layout-builder/block--inline-block--<name>.html.twig`
+   is repointed at the SDC (`include('atomic:<name>', ...)` for props-only
+   components, `embed 'atomic:<name>'` with slot blocks for components with
+   slots). The block template is the **adapter layer**: it reads the Drupal field
+   values, applies defaults for legacy NULLs, and threads `directory`.
+
+## Current status
+
+As of this writing the migration has converted **26 components** to thin-wrapper
+SDCs, each schema-validated and verified to render identically to its pre-SDC
+baseline on real pages (or in isolation where no on-site content exists):
+
+Tiers below are by where the canonical template lives in this library (the
+`@atoms`/`@molecules`/`@organisms` namespace each shim delegates to):
+
+- **Atoms (9):** divider, heading, text, cta, text-link, text-copy-button, lists,
+  date-time, image.
+- **Molecules (16):** callout, accordion, inline-message, pull-quote,
+  wrapped-image, wrapped-callout, link-grid, quick-links, embed, video, tabs,
+  link-skip, read-time, taxonomy-display, basic-meta, text-with-image (rendered as
+  the content spotlight block).
+- **Organisms (1):** tiles.
+
+Testing infrastructure is stood up and wired into CI where possible:
+
+- **Schema-validation tests** (PHPUnit + `justinrainbow/json-schema`) in
+  `atomic/tests/src/Unit/SdcSchemaValidationTest.php`, run with
+  `lando composer test:sdc`. One assertion pair per component: valid data passes,
+  invalid data (bad enum / missing required) fails.
+- **Behavioral tests** (Vitest + jsdom) for interactive components, co-located in
+  this repo (`components/**/<name>.test.js`), run with `npm run test:unit` and
+  wired into CLT CI via `npm run test`.
+
+The remaining components are staged with the recipe and codegen ready to apply.
+The tractable majority is mechanical; the genuine long poles are documented in
+the epic decisions log and summarized under "Known limits" below.
+
+## How a remaining component gets migrated
+
+1. Add a spec to `scripts/sdc/components.config.js` (in `yalesites-project`) and
+   run the codegen: `node scripts/sdc/generate-sdc.js <name> --write`. Review the
+   first-draft schema (search for `x-codegen-todo` / `x-codegen-warning`).
+2. Refine the schema Canvas-forward and write the shim, following
+   [recipe-convert-a-component-to-sdc.md](recipe-convert-a-component-to-sdc.md).
+3. Repoint the Layout Builder block template at the SDC.
+4. **Capture a real before/after baseline** on an affected page and confirm the
+   output is byte-identical (normalizing SDC dev decorations and cache tokens).
+   Render twice on a fresh `drush cr` — a single render can be cache-served and
+   hide a prop-validation 500.
+5. Add a schema-validation test (and a behavioral test if interactive).
+6. Run the review gate (`/simplify`, `/code-review`, `/security-review`), lint
+   (`composer code-sniff`), commit, and push on the ticket's branch.
+
+## Known limits (decisions the back half of the epic depends on)
+
+- **Thin wrappers break for slots that depend on component-internal state.** When
+  the consumer's slot markup itself uses state generated *inside* the component (a
+  `random()` id, a loop `key`, a `base_class`) — as in tabs, where each panel's
+  `id` and each label's `aria-controls` are `tab-{id}-{key}` — the `block()`
+  capture renders the slot outside that scope and the state is undefined. Tabs was
+  solved by **threading the shared state explicitly** from the consumer through
+  the shim and the partials; the alternative is a fully self-contained SDC. This
+  choice recurs for modal, alert, menu, nested card/collection organisms, and
+  Views-driven components.
+- **Data-driven and high-blast components need dedicated work**, not a batch: the
+  meta components (entity metadata), page-title (every page's title, six slots),
+  and the Views-driven components (Wave 6, which must coordinate with the in-flight
+  Views Block Rework epic #1161).
+- **The Web Component distribution package and the OutSystems proof-of-concept**
+  (Wave 10) require an OutSystems tenant that is not available in this
+  environment; the plain-HTML Web Component wrappers are proven (see the research
+  spike), the OutSystems import demo is blocked pending that access.
+
+## A note on the name "migration guide"
+
+This repository also contains `STORYBOOK-MIGRATION-GUIDE.md` at its root. That is
+a **different** document — it covers migrating a component to the two-page
+Storybook documentation structure (MDX + visreg), not SDC. This SDC documentation
+set lives under `docs/sdc/` and does not modify it.

--- a/docs/sdc/recipe-convert-a-component-to-sdc.md
+++ b/docs/sdc/recipe-convert-a-component-to-sdc.md
@@ -168,6 +168,15 @@ The split is ~35 `list_default` / ~44 `list_key` platform-wide, so codegen reads
   Markup object). If that slot is optional and the template gates on `{% if x %}`, empty it when
   blank so the check stays falsy: `{% set x = captured|trim is empty ? '' : captured %}`. (Slots
   whose sink already applies `|raw` — e.g. the text atom — don't need this.)
+- **Thin-wrapper limit: consumer slots that depend on component-internal state.** If the CLT
+  template generates internal state (a `random()` id, a loop `key`, a `base_class`) that the slot
+  markup *itself* uses — e.g. tabs, where each label's `aria-controls` and each panel's `id` are
+  `tab-{tabs__id}-{key}` — the `block()`-capture pattern breaks, because it renders the slot
+  *outside* the component's scope (the internal state is undefined there). These components cannot be
+  thin-wrapped; they need the **fully self-contained SDC** form (move the template + partials into
+  `atomic/components/<comp>/`) or a **structured data prop** (pass an items array and let the
+  component loop internally). Applies to interactive components (tabs/modal/menu) and nested
+  collections. Flag for a per-component decision rather than shipping broken markup.
 - **Don't drop "unused"-looking `{% set %}` vars from a block template.** The pre-SDC `{% include %}`
   (no `only`) passed block-template variables like `<comp>__width`/`<comp>__alignment` via context
   inheritance even when they weren't in the `with {…}`. Under SDC they must be explicit props the

--- a/docs/sdc/recipe-convert-a-component-to-sdc.md
+++ b/docs/sdc/recipe-convert-a-component-to-sdc.md
@@ -1,0 +1,161 @@
+# Recipe: convert a component to a Single Directory Component (SDC)
+
+First-draft recipe from the Wave 0 pilot (epic #1351, ticket #1353). Proven by converting
+Divider, Accordion, and Callout end-to-end and verifying byte-identical rendering against the
+pre-SDC baseline on real pages. Update this after every wave with anything new learned.
+
+## The architecture: thin wrappers in `atomic/components/`
+
+Drupal SDC only discovers components in an installed extension's own `components/` directory — it
+does **not** scan `node_modules/`. So each migrated component gets a small SDC in the `atomic`
+theme that **delegates** to the real template, which stays canonical in `component-library-twig`
+(CLT) and keeps feeding Storybook/Percy unchanged:
+
+```
+atomic/components/<name>/
+  <name>.component.yml   # the schema (props + slots), authored Canvas-forward
+  <name>.twig            # a thin shim that includes/embeds @atoms|@molecules|@organisms/<name>/...
+```
+
+CSS/JS keep loading from the existing `dist/` via the `atomic/*` libraries, attached through the
+SDC's `libraryOverrides` (not moved or duplicated). The `@atoms`/`@molecules`/`@organisms`
+includes stay inside the shim indefinitely — that is the deliberate thin-wrapper design, not tech
+debt.
+
+## Steps
+
+### 1. Seed the schema with the codegen script
+
+```
+node scripts/sdc/generate-sdc.js <name>          # dry run (prints)
+node scripts/sdc/generate-sdc.js <name> --write   # writes atomic/components/<name>/<name>.component.yml
+```
+
+Add a spec for the component in `scripts/sdc/components.config.js` first (twig path, props path,
+block `bundle`, and the `dials` map of Twig-prop → `field_style_*`). The codegen resolves the
+`*-props.yml` `twigProp` indirection, remaps Storybook control types to JSON-Schema types, drops
+CSS-custom-property / data-attribute props, detects slots, and generates dial enums from
+`ys_themes.component_overrides.yml` **resolved against the field formatter** (see #4).
+
+The output is a **first draft** — always review it (search for `x-codegen-todo` / `x-codegen-warning`).
+
+### 2. Refine the schema (Canvas-forward)
+
+- Author `title` + `description` on every prop, and `examples` on required props — Canvas uses
+  these as editor labels/initial values, so doing it now means the schemas need no redo when a
+  Drupal 11 / Canvas upgrade lands (see `research-spike-1352-...md`).
+- **Types can diverge from Storybook controls.** A `type: boolean` prop in `*-props.yml` may be a
+  real value at render time (e.g. callout's `overlayBackgroundImage` is a **URL string**). Verify
+  against the Twig and the block template.
+- **Optional scalar props that can receive NULL** from Drupal need a nullable type
+  (`type: [string, "null"]`); SDC validates NULL against the declared type.
+- Remove codegen false-positives: it detects every `{% block %}` including those inside nested
+  `{% embed %}` of *other* components (e.g. an accordion that embeds the list atom surfaces
+  `list__content`). Drop slots that belong to embedded sub-components.
+
+### 3. Write the shim (`<name>.twig`)
+
+Props are available as variables. Slots need care — this is the biggest gotcha:
+
+- **Slots arrive as a block override** on the shim (both the SDC render element and a Twig
+  `{% embed %}` from a block template). Reading a slot as a *variable* only works for the render
+  element, so use the `block()` capture pattern below.
+- **Name each SDC slot distinctly from the CLT block it injects into** (e.g. `callout__content`
+  vs the CLT template's `callout__items`) — same-named blocks collide and the wrong one wins.
+- **Thread `directory`** so nested atoms (icons) resolve the SVG sprite path — SDC does not inject
+  it.
+
+Props-only component (no slots), e.g. Divider:
+
+```twig
+{{ include('@atoms/divider/yds-divider.twig', {
+  divider__width: divider__width,
+  divider__position: divider__position,
+}, with_context = false) }}
+```
+
+Component with a slot, e.g. Callout (`callout__content` → the CLT `callout__items` block):
+
+```twig
+{% set callout__content_slot = block('callout__content') %}
+{% embed '@molecules/callout/yds-callout.twig' with {
+  callout__background_color: callout__background_color,
+  callout__alignment: callout__alignment,
+  callout__content_slot: callout__content_slot,
+  directory: directory,
+} only %}
+  {% block callout__items %}{{ callout__content_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block callout__content %}{% endblock %}{% endif %}
+```
+
+Why each line:
+- `block('callout__content')` captures the override (works for both render paths).
+- the captured value is passed **inside** the `with { … } only` so it is in scope in the override.
+- `|raw` because `block()` returns a plain string and the content is already-rendered, trusted
+  Drupal field output (double-escaping otherwise).
+- `{% if false %}{% block callout__content %}{% endblock %}{% endif %}` registers the receiver block
+  at compile time (so `block()` finds it) without rendering it inline (which would duplicate the
+  content). A slot the CLT template consumes as a *variable* (e.g. accordion's heading) is captured
+  the same way and passed through the `with`.
+
+### 4. Wire assets via `libraryOverrides`
+
+For a component with JS/CSS beyond the global stylesheet, depend on its existing library:
+
+```yaml
+libraryOverrides:
+  dependencies:
+    - atomic/accordion
+```
+
+The SDC render element attaches the component's auto-library, whose dependency pulls in the real
+JS/CSS. (`include`/`embed` bypass `#attached`, so relying on the inner template to attach assets
+does **not** work — this is why the dependency goes on the SDC.)
+
+### 5. Point the Layout Builder block template at the SDC
+
+In `atomic/templates/block/layout-builder/block--inline-block--<name>.html.twig`:
+
+- Render props-only components with `{{ include('atomic:<name>', { … }, with_context = false) }}`.
+- Render components with slots with `{% embed 'atomic:<name>' with { … } %}{% block <slot> %}…{% endblock %}{% endembed %}` — **do not use `only` here**, or the slot block override loses access to `content` and `directory`.
+- **The block template is the adapter layer.** Default dial values here — older blocks can store
+  NULL and the SDC enums are strict, and the schema `default` only applies to *absent* (not NULL)
+  props: `content.field_style_color.0['#markup']|default('one')`. Choose the default that matches
+  the pre-SDC behavior for a NULL value (trace the CLT template's own `|default(...)`).
+- Remove now-redundant `{{ attach_library() }}` calls (the SDC attaches via `libraryOverrides`).
+
+### 6. Dial enums come from the field FORMATTER, not just the config
+
+`ys_themes.component_overrides.yml` gives `values: {machine: Label}` per component/field, but what
+actually reaches the prop is the **view-display formatter** output
+(`core.entity_view_display.block_content.<bundle>.default.yml`):
+
+- `list_key` formatter → the machine **keys** (`one`…`five`, `left`, `center`, `default`).
+- `list_default` formatter → the human **labels** (divider width `100/75/50/25`, position
+  `Left/Center` — which the template then `|lower`s).
+
+The split is ~35 `list_default` / ~44 `list_key` platform-wide, so codegen reads the formatter; the
+`*-props.yml` `options` and the override keys are cross-checks that warn on drift, not the source.
+
+## Verify (do not skip)
+
+- `lando drush cr`, then render in isolation:
+  `lando drush ev '$b=["#type"=>"component","#component"=>"atomic:<name>","#props"=>[...],"#slots"=>[...]]; print \Drupal::service("renderer")->renderInIsolation($b);'`
+- **Capture a real before/after baseline.** Stash the atomic changes, render an affected page,
+  restore, render again, and diff (strip SDC dev decorations: `data-component-id` and the
+  `🥚/🥜 Component` comments, which only appear with Twig debug on). Confirm byte-identical output.
+- Confirm the JS attaches on a real page (grep the page for the component's `dist/js/*.js`).
+- Run the schema-validation test (`lando composer test:sdc`) and any behavioral tests
+  (`npm run test:unit` in CLT).
+
+## Gotchas cheat-sheet
+
+- SDC does **not** inherit Twig context; props/slots only. `directory` and any other ambient
+  variable a nested include needs must be threaded explicitly.
+- SDC prop validation is **assertion-gated** (dev/tests only). Invalid props throw in dev, silently
+  render in a `--no-dev` prod build. Tests must run with assertions on.
+- A prop and a slot may not share a name (SDC rejects it) — and an SDC slot must not share a name
+  with the CLT block the shim overrides.
+- Prefer `include(..., with_context=false)` / explicit `with { … } only` on the shim's inner embed
+  for isolation, but forward everything the inner template needs (props, slots, `directory`).

--- a/docs/sdc/recipe-convert-a-component-to-sdc.md
+++ b/docs/sdc/recipe-convert-a-component-to-sdc.md
@@ -159,3 +159,16 @@ The split is ~35 `list_default` / ~44 `list_key` platform-wide, so codegen reads
   with the CLT block the shim overrides.
 - Prefer `include(..., with_context=false)` / explicit `with { … } only` on the shim's inner embed
   for isolation, but forward everything the inner template needs (props, slots, `directory`).
+- **Rich content into an auto-escaping sink.** When the CLT template consumes a slot as a *variable*
+  printed with a bare `{{ x }}` (no `|raw`) — e.g. a `<blockquote>{{ quote }}` or `<figcaption>{{ attribution }}` —
+  capturing the slot as a plain string and passing it will **double-escape** rich field markup
+  (the block template feeds a render array whose rendered HTML is already escaped). Capture it as
+  **Markup** instead so the sink doesn't re-escape:
+  `{% set x %}{{ block('slot')|raw }}{% endset %}` (a `{% set %}…{% endset %}` capture is a safe
+  Markup object). If that slot is optional and the template gates on `{% if x %}`, empty it when
+  blank so the check stays falsy: `{% set x = captured|trim is empty ? '' : captured %}`. (Slots
+  whose sink already applies `|raw` — e.g. the text atom — don't need this.)
+- **Don't drop "unused"-looking `{% set %}` vars from a block template.** The pre-SDC `{% include %}`
+  (no `only`) passed block-template variables like `<comp>__width`/`<comp>__alignment` via context
+  inheritance even when they weren't in the `with {…}`. Under SDC they must be explicit props the
+  block template passes. Always capture a real before/after baseline to catch this.

--- a/docs/sdc/recipe-test-a-new-sdc.md
+++ b/docs/sdc/recipe-test-a-new-sdc.md
@@ -1,0 +1,56 @@
+# Recipe: test a new SDC
+
+First-draft from the Wave 0 pilot (epic #1351). Two depths of testing, applied at different times.
+
+## 1. Lightweight schema-validation test — every wave
+
+Cheap, mechanical, no browser, no database. Confirms the authored schema accepts valid data and
+rejects invalid data (wrong enum, missing required) — i.e. that the dial→enum generation is correct
+and can't silently drift. Baked into every wave's own acceptance criteria.
+
+- **Runner:** PHPUnit (Unit), using `justinrainbow/json-schema` (available via `drupal/core-dev`).
+- **Location:** `atomic/tests/src/Unit/SdcSchemaValidationTest.php` (extend it as waves add components).
+- **Run:** `lando composer test:sdc` (filters `--group sdc`).
+- **Pattern:** load the component's `props` schema from its `*.component.yml`, validate a
+  valid-data object (expect no errors) and an invalid-data object (expect errors). Example (Callout
+  invalid dial):
+
+```php
+$errors = $this->validate('callout', ['callout__background_color' => 'not-a-real-theme']);
+$this->assertNotEmpty($errors);
+```
+
+This proves the schema is *correct*, not merely that the file exists. Render-level enforcement —
+that SDC actually applies the schema when assertions are on — was verified on Lando for the pilot
+(an invalid enum throws `Twig\Error\RuntimeError: … Does not have a value in the enumeration`). A
+Kernel test that renders a themed SDC and asserts the throw is a worthwhile follow-up but is
+finicky (theme install + external `@namespace` resolution in the test container); it is not required
+for a wave's sign-off.
+
+## 2. Deep behavioral test — interactive components only (Waves 3b, 6b)
+
+Percy catches visual regressions but is blind to keyboard traps, ARIA that stops updating on toggle,
+focus order breaking after a markup change, and (for Views-driven components) data-shape edge cases.
+Those get real behavioral tests.
+
+- **Runner:** Vitest + jsdom (stood up in Wave 0). Config: `vitest.config.js`. Run: `npm run test:unit`.
+- **Location:** co-located `components/**/<name>.test.js`.
+- **Pattern (interactive, from Accordion):** build a DOM fixture mirroring the rendered markup,
+  load the `Drupal.behaviors.<name>` script (it assigns to a global `Drupal`), `attach()` it, then
+  assert initial state, activation (click — native buttons make this the keyboard path too), ARIA
+  state changes, and any all-items control. See
+  `components/02-molecules/accordion/yds-accordion.test.js`.
+- **Pattern (Views-driven, Wave 6b):** render each display mode with empty / single / many results
+  and a result missing an optional field; assert no crash and correct markup.
+- **Prove the test is meaningful:** temporarily break the behavior it targets and confirm the test
+  fails, then restore. (Verified for Accordion: mutating `expand()` failed 3/5 tests; restoring
+  passed all 5.)
+
+## CI wiring
+
+- **JS (Vitest):** wired into CLT CI — `npm run test` (run by `.github/workflows/test.yml`) now
+  includes `npm run test:unit`.
+- **PHP (schema validation):** runs locally via `lando composer test:sdc`. Wiring it into the
+  yalesites-project CI needs a CI-compatible PHPUnit bootstrap first — the committed `phpunit.xml`
+  hardcodes Lando `/app` paths, so flipping the `unit-test` composer stub blindly would break the
+  build. Tracked as a follow-up (see the epic decisions log).

--- a/docs/sdc/research-spike-1352-canvas-and-web-components.md
+++ b/docs/sdc/research-spike-1352-canvas-and-web-components.md
@@ -1,0 +1,124 @@
+# Research Spike #1352 — Drupal Canvas readiness & external-framework consumption
+
+**Prepared:** 2026-07-02 · **Context:** YaleSites on Drupal core 10.6.12 · Part of Epic #1351
+
+Every load-bearing claim is tagged **CONFIRMED** (with the source that was fetched/surfaced) or
+**INFERRED**. This memo answers the ticket's acceptance criteria and sets two decisions the Wave 0
+pilot depends on: (1) whether the thin-wrapper SDC shape is sufficient, and (2) Shadow DOM vs light
+DOM for the Web Component wrappers.
+
+---
+
+## 1. What our target Canvas version requires structurally from an SDC
+
+**A thin-wrapper SDC is Canvas-ready.** Canvas does **not** require assets to be co-located and does
+**not** require the Twig to be self-contained. What Canvas imposes is a stricter *metadata/schema*
+contract than core SDC. The migration cost is in the schema, not the asset layout.
+
+- CONFIRMED — Minimum SDC is `*.component.yml` + `*.twig`; CSS/JS are optional
+  (project.pages.drupalcode.org/canvas/sdc-components/; core SDC FAQ on drupal.org).
+- CONFIRMED — Assets need not be co-located; the `.component.yml` `libraryOverrides` key attaches
+  external Drupal libraries (Canvas docs: "Required Drupal libraries should be defined in the
+  `libraryOverrides` section"). **This is exactly the thin-wrapper model.**
+- CONFIRMED — A shim Twig may `{% include %}`/`{% embed %}` another template (even by raw path), so a
+  wrapper that delegates rendering to the CLT template is valid SDC.
+- CONFIRMED caveat — `include`/`embed` **bypass the Render API's `#attached`**, so assets on the
+  *included* template do not auto-attach. The clean fix is to declare assets on the *wrapper's own*
+  `libraryOverrides` (the SDC render element attaches that). Known SDC wrinkle, not a Canvas blocker
+  (core issue #3484580).
+
+**Canvas-specific schema constraints beyond core SDC** (author schemas to these NOW so they don't need
+redoing when D11/Canvas arrives — CONFIRMED via Canvas docs + issue queue titles/snippets):
+- Canvas currently **requires a props schema even for slot-only components** (relaxation tracked in
+  canvas #3552069). Give every component a `props` block.
+- **Required props should ship an `example`** (Canvas seeds the editor with it; active work to also
+  accept `default`).
+- **`object`-typed props require a `$ref`**; **image props must be objects** (`{url, alt}`), not bare
+  URL strings; rich-text props render in a reduced CKEditor5 toolbar.
+- Props should carry **`title` + `description`** (they become editor labels); props defined but unused
+  in Twig get flagged.
+
+## 2. Which Canvas / Drupal release to validate against
+
+- CONFIRMED — **Canvas 1.7.1 (2026-07-01) requires Drupal core `^11.2`** (drupal.org/project/canvas).
+  The 1.x line moves fast (1.0 Dec 2025 → 1.7 Jul 2026) with frequent security point releases.
+- Correction to a stale premise circulating in blogs: "latest is 1.3.2 on Core 11.3.5" is **out of
+  date** — authoritative drupal.org data shows 1.7.1.
+- **Recommendation:** do not pin validation to a specific Canvas patch yet. Canvas is unreachable
+  until we're on Core 11.2+, which we are not. Validate Canvas-readiness *indirectly* now by authoring
+  schemas to the Canvas constraints above; do live Canvas validation only once a D11 upgrade lands, and
+  target whatever Canvas minor is current then.
+
+## 3. Exposing a YaleSites component to a non-Drupal team — realistic vs. not
+
+- CONFIRMED — Canvas "Code Components" are **React/JSX** rendered by Preact-compat, stored as config
+  entities, synced by `@drupal-canvas/cli`. The in-browser editor + Code Components are **React-only**;
+  other frameworks need the separate `canvas_extjs` module.
+- **React team:** plausible-but-frictional, and only if we *authored* components as Canvas Code
+  Components — our library is Twig+SCSS SDC, which the CLI does not export. Consuming our existing
+  components this way would be a **rewrite**. (INFERRED from the architecture.)
+- **OutSystems team:** consuming Canvas Code Components as running code is **not realistic** (presumes a
+  React/Preact runtime + Canvas sync toolchain). The only things that cross that boundary are the
+  component *contract* (the `.component.yml` JSON-Schema) or a framework-neutral **Web Component**.
+- **Takeaway:** Canvas Code Components are a Drupal-internal *React* decoupling story, **not** a
+  cross-framework distribution mechanism. For "any team runs our component," the vehicle is a native
+  **Web Component** (see §5), not a Canvas Code Component. Confidence: HIGH.
+
+## 4. Thin-wrapper vs. fully self-contained — recommendation
+
+**Stay with thin wrappers.** Canvas-readiness is a schema-authoring exercise, not a demand to bundle
+self-contained assets. The thin-wrapper shape (schema + Twig shim + `libraryOverrides` → existing CLT
+libraries) is valid SDC *and* valid Canvas SDC. The fully self-contained form remains a possible later
+end-state, not a prerequisite. Confidence: HIGH.
+
+## 5. Shadow DOM vs light DOM for Web Component wrappers — recommendation
+
+**Use Shadow DOM + CSS-custom-property tokens, with `::part()` for structural overrides. Wrap with Lit.**
+
+- CONFIRMED — **CSS custom properties inherit through the shadow boundary** (inheritance resolves on
+  the composed tree); regular CSS rules do not. So tokens defined on `:root` cascade *into* shadow
+  trees. A consumer themes by setting those custom properties from outside; authors expose `::part()`
+  for deeper overrides. (MDN, open-wc, web.dev/Nordhealth, javascript.info.)
+- CONFIRMED — **Carbon, Porsche, and Shoelace/Web Awesome all chose Shadow DOM + CSS-variable tokens**
+  (+ `::part()`); Carbon and Shoelace/Web Awesome are built on **Lit**. (Their own styling docs.)
+- CONFIRMED — **OutSystems supports importing custom Web Components and theming only via CSS custom
+  properties across the shadow boundary** (OutSystems Eng. blog "Web Components: A Native Component
+  Model for UI"). It's a "high-code" path: register the custom element manually (e.g. layout
+  `OnReady`), ship compiled CSS (no in-app Sass), external stylesheets via `@import`.
+- **Why this fits YaleSites:** our design tokens are *already* CSS custom properties (the `tokens`
+  repo / `:root`), so token-piercing works for free once component internals use `var(--token)`.
+
+**Honest costs (not blockers):** we must publish + maintain an explicit theming API (which tokens +
+which `::part()`s); component SCSS must be pulled into the shadow root (mechanical, since tokens are
+already variables); SSR for consumers needs Declarative Shadow DOM; consumers who want to restyle
+un-exposed internals will be frustrated (mitigate with generous `::part()`).
+
+**Tooling:** **Lit** — ~5 KB, no build step required, closest to the standard, handles Shadow DOM +
+`static styles` + reactive props with minimal boilerplate; matches Carbon/Shoelace prior art. The
+unavoidable, tool-independent work: Twig can't run client-side, so each wrapped component's markup is
+re-expressed once as a Lit template (or produced server-side as Declarative Shadow DOM), compiled SCSS
+moves into the shadow `styles`, and `Drupal.behaviors` init moves into `connectedCallback`/
+`firstUpdated`. Vanilla `customElements` is the zero-dependency alternative; Stencil only earns its
+complexity if we must auto-generate typed React/Vue/Angular wrapper packages simultaneously.
+
+## 6. Drupal 11 roadmap — TEAM QUESTION (external facts only)
+
+- CONFIRMED — **Drupal 10 EOL is 2026-12-09**; 10.6 is the *final* D10 minor (security support to Dec
+  2026). Drupal 11 stable line is 11.3.x; next milestone D11.5/D12.0 ~week of 2026-12-07.
+- CONFIRMED — Canvas needs Core `^11.2`, so **Canvas is strictly downstream of a D11 upgrade**.
+- **I cannot confirm YaleSites' internal upgrade roadmap.** External facts say a Core 11 upgrade is a
+  hard deadline (~5 months out from this memo) *independent of Canvas*. **→ Team question: is a D11
+  upgrade scheduled, and when?** That answer determines how soon the Canvas half of Goal 2 matters
+  (near-term vs. Phase 4+).
+
+---
+
+## Lowest-confidence claims to double-check before this drives a decision
+(a) Porsche v4 still Stencil-built (INFERRED — not load-bearing); (b) exact current D11 patch level
+(search-surfaced, not fetched from the schedule page); (c) Canvas's precise PHP pin (INFERRED from
+D11's PHP 8.3+ floor). None change the recommendations.
+
+## Net decisions handed to Wave 0
+1. Thin-wrapper SDC + `libraryOverrides` — proceed.
+2. Author schemas with typed props + `title`/`description`/`example` (Canvas-forward).
+3. Web Component wrappers: Shadow DOM + CSS-custom-property tokens + `::part()`, built with Lit.

--- a/docs/sdc/wave-8-storybook-only-audit.md
+++ b/docs/sdc/wave-8-storybook-only-audit.md
@@ -1,0 +1,53 @@
+# Wave 8 (#1363) — Storybook-only completion audit
+
+Epic [#1351](https://github.com/yalesites-org/YaleSites-Internal/issues/1351), ticket #1363.
+
+Wave 8 asks us to complete the SDC migration for components that exist only in
+Storybook (no Drupal render path) and to delete genuinely-stale ones. This audit
+is the deliverable: a full inventory of what remains, its disposition, and the
+deletion candidates that need maintainer sign-off before removal.
+
+**Headline finding: there is no Storybook-only component that is both
+SDC-appropriate and independent of the in-flight Views rework.** The 26 already
+converted components are the ones that fit the thin-wrapper SDC pattern. What is
+left in Storybook-without-a-render-path is demos, tokens, page examples, internal
+sub-partials, or the Views/calendar-coupled `modal`. So Wave 8 is not a
+"convert N more components" wave; it is a **re-scope / clean-up decision** for you.
+
+Method: every non-visreg `*.stories.js` and every `yds-*.twig` entry template in
+CLT was cross-referenced against all `@atoms|@molecules|@organisms` includes/embeds
+across the whole repo (the `atomic` theme and the profile modules `ys_core`,
+`ys_layouts`, `ys_views_basic`, `ys_views_content_resources`).
+
+## Inventory and disposition
+
+| Component / area | Tier | Disposition | Reason |
+|---|---|---|---|
+| `modal` (`yds-modal.twig` + JS) | molecule | **Convert later, coupled** | Real JS overlay, but embedded inside the Views-driven `calendar` organism (special-cases `id == 'calendar-modal'`). Not editor-placeable; conversion belongs with the interactive-molecule set (#1356) and is coupled to the Views/calendar work. Not a standalone Wave 8 win. |
+| `menu`, `menu-toggle`, `menu-in-this-section-toggle`, `link-group` | molecules | **Keep as-is** | Internal building blocks embedded in nav organisms / the footer; not standalone components. |
+| `secondary-nav` | organism | **Keep as-is** | Embedded in `site-in-this-section` (rendered via `book-tree.html.twig`). |
+| `00-tokens/*`, `00-introduction/*` | atoms | **Keep as Storybook docs** | Token/color-swatch displays and documentation, not components. |
+| `controls/control.stories.js`, `images/images.stories.js`, `galleries/gallery.stories.js` | atoms/orgs | **Keep as demo stories** | Aggregator stories over components that are already rendered elsewhere. |
+| `images/fa-icons/yds-fa-icons.twig` | atom | **Keep (demo)** | A demo loop like `icons`; the real icon is the `_yds-fa-icon` partial. Not even in Storybook (`no .stories.js`). |
+| `utility-nav/yds-utility-nav--example.twig` | organism | **Not a clean delete** | An `--example` demo file, but still referenced by `utility-nav.visreg.stories.js` and `_yds-utility-nav.scss` — removing it would break the visreg story and an SCSS reference, so it is not a safe standalone deletion. |
+| `04-page-layouts/*`, `05-page-examples/*` | page tiers | **Keep** | Page-layout tier and full-page Storybook demos; out of the component-SDC scope. |
+| `button`, `tables`, `icons`, forms (checkbox/radio/select/textfields) | atoms | **Keep (already documented non-convertible)** | SCSS-only / JS-on-WYSIWYG / demo-vs-partial / Form-API driven. See the Wave 1 notes in the epic log. |
+
+## Deletion candidates (need your sign-off)
+
+**None that are clean.** The sweep surfaced one demo file
+(`yds-utility-nav--example.twig`), but it is still referenced by its own visreg
+story and by `_yds-utility-nav.scss`, so it cannot be removed without also updating
+those — not a safe standalone deletion. The token/intro/page-example stories are
+legitimate Storybook documentation and should stay. I did **not** delete anything —
+deletion of shared library files is exactly the kind of irreversible, sign-off-gated
+action to leave to you.
+
+## Recommendation
+
+**Re-scope or close #1363.** There is no SDC conversion work here that is both
+appropriate and independent of the Views rework, and no clean stale-file deletion.
+The concrete actions are: (a) decide whether the `--example` demo is worth removing
+(and updating its visreg story + SCSS), and (b) fold `modal` into the
+interactive-molecule conversion set (#1356) once the Views/calendar work settles,
+rather than treating it as a Wave 8 item.

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "exports-loader": "^1.1.1",
         "husky": "^9.0.11",
         "js-yaml-loader": "^1.2.2",
+        "jsdom": "^25.0.1",
         "lint-staged": "^15.2.7",
         "postcss": "^8.4.29",
         "postcss-loader": "^7.3.3",
@@ -64,6 +65,7 @@
         "storybook": "^8.3.6",
         "style-loader": "^2.0.0",
         "twig-loader": "https://github.com/fourkitchens/twig-loader",
+        "vitest": "^2.1.9",
         "webpack-cli": "^5.1.4"
       }
     },
@@ -79,6 +81,25 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.25.9",
@@ -1811,10 +1832,10 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.2.tgz",
-      "integrity": "sha512-6tC/MnlEvs5suR4Ahef4YlBccJDHZuxGsAlxXmybWjZ5jPxlzLSMlRZ9mVHSRvlD+CmtE7+hJ+UQbfXrws/rUQ==",
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
       "funding": [
         {
@@ -1826,18 +1847,37 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.2"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
-    "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.2.tgz",
-      "integrity": "sha512-IuTRcD53WHsXPCZ6W7ubfGqReTJ9Ra0yRRFmXYP/Re8hFYYfoIYIK4080X5luslVLWimhIeFq0hj09urVMQzTw==",
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "dev": true,
       "funding": [
         {
@@ -1849,7 +1889,55 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
         "node": ">=18"
       }
@@ -3310,6 +3398,331 @@
         "node": ">=12"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4682,9 +5095,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -5143,6 +5556,112 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -5872,6 +6391,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -5913,6 +6441,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/async-throttle/-/async-throttle-1.1.0.tgz",
       "integrity": "sha512-t5kQ/BRlYTNG2GsQue48DeKByahFGGHtC8w7LCEl1sGHbAgpthKXX6U2GL1t6xI89rWxCDc/xzEOW/8ObrZH0Q=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -6700,6 +7234,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cacache": {
       "version": "10.0.4",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
@@ -6879,6 +7422,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/call-me-maybe": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
@@ -6973,6 +7528,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -7044,6 +7615,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -7613,6 +8193,18 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "8.3.0",
@@ -8471,6 +9063,25 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -8510,6 +9121,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -8617,6 +9284,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -8789,6 +9462,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -8936,6 +9618,15 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -9159,6 +9850,19 @@
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer2": {
@@ -9496,12 +10200,9 @@
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "engines": {
         "node": ">= 0.4"
       }
@@ -9546,9 +10247,9 @@
       "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -9557,13 +10258,14 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10332,6 +11034,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -10578,6 +11289,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exports-loader": {
@@ -11330,6 +12050,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -11512,21 +12248,38 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-proxy": {
@@ -11906,11 +12659,11 @@
       "peer": true
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12057,9 +12810,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -12171,9 +12924,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -12285,6 +13038,18 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/html-entities": {
       "version": "2.5.2",
@@ -13837,6 +14602,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -14287,6 +15058,113 @@
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -14999,6 +15877,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
     "node_modules/lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
@@ -15318,6 +16202,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -19132,6 +20024,12 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -19877,6 +20775,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pend": {
@@ -21452,6 +22365,56 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -21650,6 +22613,18 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -22676,6 +23651,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -23122,6 +24103,12 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -23165,6 +24152,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "node_modules/storybook": {
       "version": "8.3.6",
@@ -25112,6 +26105,12 @@
         "upper-case": "^1.1.1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "node_modules/table": {
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
@@ -25488,11 +26487,44 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "dev": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
     "node_modules/tinyexec": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
       "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
       "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/title-case": {
       "version": "2.1.1",
@@ -25502,6 +26534,24 @@
         "no-case": "^2.2.0",
         "upper-case": "^1.0.3"
       }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true
     },
     "node_modules/to-buffer": {
       "version": "1.1.1",
@@ -25562,6 +26612,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -26457,6 +27519,570 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walk": {
       "version": "2.3.15",
       "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
@@ -26780,6 +28406,40 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -26894,6 +28554,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wildcard": {
@@ -27012,6 +28688,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "storybook": "storybook dev --ci ./dist, ./images -p 6006",
     "storybook:build": "npm run build && storybook build ./dist, ./images -o .out",
     "storybook:deploy": "storybook-to-ghpages -o .out",
-    "test": "npm run lint:js && npm run lint:styles && npm run prettier && npm run storybook:build",
+    "test": "npm run lint:js && npm run lint:styles && npm run prettier && npm run test:unit && npm run storybook:build",
     "visreg:ci": "percy storybook .out",
-    "webpack": "webpack --watch --config ./webpack/webpack.dev.js"
+    "webpack": "webpack --watch --config ./webpack/webpack.dev.js",
+    "test:unit": "vitest run"
   },
   "devDependencies": {
     "@babel/core": "^7.16.7",
@@ -50,6 +51,7 @@
     "exports-loader": "^1.1.1",
     "husky": "^9.0.11",
     "js-yaml-loader": "^1.2.2",
+    "jsdom": "^25.0.1",
     "lint-staged": "^15.2.7",
     "postcss": "^8.4.29",
     "postcss-loader": "^7.3.3",
@@ -59,6 +61,7 @@
     "storybook": "^8.3.6",
     "style-loader": "^2.0.0",
     "twig-loader": "https://github.com/fourkitchens/twig-loader",
+    "vitest": "^2.1.9",
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Unit/behavioral test runner for the component library (epic #1351, Wave 0).
+// Percy covers visual regression; Vitest covers behavior Percy is blind to
+// (keyboard operation, focus, ARIA state changes on interaction).
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['components/**/*.test.js'],
+    globals: true,
+  },
+});

--- a/web-components/OUTSYSTEMS.md
+++ b/web-components/OUTSYSTEMS.md
@@ -1,0 +1,116 @@
+# Consuming YaleSites Web Components in OutSystems
+
+How a non-Drupal OutSystems team consumes this package. This is the achievable
+half of the epic #1351 / Wave 10 (#1365) OutSystems proof-of-concept. The
+integration path below is documented and ready; the **live tenant demo is blocked**
+pending access to an OutSystems environment (see "What is blocked").
+
+The direction comes from the research spike
+([`../docs/sdc/research-spike-1352-canvas-and-web-components.md`](../docs/sdc/research-spike-1352-canvas-and-web-components.md)):
+OutSystems can import framework-neutral custom elements, and the only theming
+channel it accepts across the shadow boundary is **CSS custom properties** — which
+is exactly why these components are built with Lit + Shadow DOM + token-based
+theming.
+
+## Why a Web Component (not a Canvas Code Component)
+
+Drupal Canvas "Code Components" are React/JSX synced by a Canvas CLI and run on a
+Preact-compat runtime — a Drupal-internal decoupling story, not a cross-framework
+distribution vehicle. Nothing about that toolchain runs in OutSystems. The only
+artifacts that cross into OutSystems are the component *contract* (the
+`.component.yml` schema) or a native **custom element**. This package is that
+custom element.
+
+## The integration path (high-code, per OutSystems docs)
+
+OutSystems treats custom Web Components as a "high-code" extension. The steps:
+
+### 1. Host the compiled bundle
+
+Run the package build and host the ESM output on a URL the OutSystems app can
+reach (a Resource in the module, or a CDN):
+
+```bash
+npm install
+npm run build      # emits dist/*.js (ESM, Lit bundled in — no import map needed)
+```
+
+Ship `dist/yalesites-web-components.js` (registers every element) or a
+per-component bundle (`dist/yds-divider.js`, `dist/yds-accordion.js`).
+
+### 2. Register the element(s)
+
+Load the module as an ES module script so the `customElements.define(...)` calls
+run. In OutSystems this typically goes in a layout/screen "OnReady" client action
+or a `<script type="module">` require, since the definitions must exist before the
+tags are parsed into live elements:
+
+```html
+<script type="module" src="/resources/yalesites-web-components.js"></script>
+```
+
+### 3. Place the tags
+
+Use the custom elements directly in the screen markup. Scalar options are
+attributes; array/object inputs are JS **properties** (set from a client action,
+because HTML attributes are strings only):
+
+```html
+<yds-divider width="50" position="left"></yds-divider>
+
+<yds-accordion heading="FAQ" theme="one"></yds-accordion>
+```
+
+```javascript
+// client-side, after the element is in the DOM:
+document.querySelector('yds-accordion').items = [
+  { heading: 'Question', content: '<p>Answer with <strong>HTML</strong>.</p>' },
+];
+```
+
+### 4. Theme with CSS custom properties (the only channel that crosses the boundary)
+
+OutSystems cannot restyle shadow-DOM internals with ordinary CSS, and it does not
+run Sass in-app. Ship **compiled** CSS and set the design tokens on an ancestor
+(custom properties inherit through the shadow boundary):
+
+```css
+/* an OutSystems theme stylesheet, or an @import of the compiled tokens */
+:root {
+  --color-divider: #00356b;      /* Yale blue */
+  --color-slot-one: #00356b;     /* accordion accent */
+}
+```
+
+To get the full, real Yale token set rather than the per-`var()` fallbacks baked
+into each component, `@import` the compiled token stylesheet
+(`@yalesites-org/tokens/build/css/tokens.css`) into the OutSystems theme. For
+structural overrides a token cannot reach, use the exposed `::part()` hooks
+(see the component tables in [`README.md`](README.md)):
+
+```css
+yds-accordion::part(toggle) { text-transform: uppercase; }
+```
+
+## What is confirmed vs. what is blocked
+
+**Confirmed (from the research spike, sources cited there):** OutSystems supports
+importing custom Web Components; theming across the shadow boundary is via CSS
+custom properties; it is a high-code path (manual element registration, compiled
+CSS, external stylesheets via `@import`). The package is built to match all three.
+
+**Blocked — needs a human with an OutSystems tenant:** actually importing the
+bundle into an OutSystems module, wiring the OnReady registration, and confirming
+the elements render and theme correctly in a running OutSystems app. This cannot
+be done from this environment (no OutSystems access). It is the one remaining
+Wave 10 acceptance-criterion item, and it needs an OutSystems developer to run
+the steps above and report back. Everything they need — the built bundle, the
+registration snippet, the attribute/property/`::part()` contract, and the theming
+approach — is in this package and its README.
+
+## Note on the trust model
+
+The accordion injects item `content` (and harvested light-DOM innerHTML) with
+Lit's `unsafeHTML`, mirroring the source Twig, which prints author-provided rich
+text. Do **not** pass untrusted or end-user-supplied HTML into `content` without
+sanitizing it first (e.g. DOMPurify) — this applies equally in an OutSystems host.

--- a/web-components/README.md
+++ b/web-components/README.md
@@ -1,0 +1,193 @@
+# YaleSites Web Components — Wave 0 pilot
+
+A **proof of concept** (epic #1351 / ticket #1353) that the YaleSites design system can
+be consumed outside Drupal. It wraps two existing components — a trivial static one
+(`<yds-divider>`) and a harder one with JavaScript behavior (`<yds-accordion>`) — as
+framework-neutral [custom elements](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)
+built with [Lit](https://lit.dev).
+
+This is intentionally small and self-contained. It does **not** package the whole
+library — that is Wave 10. Treat this README as the first draft of the
+"Wrap an SDC as a Web Component" recipe; it will be extended in Wave 10.
+
+The approach follows the research spike decision
+(`docs/sdc/research-spike-1352-canvas-and-web-components.md`):
+**Lit + Shadow DOM + CSS custom properties for theming, with `::part()` hooks.**
+
+---
+
+## Quick start
+
+```bash
+cd web-components
+nvm use            # Node 20.14.0 (repo .nvmrc); system Node 20+ also works
+npm install
+npm run build      # bundles to ./dist as ESM (Lit included)
+```
+
+Then view the no-Drupal demo. ES module scripts do not load over `file://`, so serve
+over HTTP:
+
+```bash
+# from web-components/
+npx http-server . -o /demo/
+# or
+python3 -m http.server   # then open http://localhost:8000/demo/
+```
+
+## Consuming the package
+
+The build emits ESM with Lit bundled in, so a consumer needs no build step and no
+import map — just import the file and use the tags:
+
+```html
+<script type="module" src="/path/to/yalesites-web-components.js"></script>
+
+<yds-divider width="50" position="left"></yds-divider>
+
+<yds-accordion heading="FAQ" theme="one"></yds-accordion>
+<script type="module">
+  document.querySelector("yds-accordion").items = [
+    { heading: "Question", content: "<p>Answer with <strong>HTML</strong>.</p>" },
+  ];
+</script>
+```
+
+Per-component bundles are also emitted (`dist/yds-divider.js`, `dist/yds-accordion.js`)
+for consumers who only want one element.
+
+---
+
+## The recipe: wrapping an SDC as a Web Component
+
+### 1. Re-express the markup (Twig cannot run client-side)
+
+Each SDC's `.twig` is authored once as a Lit `render()` template. This is unavoidable,
+tool-independent work: there is no browser Twig runtime, so the DOM structure and BEM
+class names are reproduced by hand. Keep the class names identical so ported SCSS
+selectors keep matching.
+
+### 2. Move the SCSS into the shadow root
+
+The component's compiled styles live in Lit's `static styles = css\`...\``, scoped to the
+shadow root. Regular CSS selectors do **not** cross the shadow boundary, which is what
+gives the component style isolation.
+
+### 3. Theme with CSS custom properties (the key move)
+
+CSS custom properties **inherit through the shadow boundary** — they resolve on the
+composed tree. YaleSites design tokens (`@yalesites-org/tokens`) are already CSS custom
+properties, so component internals just reference them:
+
+```css
+.divider {
+  background: var(--color-divider, var(--color-gray-500, hsl(0, 0%, 46%)));
+}
+```
+
+A consumer themes by setting those properties on any ancestor (typically `:root`):
+
+```css
+:root {
+  --color-divider: rebeccapurple;
+}
+```
+
+Every `var()` here ships a **fallback**, so the component renders correctly even when no
+token stylesheet is loaded. Load `@yalesites-org/tokens/build/css/tokens.css` to get the
+full, real Yale token set.
+
+### 4. Add `::part()` for structural overrides
+
+Custom properties re-theme values; `::part()` lets a consumer restyle internal elements
+a token cannot reach:
+
+```css
+yds-accordion::part(toggle) {
+  text-transform: uppercase;
+}
+```
+
+### 5. Port JS behavior into the Lit lifecycle
+
+The Drupal behavior (`Drupal.behaviors.*.attach`) moves into Lit's reactive cycle:
+- initial state (accordion: "collapse all on attach") → the constructor / `willUpdate`
+- event wiring → declarative `@click` bindings in the template
+- imperative DOM reads that must run after render (accordion: measuring
+  `scrollHeight` to animate panel height) → `updated()` / `firstUpdated()`
+
+### Prop / slot → attribute / property / slot mapping
+
+| SDC concept | Web Component surface |
+| --- | --- |
+| Scalar Twig variable (e.g. `divider__width`) | reflected **attribute** (`width="50"`) |
+| Enum variable (e.g. `divider__position`) | attribute with validation in `render()` |
+| Array/object variable (e.g. `accordion__items`) | JS **property** (`el.items = [...]`) — attributes are strings only |
+| Rich-text/HTML variable | JS property (string of HTML), injected with `unsafeHTML` |
+| Twig `{% block %}` / children | light-DOM **slots** (here: `data-accordion-heading` children, harvested) |
+| Component theme (`data-component-theme`) | `theme` attribute → `data-component-theme` + token overrides |
+
+---
+
+## Components
+
+### `<yds-divider>`
+
+| Attribute | Values | Default | Notes |
+| --- | --- | --- | --- |
+| `width` | `100` `75` `50` `25` | `100` | Width as a % of the container |
+| `position` | `left` `center` | `center` | Horizontal alignment |
+
+Parts: `wrapper`, `inner`, `divider`. Recolor with `--color-divider`; resize the line
+with `--thickness-divider`.
+
+### `<yds-accordion>`
+
+| Attribute / property | Values | Default | Notes |
+| --- | --- | --- | --- |
+| `heading` (attr) | string | — | Optional group heading above all items |
+| `theme` (attr) | `default` `one`–`five` | `default` | Color accent |
+| `alignment` (attr) | `center` `left` | `center` | |
+| `items` (property) | `Array<{heading, content}>` | `[]` | `content` is an HTML string |
+
+Items can also be authored in light DOM as child elements with
+`data-accordion-heading` (their innerHTML becomes the panel body). Behavior: per-item
+expand/collapse, an "Expand All / Collapse All" toggle (shown only with 2+ items), and
+native keyboard operation (headers are real `<button>`s, so Enter/Space work).
+
+Parts: `accordion`, `inner`, `heading`, `controls`, `toggle-all`, `item`,
+`item-heading`, `toggle`, `content`, `icon`. Accent color follows
+`--color-accordion-accent` (or the underlying `--color-slot-*` tokens).
+
+---
+
+## Honest limitations
+
+- **Markup is re-expressed, not shared.** Twig cannot run in the browser, so each
+  wrapped component duplicates the source template's structure by hand. The two
+  representations can drift; keeping them in sync is manual until a generation step
+  exists.
+- **SSR needs Declarative Shadow DOM.** These components render client-side. Server-side
+  rendering for consumers requires emitting
+  [Declarative Shadow DOM](https://web.dev/articles/declarative-shadow-dom) (e.g. via
+  `@lit-labs/ssr`); not covered in Wave 0.
+- **`unsafeHTML` trust model.** Accordion `content` (and harvested light-DOM innerHTML)
+  is injected with Lit's `unsafeHTML`, matching the source Twig, which prints
+  author-provided rich text. Do **not** pass untrusted/user-supplied HTML without
+  sanitizing it first.
+- **Light-DOM harvesting is timing-sensitive.** Child items are read once in
+  `connectedCallback`. With deferred module scripts (as in the demo) the children are
+  parsed first, so this is safe — but the `items` **property** is the robust,
+  order-independent path.
+- **Theme fidelity is partial.** The full accordion SCSS resolves color slots across
+  global + component themes; this pilot ports the default theme plus the non-default
+  accent-bar treatment and maps `theme="one".."five"` to `--color-slot-*`. Full
+  slot/global-theme fidelity is deferred.
+- **No automated tests yet.** Verified via build + syntax parse; browser/interaction
+  verification is a manual step (see the demo).
+
+## Scope note
+
+Nothing here touches the existing webpack/Storybook build. This directory is fully
+self-contained: its own `package.json`, its own `esbuild` build (`build.mjs`), its own
+`dist/`. Removing `web-components/` leaves the library build untouched.

--- a/web-components/README.md
+++ b/web-components/README.md
@@ -1,18 +1,23 @@
-# YaleSites Web Components — Wave 0 pilot
+# YaleSites Web Components
 
-A **proof of concept** (epic #1351 / ticket #1353) that the YaleSites design system can
-be consumed outside Drupal. It wraps two existing components — a trivial static one
-(`<yds-divider>`) and a harder one with JavaScript behavior (`<yds-accordion>`) — as
-framework-neutral [custom elements](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)
-built with [Lit](https://lit.dev).
+The framework-neutral distribution of YaleSites design-system components as
+[custom elements](https://developer.mozilla.org/en-US/docs/Web/API/Web_components),
+built with [Lit](https://lit.dev). It lets non-Drupal teams consume YaleSites
+components (epic #1351 — pilot in #1353, distribution package in #1365 / Wave 10).
 
-This is intentionally small and self-contained. It does **not** package the whole
-library — that is Wave 10. Treat this README as the first draft of the
-"Wrap an SDC as a Web Component" recipe; it will be extended in Wave 10.
+**Scope, honestly:** the package infrastructure is complete — a self-contained
+build, a behavioral test suite, publish-ready packaging, and an OutSystems
+integration guide. **Two** components are wrapped so far: a trivial static one
+(`<yds-divider>`) and a harder one with JavaScript behavior (`<yds-accordion>`).
+Wrapping the rest of the library is per-component work that reuses the recipe below
+(each SDC's Twig is re-expressed once as a Lit template — see "Honest limitations").
 
 The approach follows the research spike decision
-(`docs/sdc/research-spike-1352-canvas-and-web-components.md`):
+(`../docs/sdc/research-spike-1352-canvas-and-web-components.md`):
 **Lit + Shadow DOM + CSS custom properties for theming, with `::part()` hooks.**
+
+To consume this package from OutSystems specifically, see
+[`OUTSYSTEMS.md`](OUTSYSTEMS.md).
 
 ---
 
@@ -23,6 +28,7 @@ cd web-components
 nvm use            # Node 20.14.0 (repo .nvmrc); system Node 20+ also works
 npm install
 npm run build      # bundles to ./dist as ESM (Lit included)
+npm test           # behavioral tests (Vitest + jsdom)
 ```
 
 Then view the no-Drupal demo. ES module scripts do not load over `file://`, so serve
@@ -183,11 +189,34 @@ Parts: `accordion`, `inner`, `heading`, `controls`, `toggle-all`, `item`,
   global + component themes; this pilot ports the default theme plus the non-default
   accent-bar treatment and maps `theme="one".."five"` to `--color-slot-*`. Full
   slot/global-theme fidelity is deferred.
-- **No automated tests yet.** Verified via build + syntax parse; browser/interaction
-  verification is a manual step (see the demo).
+
+## Testing
+
+Behavioral tests run in Vitest + jsdom (`test/*.test.js`), covering what Percy
+cannot see: divider enum-validation fallbacks and separator semantics; accordion
+collapse-on-attach, per-item toggle ARIA, the "toggle all" control (present only
+with 2+ items), light-DOM item harvesting, rich-content injection, and heading-level
+outline (h2 vs h3 with a group heading).
+
+```bash
+npm test           # vitest run
+```
+
+Each test was mutation-verified (breaking the targeted behavior fails exactly the
+test that covers it). New wrapped components should add a co-located
+`test/<name>.test.js` in the same style.
+
+## Publishing
+
+The package is configured for publication to GitHub Packages
+(`publishConfig.registry`); `prepublishOnly` runs `check`, `test`, and `build` so a
+release always ships a fresh, tested bundle. Publishing itself is a **gated human
+step** — it needs the `@yalesites-org` registry auth (`YALESITES_BUILD_TOKEN`) and
+team sign-off, and is intentionally not automated here.
 
 ## Scope note
 
 Nothing here touches the existing webpack/Storybook build. This directory is fully
-self-contained: its own `package.json`, its own `esbuild` build (`build.mjs`), its own
-`dist/`. Removing `web-components/` leaves the library build untouched.
+self-contained: its own `package.json`, its own `esbuild` build (`build.mjs`), its
+own Vitest config, its own `dist/`. Removing `web-components/` leaves the library
+build untouched.

--- a/web-components/build.mjs
+++ b/web-components/build.mjs
@@ -1,0 +1,27 @@
+// Minimal, self-contained build for the Wave 0 Web Component wrappers.
+//
+// Deliberately independent of the main webpack/Storybook build so it cannot
+// disturb the existing component library pipeline. Produces distributable ESM
+// with Lit bundled in, so a consumer needs no build step and no import map:
+// just `import` the output file.
+import { build } from 'esbuild';
+
+const shared = {
+  bundle: true,
+  format: 'esm',
+  target: 'es2020',
+  sourcemap: true,
+  logLevel: 'info',
+};
+
+const entries = [
+  // Combined bundle — registers both elements.
+  { entryPoints: ['src/index.js'], outfile: 'dist/yalesites-web-components.js', minify: true },
+  // Per-component bundles for consumers who only want one element.
+  { entryPoints: ['src/yds-divider.js'], outfile: 'dist/yds-divider.js', minify: true },
+  { entryPoints: ['src/yds-accordion.js'], outfile: 'dist/yds-accordion.js', minify: true },
+];
+
+await Promise.all(entries.map((entry) => build({ ...shared, ...entry })));
+
+console.log('Build complete -> web-components/dist/');

--- a/web-components/demo/index.html
+++ b/web-components/demo/index.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>YaleSites Web Components — Wave 0 demo</title>
+
+    <!--
+      This page uses ZERO Drupal. It imports the built ESM bundle and renders both
+      wrapped components as native custom elements.
+
+      Prerequisites:
+        1. cd web-components && npm install && npm run build   (creates dist/)
+        2. Serve this folder over HTTP (ES module scripts do not load over file://):
+             npx http-server web-components   →  open /demo/
+           or from web-components/:  python3 -m http.server  →  open /demo/
+
+      Optional — load the real Yale design tokens to see full-fidelity theming.
+      The components have sensible fallbacks and render without this, but with it
+      the actual Yale token values pierce the shadow boundary. Path is relative to
+      this file; enable it when serving from the component-library-twig repo root:
+
+      <link rel="stylesheet"
+            href="../../node_modules/@yalesites-org/tokens/build/css/tokens.css" />
+    -->
+
+    <style>
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+          sans-serif;
+        line-height: 1.5;
+        margin: 0;
+        padding: 2rem clamp(1rem, 5vw, 4rem);
+        max-width: 60rem;
+        color: hsl(0, 0%, 13%);
+      }
+
+      h1 {
+        margin-top: 0;
+      }
+
+      section {
+        margin-block: 3rem;
+      }
+
+      .note {
+        background: hsl(0, 0%, 97%);
+        border-left: 4px solid hsl(210, 100%, 21%);
+        padding: 0.75rem 1rem;
+        font-size: 0.9rem;
+      }
+
+      code {
+        background: hsl(0, 0%, 95%);
+        padding: 0.1em 0.35em;
+        border-radius: 3px;
+        font-size: 0.9em;
+      }
+
+      /*
+       * THEMING VIA CSS CUSTOM PROPERTIES.
+       * These properties are set in the light DOM but inherit THROUGH the shadow
+       * boundary into each component's shadow root — this is the whole theming
+       * story. The scoped block below re-themes only the components inside
+       * .themed-scope, proving tokens can be overridden per-subtree.
+       */
+      .themed-scope {
+        --color-divider: hsl(350, 70%, 45%); /* recolor the divider line */
+        --color-slot-one: hsl(28, 90%, 45%); /* accordion accent (theme "one") */
+        --color-link-base: hsl(28, 90%, 40%); /* hover color */
+      }
+    </style>
+  </head>
+  <body>
+    <h1>YaleSites Web Components — Wave 0 demo</h1>
+    <p>
+      A proof that two YaleSites components can run as framework-neutral custom
+      elements, with <strong>no Drupal, no Twig, and no framework</strong>. Built with
+      Lit + Shadow DOM; themed with CSS custom properties (design tokens) that pierce
+      the shadow boundary.
+    </p>
+
+    <section>
+      <h2>&lt;yds-divider&gt;</h2>
+      <p>Width 100 / 75 / 50 / 25, centered:</p>
+      <yds-divider width="100"></yds-divider>
+      <yds-divider width="75"></yds-divider>
+      <yds-divider width="50"></yds-divider>
+      <yds-divider width="25"></yds-divider>
+
+      <p>Width 50, left-aligned:</p>
+      <yds-divider width="50" position="left"></yds-divider>
+    </section>
+
+    <section>
+      <h2>&lt;yds-accordion&gt; — items via JS property</h2>
+      <p class="note">
+        Items set with <code>element.items = [{ heading, content }]</code>. Click a
+        header (or focus it and press Enter/Space) to expand; "Expand All" toggles
+        every panel.
+      </p>
+      <yds-accordion id="accordion-js" heading="List of Art Collections"></yds-accordion>
+    </section>
+
+    <section>
+      <h2>&lt;yds-accordion&gt; — items authored in light DOM</h2>
+      <p class="note">
+        Panels declared as child elements carrying
+        <code>data-accordion-heading</code>; their inner HTML becomes the panel body.
+      </p>
+      <yds-accordion heading="Frequently asked questions">
+        <div data-accordion-heading="How do I request a new site?">
+          <p>
+            Submit a request through the YaleSites intake form. Eligibility is
+            reviewed by the platform team.
+          </p>
+        </div>
+        <div data-accordion-heading="Can I use my own components?">
+          <p>
+            The design system is the supported path. This Wave 0 pilot explores
+            consuming those components outside Drupal as Web Components.
+          </p>
+        </div>
+        <div data-accordion-heading="Where do design tokens come from?">
+          <p>
+            From <code>@yalesites-org/tokens</code>, exposed as CSS custom
+            properties that inherit into each component's shadow root.
+          </p>
+        </div>
+      </yds-accordion>
+    </section>
+
+    <section class="themed-scope">
+      <h2>Theming via CSS custom properties</h2>
+      <p class="note">
+        Everything in this section sits inside <code>.themed-scope</code>, which sets
+        a few custom properties on the light-DOM ancestor. Those values inherit into
+        each shadow root and restyle the internals — no build, no per-component API.
+        The divider turns red; the themed accordion accent turns orange.
+      </p>
+      <yds-divider width="75"></yds-divider>
+      <yds-accordion id="accordion-themed" theme="one" heading="Themed accordion"></yds-accordion>
+    </section>
+
+    <script type="module">
+      import "../dist/yalesites-web-components.js";
+
+      const items = [
+        {
+          heading: "Art Collections",
+          content:
+            '<p>The Yale Center for British Art presents rotating exhibitions drawn from the most comprehensive collection of British art outside the United Kingdom. Displays span painting, sculpture, drawings, prints, and rare books.</p>',
+        },
+        {
+          heading: "Music Library",
+          content:
+            '<p>The Gilmore Music Library holds scores, recordings, and archival collections documenting centuries of musical scholarship and performance.</p><p>Reading rooms are open to researchers by appointment.</p>',
+        },
+        {
+          heading: "Peabody Museum",
+          content:
+            '<p>The Yale Peabody Museum stewards more than thirteen million specimens and objects across anthropology, paleontology, and the natural sciences.</p>',
+        },
+      ];
+
+      // Setting a property (not an attribute) is the robust authoring path.
+      document.getElementById("accordion-js").items = items;
+      document.getElementById("accordion-themed").items = items;
+    </script>
+  </body>
+</html>

--- a/web-components/package-lock.json
+++ b/web-components/package-lock.json
@@ -11,7 +11,132 @@
         "lit": "^3.1.0"
       },
       "devDependencies": {
-        "esbuild": "^0.25.0"
+        "esbuild": "^0.25.0",
+        "jsdom": "^25.0.1",
+        "vitest": "^2.1.9"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -430,6 +555,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
@@ -443,10 +574,680 @@
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -489,6 +1290,247 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lit": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
@@ -516,6 +1558,999 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     }
   }
 }

--- a/web-components/package-lock.json
+++ b/web-components/package-lock.json
@@ -1,0 +1,521 @@
+{
+  "name": "@yalesites-org/web-components",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@yalesites-org/web-components",
+      "version": "0.0.0",
+      "dependencies": {
+        "lit": "^3.1.0"
+      },
+      "devDependencies": {
+        "esbuild": "^0.25.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    }
+  }
+}

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@yalesites-org/web-components",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Wave 0 proof-of-concept: framework-neutral Web Component wrappers for YaleSites components (Lit + Shadow DOM + CSS custom property tokens).",
+  "type": "module",
+  "main": "dist/yalesites-web-components.js",
+  "module": "dist/yalesites-web-components.js",
+  "exports": {
+    ".": "./dist/yalesites-web-components.js",
+    "./divider": "./dist/yds-divider.js",
+    "./accordion": "./dist/yds-accordion.js"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "node build.mjs",
+    "check": "node --check src/yds-divider.js && node --check src/yds-accordion.js && node --check src/index.js"
+  },
+  "dependencies": {
+    "lit": "^3.1.0"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.0"
+  }
+}

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,9 +1,26 @@
 {
   "name": "@yalesites-org/web-components",
-  "version": "0.0.0",
-  "private": true,
-  "description": "Wave 0 proof-of-concept: framework-neutral Web Component wrappers for YaleSites components (Lit + Shadow DOM + CSS custom property tokens).",
+  "version": "0.1.0",
+  "description": "Framework-neutral Web Component distribution of YaleSites design-system components (Lit + Shadow DOM + CSS custom property tokens). Epic #1351, Wave 10.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yalesites-org/component-library-twig.git",
+    "directory": "web-components"
+  },
+  "keywords": [
+    "yalesites",
+    "web-components",
+    "custom-elements",
+    "lit",
+    "design-system"
+  ],
   "type": "module",
+  "sideEffects": [
+    "./src/index.js",
+    "./src/yds-divider.js",
+    "./src/yds-accordion.js",
+    "./dist/*"
+  ],
   "main": "dist/yalesites-web-components.js",
   "module": "dist/yalesites-web-components.js",
   "exports": {
@@ -15,14 +32,22 @@
     "dist",
     "src"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
   "scripts": {
     "build": "node build.mjs",
-    "check": "node --check src/yds-divider.js && node --check src/yds-accordion.js && node --check src/index.js"
+    "check": "node --check src/yds-divider.js && node --check src/yds-accordion.js && node --check src/index.js",
+    "test": "vitest run",
+    "prepack": "npm run check && npm run test && npm run build"
   },
   "dependencies": {
     "lit": "^3.1.0"
   },
   "devDependencies": {
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "jsdom": "^25.0.1",
+    "vitest": "^2.1.9"
   }
 }

--- a/web-components/src/index.js
+++ b/web-components/src/index.js
@@ -1,0 +1,5 @@
+// Wave 0 proof-of-concept entry point.
+// Importing this module registers both custom elements and re-exports their
+// classes for consumers who want to extend or reference them directly.
+export { YdsDivider } from './yds-divider.js';
+export { YdsAccordion } from './yds-accordion.js';

--- a/web-components/src/yds-accordion.js
+++ b/web-components/src/yds-accordion.js
@@ -1,0 +1,392 @@
+import { LitElement, html, css } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+
+// Module-level counter so every instance gets stable, unique ids for the
+// button/region aria-controls relationships.
+let instanceCount = 0;
+
+/**
+ * <yds-accordion> — Web Component wrapper for the YaleSites accordion molecule.
+ *
+ * Framework-neutral re-expression of components/02-molecules/accordion
+ * (yds-accordion.twig, _yds-accordion-item.twig, _yds-accordion.scss) with the
+ * expand/collapse + "toggle all" behavior from yds-accordion.js ported into the
+ * Lit lifecycle. Twig cannot run client-side, so markup is re-authored as a Lit
+ * template; the Drupal.behaviors init moves into the reactive update cycle.
+ *
+ * Items may be provided two ways:
+ *   1. `items` property — array of `{ heading, content }` (content is an HTML string).
+ *      This is the robust, fully-controlled path.
+ *   2. Light-DOM authoring — child elements carrying `data-accordion-heading`; their
+ *      innerHTML becomes the panel content. Harvested once on connect. This is
+ *      convenient for hand-authored HTML but timing-sensitive (see README limitations).
+ *
+ * Attributes:
+ *   heading   optional group heading rendered above all items
+ *   theme     "default" | "one".."five" (default "default") — color accent
+ *   alignment "center" | "left" (default "center")
+ *
+ * Parts:
+ *   accordion, inner, heading, controls, toggle-all, item, item-heading, toggle,
+ *   content, icon
+ *
+ * Security: `content` (and harvested light-DOM innerHTML) is injected with
+ * unsafeHTML — same trust model as the source Twig, which prints author-provided
+ * rich text. Do not pass untrusted/user-supplied HTML without sanitizing first.
+ */
+export class YdsAccordion extends LitElement {
+  static properties = {
+    heading: { type: String, reflect: true },
+    theme: { type: String, reflect: true },
+    alignment: { type: String, reflect: true },
+    items: { type: Array },
+    _expanded: { state: true },
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    .accordion {
+      --color-accordion-accent: var(--color-slot-one, var(--color-blue-yale, hsl(210, 100%, 21%)));
+      --color-heading: var(--color-gray-800, hsl(0, 0%, 13%));
+
+      margin-block: var(--spacing-page-section, var(--size-spacing-8, 2.5rem));
+      color: var(--color-text, inherit);
+    }
+
+    /* Per-theme accent, mirroring the source SCSS slot mapping. */
+    .accordion[data-component-theme='one'] {
+      --color-accordion-accent: var(--color-slot-one, var(--color-blue-yale, hsl(210, 100%, 21%)));
+    }
+    .accordion[data-component-theme='two'] {
+      --color-accordion-accent: var(--color-slot-two, var(--color-blue-yale, hsl(210, 100%, 21%)));
+    }
+    .accordion[data-component-theme='three'] {
+      --color-accordion-accent: var(--color-slot-three, var(--color-blue-yale, hsl(210, 100%, 21%)));
+    }
+    .accordion[data-component-theme='four'] {
+      --color-accordion-accent: var(--color-slot-four, var(--color-blue-yale, hsl(210, 100%, 21%)));
+    }
+    .accordion[data-component-theme='five'] {
+      --color-accordion-accent: var(--color-slot-five, var(--color-blue-yale, hsl(210, 100%, 21%)));
+    }
+
+    .accordion__heading {
+      font-family: var(--font-families-mallory, sans-serif);
+      font-size: var(--font-size-30, 1.875rem);
+      font-weight: 700;
+      line-height: 1.2;
+      margin: 0 0 var(--size-spacing-5, 1rem);
+      color: var(--color-heading);
+    }
+
+    .accordion__controls {
+      display: flex;
+      list-style: none;
+      margin: 0 0 var(--size-spacing-5, 1rem);
+      padding: 0;
+    }
+
+    .accordion__toggle-all {
+      display: inline-flex;
+      gap: var(--size-spacing-3, 0.5rem);
+      align-items: center;
+      font: inherit;
+      font-size: var(--font-size-15, 0.9375rem);
+      color: inherit;
+      background: none;
+      border: 0;
+      padding: 0;
+      cursor: pointer;
+    }
+
+    .accordion__toggle-all:hover {
+      color: var(--color-link-base, hsl(213, 66%, 45%));
+    }
+
+    .accordion__icon {
+      height: 1em;
+      width: 1em;
+      fill: currentColor;
+      transition: transform var(--animation-speed-default, 200ms) ease-in-out;
+    }
+
+    .accordion__toggle-all[aria-expanded='true'] .accordion__icon {
+      transform: rotate(180deg);
+    }
+
+    .accordion-item {
+      border-bottom: var(--border-thickness-1, 0.063rem) solid;
+      padding-top: var(--size-spacing-5, 1rem);
+    }
+
+    .accordion-item__heading {
+      font-family: var(--font-families-mallory, sans-serif);
+      font-size: var(--font-size-19, 1.1875rem);
+      font-weight: 600;
+      margin: 0 0 var(--size-spacing-5, 1rem);
+    }
+
+    .accordion-item__toggle {
+      display: flex;
+      gap: var(--size-spacing-5, 1rem);
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+      padding: var(--size-spacing-3, 0.5rem) var(--size-spacing-4, 0.75rem)
+        var(--size-spacing-3, 0.5rem) 0;
+      font: inherit;
+      color: inherit;
+      text-align: left;
+      background: none;
+      border: 0;
+      cursor: pointer;
+    }
+
+    .accordion-item__toggle:hover {
+      color: var(--color-link-base, hsl(213, 66%, 45%));
+    }
+
+    .accordion-item__icon {
+      height: 1em;
+      width: 1em;
+      flex-shrink: 0;
+      fill: currentColor;
+      transition: transform var(--animation-speed-default, 200ms) ease-in-out;
+    }
+
+    .accordion-item__toggle[aria-expanded='true'] .accordion-item__icon {
+      transform: rotate(180deg);
+    }
+
+    .accordion-item__content {
+      max-height: var(--accordion-item-height, 0);
+      overflow: hidden;
+      transition: all var(--animation-speed-slow, 800ms) ease-in-out;
+    }
+
+    .accordion-item[data-accordion-expanded='true'] .accordion-item__content {
+      margin-bottom: var(--size-spacing-6, 1.5rem);
+    }
+
+    .accordion-item[data-accordion-expanded='false'] .accordion-item__content {
+      max-height: 0;
+      visibility: hidden;
+    }
+
+    /* Non-default themes: accent bar + panel background, per the source SCSS. */
+    .accordion[data-component-theme]:not([data-component-theme='default'])
+      .accordion-item {
+      border-bottom: none;
+      background-color: var(--color-gray-100, hsl(0, 0%, 97%));
+      padding: var(--size-spacing-3, 0.5rem) var(--size-spacing-4, 0.75rem);
+      border-left: var(--border-thickness-6, 0.375rem) solid
+        var(--color-accordion-accent);
+      margin-bottom: var(--size-spacing-5, 1rem);
+      color: var(--color-gray-700, hsl(0, 0%, 29%));
+    }
+
+    .accordion[data-component-theme]:not([data-component-theme='default'])
+      .accordion-item__heading {
+      padding-inline-start: var(--size-spacing-5, 1rem);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .accordion-item__content,
+      .accordion-item__icon,
+      .accordion__icon {
+        transition: none;
+      }
+    }
+  `;
+
+  constructor() {
+    super();
+    this.heading = '';
+    this.theme = 'default';
+    this.alignment = 'center';
+    this.items = [];
+    // Items start collapsed — mirrors the source JS graceful-degradation model,
+    // where the server renders items open and JS collapses them on attach.
+    this._expanded = [];
+    this._uid = `yds-accordion-${(instanceCount += 1)}`;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Harvest light-DOM authored items only if no `items` property was supplied.
+    if (!this.items || this.items.length === 0) {
+      const harvested = Array.from(
+        this.querySelectorAll('[data-accordion-heading]'),
+      ).map((el) => ({
+        heading: el.getAttribute('data-accordion-heading') || '',
+        content: el.innerHTML,
+      }));
+      if (harvested.length) {
+        this.items = harvested;
+      }
+    }
+  }
+
+  willUpdate(changed) {
+    // Keep the expanded-state array in lockstep with the items array.
+    if (changed.has('items')) {
+      const count = this.items ? this.items.length : 0;
+      if (this._expanded.length !== count) {
+        this._expanded = new Array(count).fill(false);
+      }
+    }
+  }
+
+  updated() {
+    // Set each open panel's max-height to its content height so the CSS
+    // transition animates open/closed. scrollHeight reports full content height
+    // even while the panel is clipped, so it is safe to read at any time.
+    const contents = this.renderRoot.querySelectorAll('.accordion-item__content');
+    this._expanded.forEach((isOpen, i) => {
+      const content = contents[i];
+      if (!content) return;
+      if (isOpen) {
+        content.style.setProperty(
+          '--accordion-item-height',
+          `${content.scrollHeight}px`,
+        );
+      } else {
+        content.style.removeProperty('--accordion-item-height');
+      }
+    });
+  }
+
+  get _allExpanded() {
+    return this._expanded.length > 0 && this._expanded.every(Boolean);
+  }
+
+  _toggleItem(index) {
+    this._expanded = this._expanded.map((open, i) =>
+      i === index ? !open : open,
+    );
+  }
+
+  _toggleAll() {
+    const target = !this._allExpanded;
+    this._expanded = this._expanded.map(() => target);
+  }
+
+  _angleIcon(className) {
+    // Inlined from images/icons/angle-down.svg (Font Awesome angle-down).
+    return html`
+      <svg
+        class=${className}
+        part="icon"
+        viewBox="0 0 384 512"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          d="M360.5 217.5l-152 143.1C203.9 365.8 197.9 368 192 368s-11.88-2.188-16.5-6.562L23.5 217.5C13.87 208.3 13.47 193.1 22.56 183.5C31.69 173.8 46.94 173.5 56.5 182.6L192 310.9l135.5-128.4c9.562-9.094 24.75-8.75 33.94 .9375C370.5 193.1 370.1 208.3 360.5 217.5z"
+        />
+      </svg>
+    `;
+  }
+
+  _renderItem(item, index) {
+    const isOpen = Boolean(this._expanded[index]);
+    const contentId = `${this._uid}-content-${index}`;
+    const toggleId = `${this._uid}-toggle-${index}`;
+
+    const toggle = html`
+      <button
+        id=${toggleId}
+        class="accordion-item__toggle"
+        part="toggle"
+        type="button"
+        aria-expanded=${isOpen ? 'true' : 'false'}
+        aria-controls=${contentId}
+        @click=${() => this._toggleItem(index)}
+      >
+        <span>${item.heading}</span>
+        ${this._angleIcon('accordion-item__icon')}
+      </button>
+    `;
+
+    // Heading level follows the source: h2 by default, h3 when a group heading
+    // is present so the outline stays valid.
+    const itemHeading = this.heading
+      ? html`<h3 class="accordion-item__heading" part="item-heading">${toggle}</h3>`
+      : html`<h2 class="accordion-item__heading" part="item-heading">${toggle}</h2>`;
+
+    return html`
+      <div
+        class="accordion-item"
+        part="item"
+        data-accordion-expanded=${isOpen ? 'true' : 'false'}
+      >
+        ${itemHeading}
+        <div
+          id=${contentId}
+          class="accordion-item__content"
+          part="content"
+          role="region"
+          aria-labelledby=${toggleId}
+        >
+          ${unsafeHTML(item.content)}
+        </div>
+      </div>
+    `;
+  }
+
+  render() {
+    const items = this.items || [];
+    const theme = this.theme || 'default';
+    const alignment = this.alignment || 'center';
+    const allExpanded = this._allExpanded;
+
+    return html`
+      <div
+        class="accordion"
+        part="accordion"
+        data-component-theme=${theme}
+        data-component-alignment=${alignment}
+      >
+        <div class="accordion__inner" part="inner">
+          ${this.heading
+            ? html`<h2 class="accordion__heading" part="heading">
+                ${this.heading}
+              </h2>`
+            : ''}
+          ${items.length > 1
+            ? html`
+                <ul class="accordion__controls" part="controls" aria-label="Section controls">
+                  <li>
+                    <button
+                      class="accordion__toggle-all"
+                      part="toggle-all"
+                      type="button"
+                      aria-expanded=${allExpanded ? 'true' : 'false'}
+                      @click=${this._toggleAll}
+                    >
+                      ${allExpanded ? 'Collapse All' : 'Expand All'}
+                      ${this._angleIcon('accordion__icon')}
+                    </button>
+                  </li>
+                </ul>
+              `
+            : ''}
+          ${items.map((item, index) => this._renderItem(item, index))}
+        </div>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get('yds-accordion')) {
+  customElements.define('yds-accordion', YdsAccordion);
+}

--- a/web-components/src/yds-divider.js
+++ b/web-components/src/yds-divider.js
@@ -1,0 +1,114 @@
+import { LitElement, html, css } from 'lit';
+
+/**
+ * <yds-divider> — Web Component wrapper for the YaleSites divider atom.
+ *
+ * Framework-neutral re-expression of components/01-atoms/divider (yds-divider.twig
+ * + _yds-divider.scss). Twig cannot run in the browser, so the markup is authored
+ * once as a Lit template and the SCSS is ported into the shadow root's `styles`.
+ *
+ * Theming: internal colors/sizes reference design tokens via `var(--token, fallback)`.
+ * CSS custom properties inherit through the shadow boundary, so a consumer can theme
+ * by setting the underlying tokens (or `--color-divider` / `--thickness-divider`
+ * directly) on any ancestor — no build step required. `::part()` hooks are exposed for
+ * structural overrides that a bare custom property cannot reach.
+ *
+ * Attributes:
+ *   width    "100" | "75" | "50" | "25"  (default "100") — divider width as a % of container
+ *   position "left" | "center"           (default "center") — horizontal alignment
+ *
+ * Parts:
+ *   wrapper, inner, divider
+ */
+export class YdsDivider extends LitElement {
+  static properties = {
+    width: { type: String, reflect: true },
+    position: { type: String, reflect: true },
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    /*
+     * In Drupal the vertical section spacing is supplied by the parent layout
+     * region, not by the divider itself (the SCSS spacing-page-section mixin is a
+     * no-op with default args). Standalone we approximate that spacing here so the
+     * component has breathing room outside a Drupal layout.
+     */
+    .divider__wrapper {
+      margin-block: var(--spacing-page-section, var(--size-spacing-8, 2.5rem));
+    }
+
+    .divider__inner {
+      display: flex;
+      justify-content: var(--position-divider, center);
+    }
+
+    .divider__inner[data-divider-position='left'] {
+      --position-divider: var(--layout-flex-position-left, flex-start);
+    }
+
+    .divider__inner[data-divider-position='center'] {
+      --position-divider: var(--layout-flex-position-center, center);
+    }
+
+    .divider {
+      /* --color-divider default in the library resolves to --color-gray-500. */
+      background: var(--color-divider, var(--color-gray-500, hsl(0, 0%, 46%)));
+      /* --thickness-divider default in the library resolves to --size-thickness-1. */
+      height: var(--thickness-divider, var(--size-thickness-1, 0.063rem));
+      width: var(--width-divider, var(--layout-width-100, 100%));
+    }
+
+    .divider[data-divider-width='100'] {
+      --width-divider: var(--layout-width-100, 100%);
+    }
+
+    .divider[data-divider-width='75'] {
+      --width-divider: var(--layout-width-75, 75%);
+    }
+
+    .divider[data-divider-width='50'] {
+      --width-divider: var(--layout-width-50, 50%);
+    }
+
+    .divider[data-divider-width='25'] {
+      --width-divider: var(--layout-width-25, 25%);
+    }
+  `;
+
+  constructor() {
+    super();
+    this.width = '100';
+    this.position = 'center';
+  }
+
+  render() {
+    const width = ['100', '75', '50', '25'].includes(this.width)
+      ? this.width
+      : '100';
+    const position = ['left', 'center'].includes(this.position)
+      ? this.position
+      : 'center';
+
+    return html`
+      <div class="divider__wrapper" part="wrapper">
+        <div class="divider__inner" part="inner" data-divider-position=${position}>
+          <div
+            class="divider"
+            part="divider"
+            role="separator"
+            aria-orientation="horizontal"
+            data-divider-width=${width}
+          ></div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get('yds-divider')) {
+  customElements.define('yds-divider', YdsDivider);
+}

--- a/web-components/test/yds-accordion.test.js
+++ b/web-components/test/yds-accordion.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import '../src/yds-accordion.js';
+
+// Behavioral tests for the <yds-accordion> Web Component (epic #1351, Wave 10).
+// These mirror the Drupal-behavior accordion test (Wave 3b) but exercise the Lit
+// port: collapse-on-attach, per-item toggle ARIA, the "toggle all" control (only
+// with 2+ items), light-DOM item harvesting, and heading-level outline. Percy is
+// blind to all of these.
+
+const ITEMS = [
+  { heading: 'First', content: '<p>Body <strong>one</strong>.</p>' },
+  { heading: 'Second', content: '<p>Body two.</p>' },
+  { heading: 'Third', content: '<p>Body three.</p>' },
+];
+
+async function mount({ items, attrs = {}, lightDom } = {}) {
+  const el = document.createElement('yds-accordion');
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+  if (lightDom) el.innerHTML = lightDom;
+  if (items) el.items = items;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const toggles = (el) =>
+  el.shadowRoot.querySelectorAll('.accordion-item__toggle');
+const toggleAll = (el) => el.shadowRoot.querySelector('.accordion__toggle-all');
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('<yds-accordion>', () => {
+  it('registers as a custom element', () => {
+    expect(customElements.get('yds-accordion')).toBeTruthy();
+  });
+
+  it('renders one item per items entry, all collapsed on attach', async () => {
+    const el = await mount({ items: ITEMS });
+    const items = el.shadowRoot.querySelectorAll('.accordion-item');
+    expect(items).toHaveLength(3);
+    toggles(el).forEach((t) =>
+      expect(t.getAttribute('aria-expanded')).toBe('false'),
+    );
+  });
+
+  it('shows the "toggle all" control only with 2+ items', async () => {
+    const one = await mount({ items: [ITEMS[0]] });
+    expect(toggleAll(one)).toBeNull();
+
+    const many = await mount({ items: ITEMS });
+    expect(toggleAll(many)).toBeTruthy();
+    expect(toggleAll(many).textContent).toContain('Expand All');
+  });
+
+  it('expands a single item on toggle click and updates ARIA', async () => {
+    const el = await mount({ items: ITEMS });
+    const first = toggles(el)[0];
+    first.click();
+    await el.updateComplete;
+    expect(first.getAttribute('aria-expanded')).toBe('true');
+    // Siblings stay collapsed.
+    expect(toggles(el)[1].getAttribute('aria-expanded')).toBe('false');
+    const region = el.shadowRoot.getElementById(
+      first.getAttribute('aria-controls'),
+    );
+    expect(region).toBeTruthy();
+    expect(el.shadowRoot.querySelector('.accordion-item').getAttribute('data-accordion-expanded')).toBe('true');
+  });
+
+  it('toggle-all expands then collapses every item and flips its label', async () => {
+    const el = await mount({ items: ITEMS });
+    toggleAll(el).click();
+    await el.updateComplete;
+    toggles(el).forEach((t) =>
+      expect(t.getAttribute('aria-expanded')).toBe('true'),
+    );
+    expect(toggleAll(el).getAttribute('aria-expanded')).toBe('true');
+    expect(toggleAll(el).textContent).toContain('Collapse All');
+
+    toggleAll(el).click();
+    await el.updateComplete;
+    toggles(el).forEach((t) =>
+      expect(t.getAttribute('aria-expanded')).toBe('false'),
+    );
+    expect(toggleAll(el).textContent).toContain('Expand All');
+  });
+
+  it('harvests light-DOM items when no items property is given', async () => {
+    const el = await mount({
+      lightDom:
+        '<div data-accordion-heading="Alpha"><p>A</p></div>' +
+        '<div data-accordion-heading="Beta"><p>B</p></div>',
+    });
+    const items = el.shadowRoot.querySelectorAll('.accordion-item');
+    expect(items).toHaveLength(2);
+    expect(el.shadowRoot.textContent).toContain('Alpha');
+  });
+
+  it('injects rich content as HTML, not escaped text', async () => {
+    const el = await mount({ items: ITEMS });
+    const content = el.shadowRoot.querySelector('.accordion-item__content');
+    expect(content.querySelector('strong')).toBeTruthy();
+    expect(content.textContent).toContain('one');
+  });
+
+  it('uses h2 item headings without a group heading, h3 with one', async () => {
+    const flat = await mount({ items: ITEMS });
+    expect(flat.shadowRoot.querySelector('h2.accordion-item__heading')).toBeTruthy();
+    expect(flat.shadowRoot.querySelector('.accordion__heading')).toBeNull();
+
+    const grouped = await mount({ items: ITEMS, attrs: { heading: 'FAQ' } });
+    expect(grouped.shadowRoot.querySelector('h2.accordion__heading')).toBeTruthy();
+    expect(grouped.shadowRoot.querySelector('h3.accordion-item__heading')).toBeTruthy();
+  });
+});

--- a/web-components/test/yds-divider.test.js
+++ b/web-components/test/yds-divider.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import '../src/yds-divider.js';
+
+// Behavioral tests for the <yds-divider> Web Component (epic #1351, Wave 10).
+// Percy covers the visual rendering of the Twig source; these cover the parts a
+// screenshot cannot: attribute reflection and the enum-validation fallbacks that
+// the Lit render() applies (an out-of-range width/position must not reach the DOM).
+
+async function mount(attrs = {}) {
+  const el = document.createElement('yds-divider');
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('<yds-divider>', () => {
+  it('registers as a custom element', () => {
+    expect(customElements.get('yds-divider')).toBeTruthy();
+  });
+
+  it('defaults to width 100 / position center', async () => {
+    const el = await mount();
+    const inner = el.shadowRoot.querySelector('.divider__inner');
+    const rule = el.shadowRoot.querySelector('.divider');
+    expect(inner.getAttribute('data-divider-position')).toBe('center');
+    expect(rule.getAttribute('data-divider-width')).toBe('100');
+  });
+
+  it('reflects a valid width and position', async () => {
+    const el = await mount({ width: '50', position: 'left' });
+    expect(el.shadowRoot.querySelector('.divider').getAttribute('data-divider-width')).toBe('50');
+    expect(el.shadowRoot.querySelector('.divider__inner').getAttribute('data-divider-position')).toBe('left');
+  });
+
+  it('falls back to 100 for an out-of-enum width', async () => {
+    const el = await mount({ width: '999' });
+    expect(el.shadowRoot.querySelector('.divider').getAttribute('data-divider-width')).toBe('100');
+  });
+
+  it('falls back to center for an out-of-enum position', async () => {
+    const el = await mount({ position: 'diagonal' });
+    expect(el.shadowRoot.querySelector('.divider__inner').getAttribute('data-divider-position')).toBe('center');
+  });
+
+  it('exposes the separator semantics for assistive tech', async () => {
+    const el = await mount();
+    const rule = el.shadowRoot.querySelector('.divider');
+    expect(rule.getAttribute('role')).toBe('separator');
+    expect(rule.getAttribute('aria-orientation')).toBe('horizontal');
+  });
+});

--- a/web-components/vitest.config.js
+++ b/web-components/vitest.config.js
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { environment: 'jsdom', include: ['test/**/*.test.js'], globals: true },
+});


### PR DESCRIPTION
## [1363: Wave 8: Full-library completion (Storybook-only and demo components)](https://github.com/yalesites-org/YaleSites-Internal/issues/1363)

### Description of work
- Adds a completion audit (`docs/sdc/wave-8-storybook-only-audit.md`): a full sweep found no Storybook-only component that is both SDC-appropriate and independent of the Views rework (only `modal`, which is Views/calendar-coupled), and no clean stale-file deletion.
- Recommendation: re-scope or close #1363; fold `modal` into the interactive-molecule set once the Views/calendar work settles. Nothing deleted (sign-off-gated).

### Functional testing steps:
- [ ] Review `docs/sdc/wave-8-storybook-only-audit.md` and decide on re-scope/close

References yalesites-org/YaleSites-Internal#1363
