### PR TITLE
#750: Add Free-Form Location Field to Drupal Events

### DIFF
--- a/components/02-molecules/meta/event-meta/event-localist--no-place.yml
+++ b/components/02-molecules/meta/event-meta/event-localist--no-place.yml
@@ -1,0 +1,42 @@
+event_dates:
+  - formatted_start_date: Friday, May 3rd, 2024
+    formatted_end_date: Friday, May 3rd, 2024
+    formatted_start_time: 8:30 am EDT
+    formatted_end_time: 9:30 am EDT
+    original_start: 1714739400
+    original_end: 1714743000
+    is_past_event: true
+    is_all_day: false
+  - formatted_start_date: Sunday, May 10th, 2030
+    formatted_end_date: Sunday, May 10th, 2030
+    formatted_start_time: 8:30 am EDT
+    formatted_end_time: 9:30 am EDT
+    original_start: 1904483400
+    original_end: 1904487000
+    is_past_event: false
+ticket_cost: $40 pre registration, $60 at the door
+ticket_url: https://www.yale.edu
+event_meta__cta_primary__content: Event Name Website
+event_meta__cta_primary__href: https://www.example.com
+event_types:
+  - name: Music
+  - name: Lecture
+location_additional_info: '<p>Meet in the lobby of the Yale School of Music, 470 College St. This session will also be streamed live on our virtual platform for remote attendees; a link will be emailed after registration.</p>'
+event_audience:
+  - name: Audience Name one
+  - name: Audience Name two
+event_topics:
+  - name: Topic One
+  - name: Topic Two
+description: '<p>Vel quasi dicta ut fugit molestiae ea sint voluptatem soluta repellendus quod qui fugit dolores illo.</p>'
+stream_url: https://www.example.com
+stream_embed_code: Watch the event
+event_featured_date:
+  formatted_start_date: Sunday, May 10th, 2030
+  formatted_end_date: Sunday, May 10th, 2030
+  formatted_start_time: 8:30 am EDT
+  formatted_end_time: 9:30 am EDT
+  original_start: 1904483400
+  original_end: 1904487000
+  is_past_event: false
+event_featured_index: 1

--- a/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
+++ b/components/02-molecules/meta/event-meta/yds-event-meta-localist.twig
@@ -4,6 +4,8 @@
  # - event_meta__date_end
  # - event_meta__format: Multiselect. Options are 'In-person', 'Virtual', or both.
  # - event_meta__address
