### PR TITLE
998: Optimize Gallery Block Image Loading and File Size Limits

### DIFF
--- a/components/03-organisms/galleries/media-grid/_yds-media-grid-modal.scss
+++ b/components/03-organisms/galleries/media-grid/_yds-media-grid-modal.scss
@@ -25,29 +25,49 @@ $modal-speed: var(--animation-speed-slow);
   width: 100%;
   background: transparent;
 
-  [data-media-grid-modal-state='inactive'] & {
-    @include tokens.animate-hidden($modal-speed);
-    @include media-grid-modal-transition;
+  // Fade the modal in/out. `display` is transitioned with `allow-discrete` so
+  // the inactive modal can use `display: none` (see below) while still animating
+  // opacity on open and close.
+  @media (prefers-reduced-motion: no-preference) {
+    transition: opacity $modal-speed ease-in-out,
+      display $modal-speed ease-in-out allow-discrete;
+  }
 
+  [data-media-grid-modal-state='inactive'] & {
+    // Use `display: none` (not `visibility: hidden`) so the browser removes the
+    // modal from layout entirely. The modal is a full-viewport fixed overlay, so
+    // when it merely occupies layout the browser treats its `loading="lazy"`
+    // images as on screen and fetches them on page load even though the modal is
+    // closed. `display: none` lets native lazy loading defer those images until
+    // the modal is opened, and also removes the modal from the a11y tree and tab
+    // order while inactive.
+    display: none;
     opacity: 0;
 
-    // when inactive, set the z-index below the `media-grid__inner`
-    // to make sure it doesn't render as an invisible elements over the grid
-    // preventing interaction.
+    // During the close fade the `display ... allow-discrete` transition keeps the
+    // modal painted while its opacity animates out; keep it below
+    // `media-grid__inner` so the fading overlay stays behind the grid.
     z-index: -1;
   }
 
   // Show the modal and backdrop when active.
   [data-media-grid-modal-state='active'] & {
-    @include media-grid-modal-transition;
-
-    opacity: 1;
     display: flex;
     align-items: center;
     justify-content: center;
+    opacity: 1;
 
     // This z-index is crazy high to ensure it shows above admin toolbars.
     z-index: 600;
+
+    // Fade in from transparent when the modal is displayed. stylelint does not
+    // yet recognize the standard `@starting-style` at-rule.
+    @media (prefers-reduced-motion: no-preference) {
+      /* stylelint-disable-next-line at-rule-no-unknown, scss/at-rule-no-unknown */
+      @starting-style {
+        opacity: 0;
+      }
+    }
   }
 
   &::before {

--- a/components/03-organisms/galleries/media-grid/yds-media-grid-interactive.js
+++ b/components/03-organisms/galleries/media-grid/yds-media-grid-interactive.js
@@ -22,6 +22,10 @@ Drupal.behaviors.mediaGridInteractive = {
       let activeIndex;
       let swipeStartX;
       let swipeEndX;
+      // Captions long enough to be truncated. Their collapsed height is measured
+      // on first open (see toggleModalState), not at attach, because the modal is
+      // `display: none` while inactive and offsetHeight would read 0.
+      const truncatedCaptions = [];
 
       /**
        * trapKeyboard
@@ -76,6 +80,19 @@ Drupal.behaviors.mediaGridInteractive = {
             .focus();
           body.removeAttribute('data-modal-active');
         } else if (newState === 'active') {
+          // Now that the modal is displayed, measure each truncated caption's
+          // collapsed height once (offsetHeight is 0 while the modal is
+          // `display: none`, so this cannot be measured at attach time).
+          truncatedCaptions.forEach((caption) => {
+            if (
+              !caption.style.getPropertyValue('--modal-content-item-height')
+            ) {
+              caption.style.setProperty(
+                '--modal-content-item-height',
+                `${caption.offsetHeight}px`,
+              );
+            }
+          });
           trapKeyboard();
           body.setAttribute('data-modal-active', 'true');
         }
@@ -185,12 +202,11 @@ Drupal.behaviors.mediaGridInteractive = {
             toggleCaption.setAttribute('aria-label', 'expand');
             toggleCaption.style.setProperty('display', 'inline');
 
-            // imageCaption: set default attributes
+            // imageCaption: set default attributes. The collapsed height is
+            // measured on first open in toggleModalState, not here — the modal is
+            // `display: none` while inactive, so offsetHeight would be 0.
             imageCaption.setAttribute('is-expanded', 'false');
-            imageCaption.style.setProperty(
-              '--modal-content-item-height',
-              `${imageCaption.offsetHeight}px`,
-            );
+            truncatedCaptions.push(imageCaption);
 
             // Toggle the full caption when the "circle plus" toggle is clicked
             if (!body.hasAttribute('gallery-has-click-event')) {


### PR DESCRIPTION
## [998: Optimize Gallery Block Image Loading and File Size Limits](https://github.com/yalesites-org/YaleSites-Internal/issues/998)

### Description of work
- Defer the interactive gallery lightbox images until the modal is opened. `.media-grid__modal` is a full-viewport `position: fixed` overlay that was hidden with `visibility: hidden` while inactive; because a `visibility: hidden` element still occupies layout, the browser treated the modal's `loading="lazy"` images as on screen and fetched every sized derivative on page load. This defeated the ticket goal even after the companion yalesites-project PR repointed the modal at a sized (`image_max_width`) derivative — all of them still downloaded up front.
- Hide the inactive modal with `display: none` instead, so native lazy loading defers the modal images until the lightbox is opened. The open/close fade is preserved with a `display ... allow-discrete` transition plus a `@starting-style` entry opacity.
- Because the closed modal is now removed from layout, the caption-truncation script could no longer measure a long caption's collapsed height at attach time (`offsetHeight` is 0 under `display: none`, which would clip long captions to zero height on open). The collapsed-height measurement is deferred to the first time the modal opens.
- **Single work unit** with yalesites-org/yalesites-project#1374 (gallery media view modes + config) and yalesites-org/atomic#490 (thumbnail view mode). All three share this branch name and must be reviewed and merged together — this change is what makes the "don't eager-load modal images" goal actually hold at runtime.
- Other work completed in: yalesites-org/yalesites-project#1374, yalesites-org/atomic#490

### Functional testing steps:
- [ ] On a page with a Gallery block, load the page fresh and do **not** open a modal. In DevTools Network, the gallery modal's `max_width_*` derivatives are **not** requested on page load (equivalently, every `.media-grid-modal__media img` has `naturalWidth: 0`).
- [ ] Open a gallery image in the lightbox — the modal image now fetches its `max_width_*` derivative **on open**, and the modal fades in.
- [ ] Close the modal — it fades out and returns to hidden; reopening still works, and navigating between items (prev/next, pager, swipe) works.
- [ ] On a gallery item with a long caption (over 100 characters), open the modal — the caption heading/area renders at full height (not clipped to zero), and the expand ("+") toggle reveals the full caption text.
- [ ] With `prefers-reduced-motion: reduce`, the modal still opens and closes correctly (no fade animation).

References yalesites-org/YaleSites-Internal#998
