### PR TITLE
1374: Hotfix: add missing separator for multi-day all-day events

### DIFF
--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -92,18 +92,15 @@ format__day__long = Thursday, December 3, 2024
     {% set date_time = start_date_formatted ~ em_dash ~ end_date_formatted ~ ' All day' %}
   {% endif %}
 {% elseif used_format == 'format__all_day' %}
-  {# For all day events, show the date (without time) followed by "All day" #}
-  {# Check if start and end dates are the same day (not just same timestamp) #}
-  {# Use format__date__start which includes em dash - keep it for both single and multi-day #}
+  {# All-day events: show the date(s) without time, followed by "All day". #}
   {% set start_date_formatted = date_time__start|date(formats['format__date']) %}
   {% set end_date_formatted = date_time__end|date(formats['format__date']) %}
   {% if start_date_formatted == end_date_formatted %}
-    {# Single day: keep the trailing em dash and add " All day" #}
+    {# Single day, e.g. "July 1, 2026 All day". #}
     {% set date_time = start_date_formatted ~ ' All day' %}
   {% else %}
-    {# Multi-day: start_date already has trailing dash, end_date has trailing dash, so we get: "Dec 25—Dec 26— All day" #}
-    {# We want: "Dec 25—Dec 26 All day", so strip the trailing dash from end_date #}
-    {% set date_time = start_date_formatted ~ end_date_formatted|trim(em_dash) ~ ' All day' %}
+    {# Multi-day, joined with an em dash, e.g. "July 1, 2026—July 5, 2026 All day". #}
+    {% set date_time = start_date_formatted ~ em_dash ~ end_date_formatted ~ ' All day' %}
   {% endif %}
 {% elseif same_start_and_end %}
   {% set date_time = date_time__start|date(formats[used_format]) %}


### PR DESCRIPTION
## Summary

Fixes multi-day all-day events rendering their start and end dates with no separator (e.g. `July 1, 2026July 5, 2026 All day`). The `format__all_day` multi-day branch of `yds-date-time.twig` concatenated the two dates directly, relying on trimming an em dash that was never added. It now inserts the em dash explicitly, mirroring the adjacent Localist all-day branch.

- Bug: yalesites-org/YaleSites-Internal#1374
- Follow-up test coverage (tech debt): yalesites-org/YaleSites-Internal#1378

## Change

`components/01-atoms/date-time/yds-date-time.twig` — the multi-day all-day branch now renders `start ~ em_dash ~ end ~ ' All day'`. Single-day all-day and all timed paths are unchanged. Corrected the misleading comments that claimed the format already carried a trailing dash.

## Verification

Rendered the atom via twig.js (the same engine Storybook uses), reusing `.storybook/setupTwig.js`:

- multi-day all-day -> `July 1, 2026—July 5, 2026 All day` (was `July 1, 2026July 5, 2026 All day`)
- single-day all-day -> `July 1, 2026 All day` (unchanged)
- single-day all-day, no end date -> `July 1, 2026 All day` (unchanged)

Reviewers can verify in Drupal on the yalesites-project multidev-only PR (matching branch name `hotfix/1374-multi-day-events-dash`).

## Notes

- This is a hotfix for a production issue. Per hotfix direction this PR targets `develop`; release cutting (CLT/atomic version bumps) is handled separately by @dblanken-yale.