+ # - place: Structured Localist location
+ # - location_additional_info: WYSIWYG for non-Localist events.
  #}
 
 {# Split upcomign and past dates #}
@@ -417,10 +419,12 @@
           {% if place %}
             <div {{ bem('location-wrapper', [], event_meta__base_class) }}>
               <label {{ bem('event__label', [], event_meta__base_class) }}>Location</label>
-              <div {{ bem('location', [], event_meta__base_class) }}>
-                {{ location_display }}<br>
-                {{ place.address }}
-                {{ place.city }}, {{ place.state }} {{ place.postal_code }}
+              <div {{ bem('location', [], event_meta__base_class) }} itemprop="location" itemscope itemtype="https://schema.org/Place">
+                <span itemprop="name">{{ location_display }}</span><br>
+                <span itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
+                  <span itemprop="streetAddress">{{ place.address }}</span>
+                  <span itemprop="addressLocality">{{ place.city }}</span>, <span itemprop="addressRegion">{{ place.state }}</span> <span itemprop="postalCode">{{ place.postal_code }}</span>
+                </span>
               </div>
               <div {{ bem('event-show-map', [], event_meta__base_class) }} is-expanded="false">
                 {% include "@atoms/controls/cta/yds-cta.twig" with {
@@ -441,6 +445,13 @@
                     cta__style: 'outline',
                   } %}
                 </div>
+              </div>
+            </div>
+          {% elseif location_additional_info %}
+            <div {{ bem('location-wrapper', [], event_meta__base_class) }}>
+              <label {{ bem('event__label', [], event_meta__base_class) }}>Location</label>
+              <div {{ bem('location', [], event_meta__base_class) }} itemprop="location">
+                {{ location_additional_info }}
               </div>
             </div>
           {% endif %}

--- a/components/02-molecules/meta/event-props.yml
+++ b/components/02-molecules/meta/event-props.yml
@@ -19,6 +19,7 @@ dataVariant:
     - Upcoming Only
     - Past Only
     - Single Date
+    - No Localist Place (Free-form Location)
   control: select
 
 withCalendar:

--- a/components/02-molecules/meta/meta.stories.js
+++ b/components/02-molecules/meta/meta.stories.js
@@ -4,6 +4,7 @@ import eventLocalistData from './event-meta/event-localist.yml';
 import eventLocalistUpcomingOnly from './event-meta/event-localist--upcoming-only.yml';
 import eventLocalistPastOnly from './event-meta/event-localist--past-only.yml';
 import eventLocalistSingleDate from './event-meta/event-localist--single-date.yml';
+import eventLocalistNoPlace from './event-meta/event-localist--no-place.yml';
 import basicMetaTwig from './basic-meta/yds-basic-meta.twig';
 import eventLocalistMetaTwig from './event-meta/yds-event-meta-localist.twig';
 import dateTimeTwig from '../../01-atoms/date-time/yds-date-time.twig';
@@ -29,6 +30,7 @@ const eventDataVariants = {
   'Upcoming Only': eventLocalistUpcomingOnly,
   'Past Only': eventLocalistPastOnly,
   'Single Date': eventLocalistSingleDate,
+  'No Localist Place (Free-form Location)': eventLocalistNoPlace,
 };
 
 /**


### PR DESCRIPTION
## [#750: Add Free-Form Location Field to Drupal Events](https://github.com/yalesites-org/YaleSites-Internal/issues/750)

### Description of work
- Adds a WYSIWYG "Additional Information" fallback to the event meta/Localist location display so non-Localist events can show a free-form location.
- When a Localist place is present it always takes precedence and the free-form field is suppressed, even if both are populated
- Adds schema-org `Place`/`PostalAddress` microdata to the existing Localist location markup, and `itemprop="location"` to the free-form fallback
- Adds a new Storybook variant  so the fallback can be reviewed in isolation

### Testing Link(s)
- [ ] Navigate to the [Event Meta Component Story](https://deploy-preview-671--dev-component-library-twig.netlify.app/?path=/story/molecules-meta--event)

### Functional Review Steps
- [ ] Navigate the the [event metadata organism](https://deploy-preview-671--dev-component-library-twig.netlify.app/?path=/docs/molecules-meta-event-meta--docs)
- [ ] Check new display logic
  - [ ] In the Controls panel, set "Event Date Scenario" to `No Localist Place (Free-form Location)`
  - [ ] Confirm the Location section shows the free-form address/building/virtual-link text
  - [ ] Verify there is no map or "Get Directions" button
- [ ] Localist regression check
  - [ ] Switch "Event Date Scenario" to `Mixed (Past & Upcoming)`
  - [ ] Confirm the original Localist place, map, and "Get Directions" button still render as before
- [ ] Open browser dev tools (Elements/Inspector) on the rendered Location section and confirm:
  - [ ] When a Localist place is shown: the wrapper has `itemscope itemtype="https://schema.org/Place"` and the address has `itemtype="https://schema.org/PostalAddress"`
  - [ ] When the free-form fallback is shown, the wrapper has `itemprop="location"` and no `Place`/`PostalAddress` attributes

### Design Review
- No significant design change as elements visibility only effected. Existing treatments are employed.

### Accessibility Review
- [ ] Using a screen reader confirm the "Location" label is announced immediately before the value in both the Localist and free-form scenarios
- [ ] Confirm the added `schema.org` microdata are not announced