### PR TITLE
Hotfix 1: 2.23.0

### DIFF
--- a/components/01-atoms/date-time/yds-date-time.twig
+++ b/components/01-atoms/date-time/yds-date-time.twig
@@ -92,18 +92,15 @@ format__day__long = Thursday, December 3, 2024
     {% set date_time = start_date_formatted ~ em_dash ~ end_date_formatted ~ ' All day' %}
   {% endif %}
 {% elseif used_format == 'format__all_day' %}
-  {# For all day events, show the date (without time) followed by "All day" #}
-  {# Check if start and end dates are the same day (not just same timestamp) #}
-  {# Use format__date__start which includes em dash - keep it for both single and multi-day #}
+  {# All-day events: show the date(s) without time, followed by "All day". #}
   {% set start_date_formatted = date_time__start|date(formats['format__date']) %}
   {% set end_date_formatted = date_time__end|date(formats['format__date']) %}
   {% if start_date_formatted == end_date_formatted %}
-    {# Single day: keep the trailing em dash and add " All day" #}
+    {# Single day, e.g. "July 1, 2026 All day". #}
     {% set date_time = start_date_formatted ~ ' All day' %}
   {% else %}
-    {# Multi-day: start_date already has trailing dash, end_date has trailing dash, so we get: "Dec 25—Dec 26— All day" #}
-    {# We want: "Dec 25—Dec 26 All day", so strip the trailing dash from end_date #}
-    {% set date_time = start_date_formatted ~ end_date_formatted|trim(em_dash) ~ ' All day' %}
+    {# Multi-day, joined with an em dash, e.g. "July 1, 2026—July 5, 2026 All day". #}
+    {% set date_time = start_date_formatted ~ em_dash ~ end_date_formatted ~ ' All day' %}
   {% endif %}
 {% elseif same_start_and_end %}
   {% set date_time = date_time__start|date(formats[used_format]) %}


### PR DESCRIPTION
## Hotfix: 2.23.0

This merges `develop` into `main` for the component-library-twig portion of the
YaleSites 2.23.0 hotfix (first step in the chain: component-library-twig -> atomic ->
yalesites-project).

The following pull request is being merged in — visit the linked issue to see what's
coming in:

- #666 — Hotfix: add missing separator for multi-day all-day events (fixes yalesites-org/YaleSites-Internal#1374)